### PR TITLE
Add a more generic bind() method to allow Unix socket server

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -23,9 +23,14 @@ class Server extends EventEmitter implements ServerInterface
             $host = '[' . $host . ']';
         }
 
-        $this->master = @stream_socket_server("tcp://$host:$port", $errno, $errstr);
+        $this->bind("tcp://$host:$port");
+    }
+
+    public function bind($address)
+    {
+        $this->master = @stream_socket_server($address, $errno, $errstr);
         if (false === $this->master) {
-            $message = "Could not bind to tcp://$host:$port: $errstr";
+            $message = "Could not bind to $address: $errstr";
             throw new ConnectionException($message, $errno);
         }
         stream_set_blocking($this->master, 0);

--- a/src/ServerInterface.php
+++ b/src/ServerInterface.php
@@ -8,6 +8,7 @@ use Evenement\EventEmitterInterface;
 interface ServerInterface extends EventEmitterInterface
 {
     public function listen($port, $host = '127.0.0.1');
+    public function bind($address);
     public function getPort();
     public function shutdown();
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -48,6 +48,24 @@ class ServerTest extends TestCase
      * @covers React\Socket\Server::handleConnection
      * @covers React\Socket\Server::createConnection
      */
+    public function testUnixConnection()
+    {
+        $unixSocket = 'unix://./server.sock';
+
+        $server = new Server($this->loop);
+        $server->bind($unixSocket);
+
+        $client = stream_socket_client($unixSocket);
+
+        $server->on('connection', $this->expectCallableOnce());
+        $this->loop->tick();
+    }
+
+    /**
+     * @covers React\EventLoop\StreamSelectLoop::tick
+     * @covers React\Socket\Server::handleConnection
+     * @covers React\Socket\Server::createConnection
+     */
     public function testConnectionWithManyClients()
     {
         $client1 = stream_socket_client('tcp://localhost:'.$this->port);


### PR DESCRIPTION
I also need to implements an unix socket server ( like #17 and #6 ) so I added a simpler method bind($address) to bind a server to any socket type.
I converted the listen() method to use this new method for BC.
