### PR TITLE
Add sockets extension to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.0",
+        "ext-sockets": "*",
         "evenement/evenement": "~2.0|~1.0",
         "react/event-loop": "0.4.*|0.3.*",
         "react/stream": "0.4.*|0.3.*"


### PR DESCRIPTION
Not all builds of PHP contain the socket extension.