### PR TITLE
Split server functionality out into a trait.

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -2,70 +2,17 @@
 
 namespace React\Socket;
 
-use Evenement\EventEmitter;
+use Evenement\EventEmitterTrait;
 use React\EventLoop\LoopInterface;
 
 /** @event connection */
-class Server extends EventEmitter implements ServerInterface
+class Server implements ServerInterface
 {
-    public $master;
-    private $loop;
+    use EventEmitterTrait;
+    use ServerTrait;
 
     public function __construct(LoopInterface $loop)
     {
-        $this->loop = $loop;
-    }
-
-    public function listen($port, $host = '127.0.0.1')
-    {
-        if (strpos($host, ':') !== false) {
-            // enclose IPv6 addresses in square brackets before appending port
-            $host = '[' . $host . ']';
-        }
-
-        $this->master = @stream_socket_server("tcp://$host:$port", $errno, $errstr);
-        if (false === $this->master) {
-            $message = "Could not bind to tcp://$host:$port: $errstr";
-            throw new ConnectionException($message, $errno);
-        }
-        stream_set_blocking($this->master, 0);
-
-        $this->loop->addReadStream($this->master, function ($master) {
-            $newSocket = stream_socket_accept($master);
-            if (false === $newSocket) {
-                $this->emit('error', array(new \RuntimeException('Error accepting new connection')));
-
-                return;
-            }
-            $this->handleConnection($newSocket);
-        });
-    }
-
-    public function handleConnection($socket)
-    {
-        stream_set_blocking($socket, 0);
-
-        $client = $this->createConnection($socket);
-
-        $this->emit('connection', array($client));
-    }
-
-    public function getPort()
-    {
-        $name = stream_socket_get_name($this->master, false);
-
-        return (int) substr(strrchr($name, ':'), 1);
-    }
-
-    public function shutdown()
-    {
-        $this->loop->removeStream($this->master);
-        fclose($this->master);
-        $this->removeAllListeners();
-    }
-
-    public function createConnection($socket)
-    {
-        return new Connection($socket, $this->loop);
+        $this->setLoop($loop);
     }
 }

--- a/src/ServerTrait.php
+++ b/src/ServerTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace React\Socket;
+
+use React\EventLoop\LoopInterface;
+
+trait ServerTrait
+{
+    public $master;
+    private $loop;
+
+    public function setLoop(LoopInterface $loop)
+    {
+        $this->loop = $loop;
+    }
+
+    public function listen($port, $host = '127.0.0.1')
+    {
+        if (strpos($host, ':') !== false) {
+            // enclose IPv6 addresses in square brackets before appending port
+            $host = '[' . $host . ']';
+        }
+
+        $this->master = @stream_socket_server("tcp://$host:$port", $errno, $errstr);
+        if (false === $this->master) {
+            $message = "Could not bind to tcp://$host:$port: $errstr";
+            throw new ConnectionException($message, $errno);
+        }
+        stream_set_blocking($this->master, 0);
+
+        $this->loop->addReadStream($this->master, function ($master) {
+            $newSocket = stream_socket_accept($master);
+            if (false === $newSocket) {
+                $this->emit('error', array(new \RuntimeException('Error accepting new connection')));
+
+                return;
+            }
+            $this->handleConnection($newSocket);
+        });
+    }
+
+    public function handleConnection($socket)
+    {
+        stream_set_blocking($socket, 0);
+
+        $client = $this->createConnection($socket);
+
+        $this->emit('connection', array($client));
+    }
+
+    public function getPort()
+    {
+        $name = stream_socket_get_name($this->master, false);
+
+        return (int) substr(strrchr($name, ':'), 1);
+    }
+
+    public function shutdown()
+    {
+        $this->loop->removeStream($this->master);
+        fclose($this->master);
+        $this->removeAllListeners();
+    }
+
+    public function createConnection($socket)
+    {
+        return new Connection($socket, $this->loop);
+    }
+}


### PR DESCRIPTION
One point of contention: I did not want to define the constructor in the trait, so I added the `setLoop` function to the trait. Not sure if that is the best solution.
