### PR TITLE
Allow setting socket/tcp options for server sockets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,11 @@ immediately.
     });
     $socket->listen(1337);
 ```
+
+### Setting `SO_REUSEADDR`
+The `SO_REUSEADDR` socket option allows a socket to forcibly bind to a
+port in use by another socket. This means multiple processes could be
+launched listening on the same port.
+```php
+    $socket->setSocketOption(SO_REUSEADDR, true);
+```

--- a/README.md
+++ b/README.md
@@ -54,3 +54,25 @@ send it a string.
 
     $loop->run();
 ```
+
+## Advanced Usage
+
+### Disabling TCP Nagle
+Nagle helps to improve the efficiency of TCP communication by reducing the
+number of packets that need to be sent over the network.
+
+This helps to reduce TCP overheads.
+
+Sometimes you want to disable Nagle to ensure that data will be sent
+immediately.
+```php
+    $socket = new React\Socket\Server($loop);
+    $socket->setTCPOption(TCP_NODELAY, true);
+    $socket->on('connection', function ($conn) {
+        $conn->write("This data will be sent.\n");
+        usleep(200);
+        $conn->write("... after 200ms!\n");
+        $conn->close();
+    });
+    $socket->listen(1337);
+```

--- a/src/Server.php
+++ b/src/Server.php
@@ -49,7 +49,7 @@ class Server extends EventEmitter implements ServerInterface
         // apply any socket options on the connection!
         foreach ($this->options as $socket_level => $options) {
             foreach($options as $option_name => $option_value) {
-                socket_set_option($socket, $option_level, $option_name, $option_value);
+                socket_set_option($socket, $socket_level, $option_name, $option_value);
             }
         }
 
@@ -79,8 +79,9 @@ class Server extends EventEmitter implements ServerInterface
 
     public function setOption($option_level, $option_name, $option_value)
     {
-        if (!is_array($this->options[$option_level]))
+        if (!is_array($this->options[$option_level])) {
             $this->options[$option_level] = array();
+        }
 
         $this->options[$option_level][$option_name] = $option_value;
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -10,6 +10,7 @@ class Server extends EventEmitter implements ServerInterface
 {
     public $master;
     private $loop;
+    private $options = array();
 
     public function __construct(LoopInterface $loop)
     {
@@ -45,6 +46,13 @@ class Server extends EventEmitter implements ServerInterface
     {
         stream_set_blocking($socket, 0);
 
+        // apply any socket options on the connection!
+        foreach ($this->options as $socket_level => $options) {
+            foreach($options as $option_name => $option_value) {
+                socket_set_option($socket, $option_level, $option_name, $option_value);
+            }
+        }
+
         $client = $this->createConnection($socket);
 
         $this->emit('connection', array($client));
@@ -67,5 +75,25 @@ class Server extends EventEmitter implements ServerInterface
     public function createConnection($socket)
     {
         return new Connection($socket, $this->loop);
+    }
+
+    public function setOption($option_level, $option_name, $option_value)
+    {
+        if (!is_array($this->options[$option_level]))
+            $this->options[$option_level] = array();
+
+        $this->options[$option_level][$option_name] = $option_value;
+
+        return true;
+    }
+
+    public function setSocketOption($option_name, $option_value)
+    {
+        return $this->setOption(SOL_SOCKET, $option_name, $option_value);
+    }
+
+    public function setTCPOption($option_name, $option_value)
+    {
+        return $this->setOption(SOL_TCP, $option_name, $option_value);
     }
 }


### PR DESCRIPTION
This patch will enable users to set options such as `SO_REUSEADDR` and `TCP_NODELAY` on new sockets that are created before being passed to the connection emitter.

nodejs by default sets `TCP_NODELAY` and `SO_REUSEADDR` to true. I wanted an easy way to replicate this behaviour in my PHP application, so I added the setTCPOption and setSocketOption functions to enable these options to be set.
