### PR TITLE
Annotations fix

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -5,7 +5,7 @@ namespace React\Socket;
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 
-/** @event connection */
+/** Emits the connection event */
 class Server extends EventEmitter implements ServerInterface
 {
     public $master;

--- a/src/ServerInterface.php
+++ b/src/ServerInterface.php
@@ -4,7 +4,7 @@ namespace React\Socket;
 
 use Evenement\EventEmitterInterface;
 
-/** @event connection */
+/** Emits the connection event */
 interface ServerInterface extends EventEmitterInterface
 {
     public function listen($port, $host = '127.0.0.1');


### PR DESCRIPTION
Removed the use of the special `@event` annotation to ease the use of the lib with annotation library, in particular Doctrine annotations

see https://github.com/doctrine/annotations/blob/master/lib/Doctrine/Common/Annotations/AnnotationReader.php#L55 for the list of ignored annotation