### PR TITLE
[RFC] Improve compatibility with legacy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "keywords": ["socket"],
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
-        "evenement/evenement": "~2.0",
-        "react/event-loop": "0.4.*",
-        "react/stream": "0.4.*"
+        "php": ">=5.3.0",
+        "evenement/evenement": "~2.0|~1.0",
+        "react/event-loop": "0.4.*|0.3.*",
+        "react/stream": "0.4.*|0.3.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Server.php
+++ b/src/Server.php
@@ -30,14 +30,16 @@ class Server extends EventEmitter implements ServerInterface
         }
         stream_set_blocking($this->master, 0);
 
-        $this->loop->addReadStream($this->master, function ($master) {
+        $that = $this;
+
+        $this->loop->addReadStream($this->master, function ($master) use ($that) {
             $newSocket = stream_socket_accept($master);
             if (false === $newSocket) {
-                $this->emit('error', array(new \RuntimeException('Error accepting new connection')));
+                $that->emit('error', array(new \RuntimeException('Error accepting new connection')));
 
                 return;
             }
-            $this->handleConnection($newSocket);
+            $that->handleConnection($newSocket);
         });
     }
 


### PR DESCRIPTION
Because *why not*… :-)

Now more seriously: This project is a low level lib that is used as a building block for quite a few higher level abstractions on top of it. As such, compatibility (even with significantly outdated versions) is a major concern to me.

Note that I'm not suggesting putting *significant amount* of work into this. The patch is already here and, personally, I see little harm in supporting this.

Also note that I'm not suggesting we need to keep support indefinitely. Should this ever turn out to be a burden in the future, e.g. because we actually *require* any new language features or some external lib, then I'm all for dropping support again.