### PR TITLE
Now connects to a given address string instead of a port number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ Here is a server that closes the connection if you send it anything.
             $conn->close();
         });
     });
-    $socket->listen(1337);
+    $socket->listen('tcp://127.0.0.1:1337');
 
     $loop->run();
-```    
-You can change the host the socket is listening on through a second parameter 
+```
+You can change the host the socket is listening on through a second parameter
 provided to the listen method:
 ```php
-    $socket->listen(1337, '192.168.0.1');
+    $socket->listen('tcp://192.168.0.1:1337');
 ```
 Here's a client that outputs the output of said server and then attempts to
 send it a string.

--- a/src/Server.php
+++ b/src/Server.php
@@ -5,29 +5,29 @@ namespace React\Socket;
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 
-/** @event connection */
+/** @event connection(Connection $client) */
+/** @event error(RuntimeException $error) */
 class Server extends EventEmitter implements ServerInterface
 {
+    protected $address;
     public $master;
-    private $loop;
+    protected $loop;
 
     public function __construct(LoopInterface $loop)
     {
         $this->loop = $loop;
     }
 
-    public function listen($port, $host = '127.0.0.1')
+    public function listen($address)
     {
-        if (strpos($host, ':') !== false) {
-            // enclose IPv6 addresses in square brackets before appending port
-            $host = '[' . $host . ']';
-        }
+        $this->address = $address;
+        $this->master = @stream_socket_server($address, $errno, $errstr);
 
-        $this->master = @stream_socket_server("tcp://$host:$port", $errno, $errstr);
         if (false === $this->master) {
-            $message = "Could not bind to tcp://$host:$port: $errstr";
+            $message = "Could not bind to {$address}: {$errstr}";
             throw new ConnectionException($message, $errno);
         }
+
         stream_set_blocking($this->master, 0);
 
         $this->loop->addReadStream($this->master, function ($master) {
@@ -50,11 +50,9 @@ class Server extends EventEmitter implements ServerInterface
         $this->emit('connection', array($client));
     }
 
-    public function getPort()
+    public function getAddress()
     {
-        $name = stream_socket_get_name($this->master, false);
-
-        return (int) substr(strrchr($name, ':'), 1);
+        return $this->address;
     }
 
     public function shutdown()

--- a/src/ServerInterface.php
+++ b/src/ServerInterface.php
@@ -7,7 +7,7 @@ use Evenement\EventEmitterInterface;
 /** @event connection */
 interface ServerInterface extends EventEmitterInterface
 {
-    public function listen($port, $host = '127.0.0.1');
-    public function getPort();
+    public function listen($address);
+    public function getAddress();
     public function shutdown();
 }


### PR DESCRIPTION
Literally the least work possible to get this functional, no parsing of the address string to try and guess what scheme the user actually wants (`tcp`, `udp`, `unix`...), so if someone uses `https`, it will fail. Intelligent address handling can be done somewhere else.
