### PR TITLE
added @ before stream_socket_accept in src/Server.php ...

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -31,7 +31,7 @@ class Server extends EventEmitter implements ServerInterface
         stream_set_blocking($this->master, 0);
 
         $this->loop->addReadStream($this->master, function ($master) {
-            $newSocket = stream_socket_accept($master);
+            $newSocket = @stream_socket_accept($master);
             if (false === $newSocket) {
                 $this->emit('error', array(new \RuntimeException('Error accepting new connection')));
 


### PR DESCRIPTION
… , preventing the server from crashing right before being able to handle the same error

This fixes the following issue:
https://github.com/reactphp/socket/issues/22