### PR TITLE
Improve test suite and switch to normal stream handler

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -6,20 +6,6 @@ use React\Stream\Stream;
 
 class Connection extends Stream implements ConnectionInterface
 {
-    public function handleData($stream)
-    {
-        // Socket is raw, not using fread as it's interceptable by filters
-        // See issues #192, #209, and #240
-        $data = stream_socket_recvfrom($stream, $this->bufferSize);
-        if ('' !== $data && false !== $data) {
-            $this->emit('data', array($data, $this));
-        }
-
-        if ('' === $data || false === $data || !is_resource($stream) || feof($stream)) {
-            $this->end();
-        }
-    }
-
     public function handleClose()
     {
         if (is_resource($this->stream)) {

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -29,12 +29,9 @@ class ConnectionTest extends TestCase
 
         $servConn = new Connection($server->master, $loop);
 
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($method->invokeArgs($servConn, array(stream_socket_get_name($master->getValue($server), false))))
-        ;
+        $mock = $this->expectCallableOnceWith(
+            $method->invokeArgs($servConn, array(stream_socket_get_name($master->getValue($server), false)))
+        );
 
         $server->on('connection', function ($conn) use ($mock) {
             $mock($conn->getRemoteAddress());

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -64,7 +64,7 @@ class ServerTest extends TestCase
      * @covers React\EventLoop\StreamSelectLoop::tick
      * @covers React\Socket\Connection::handleData
      */
-    public function testDataWithNoData()
+    public function testDataEventWillNotBeEmittedWhenClientSendsNoData()
     {
         $client = stream_socket_client('tcp://localhost:'.$this->port);
 
@@ -81,17 +81,13 @@ class ServerTest extends TestCase
      * @covers React\EventLoop\StreamSelectLoop::tick
      * @covers React\Socket\Connection::handleData
      */
-    public function testData()
+    public function testDataWillBeEmittedWithDataClientSends()
     {
         $client = stream_socket_client('tcp://localhost:'.$this->port);
 
         fwrite($client, "foo\n");
 
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with("foo\n");
+        $mock = $this->expectCallableOnceWith("foo\n");
 
         $this->server->on('connection', function ($conn) use ($mock) {
             $conn->on('data', $mock);
@@ -101,23 +97,16 @@ class ServerTest extends TestCase
     }
 
     /**
-     * Test data sent from python language
-     *
      * @covers React\EventLoop\StreamSelectLoop::tick
      * @covers React\Socket\Connection::handleData
      */
-    public function testDataSentFromPy()
+    public function testDataWillBeEmittedEvenWhenClientShutsDownAfterSending()
     {
         $client = stream_socket_client('tcp://localhost:' . $this->port);
         fwrite($client, "foo\n");
         stream_socket_shutdown($client, STREAM_SHUT_WR);
 
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with("foo\n");
-
+        $mock = $this->expectCallableOnceWith("foo\n");
 
         $this->server->on('connection', function ($conn) use ($mock) {
             $conn->on('data', $mock);
@@ -126,17 +115,13 @@ class ServerTest extends TestCase
         $this->loop->tick();
     }
 
-    public function testFragmentedMessage()
+    public function testDataWillBeFragmentedToBufferSize()
     {
         $client = stream_socket_client('tcp://localhost:' . $this->port);
 
         fwrite($client, "Hello World!\n");
 
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with("He");
+        $mock = $this->expectCallableOnceWith("He");
 
         $this->server->on('connection', function ($conn) use ($mock) {
             $conn->bufferSize = 2;
@@ -149,7 +134,7 @@ class ServerTest extends TestCase
     /**
      * @covers React\EventLoop\StreamSelectLoop::tick
      */
-    public function testDisconnectWithoutDisconnect()
+    public function testConnectionDoesNotEndWhenClientDoesNotClose()
     {
         $client = stream_socket_client('tcp://localhost:'.$this->port);
 
@@ -166,7 +151,7 @@ class ServerTest extends TestCase
      * @covers React\EventLoop\StreamSelectLoop::tick
      * @covers React\Socket\Connection::end
      */
-    public function testDisconnect()
+    public function testConnectionDoesEndWhenClientCloses()
     {
         $client = stream_socket_client('tcp://localhost:'.$this->port);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,6 +24,17 @@ class TestCase extends \PHPUnit_Framework_TestCase
         return $mock;
     }
 
+    protected function expectCallableOnceWith($value)
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($value);
+
+        return $mock;
+    }
+
     protected function expectCallableNever()
     {
         $mock = $this->createCallableMock();


### PR DESCRIPTION
Added some additional test cases to verify we can use the normal stream handler which processes any stream filters and handles any errors.

It looks like the original motivation for using raw stream handlers was that some Autobahn tests failed "very oddly" (https://github.com/reactphp/react/pull/240). I assume this might have been fixed in the meantime, possibly as part of https://github.com/reactphp/stream/pull/20.