### PR TITLE
Added getLoop method as protected

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -56,6 +56,11 @@ class Server extends EventEmitter implements ServerInterface
 
         return (int) substr(strrchr($name, ':'), 1);
     }
+    
+    protected function getLoop()
+    {
+        return $this->loop;
+    }
 
     public function shutdown()
     {


### PR DESCRIPTION
I recently ran into a problem where I wanted to extend the React\Socket\Connection class into my own Connection class, This meant also extending the server in order to replace the createConnection() method, however Connection objects require the event loop to be injected, and as the $loop variable is private, nothing extending the class can access it.

Instead of making the $loop variable protected, I opted to create a simple getter for $loop that can be used in extension.