### PR TITLE
Add functional integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
 sudo: false
 
 install:
-  - composer install --prefer-source --no-interaction
+  - COMPOSER_ROOT_VERSION=`git describe --abbrev=0` composer install --no-interaction
 
 script:
   - phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ and [`Stream`](https://github.com/reactphp/stream) components.
   * [ConnectionInterface](#connectioninterface)
     * [getRemoteAddress()](#getremoteaddress)
 * [Install](#install)
+* [Tests](#tests)
 * [License](#license)
 
 ## Quickstart example
@@ -143,6 +144,23 @@ $ composer require react/socket:^0.4.4
 ```
 
 More details about version upgrades can be found in the [CHANGELOG](CHANGELOG.md).
+
+## Tests
+
+To run the test suite, you first need to clone this repo and then install all
+dependencies [through Composer](http://getcomposer.org).
+Because the test suite contains some circular dependencies, you may have to
+manually specify the root package version like this:
+
+```bash
+$ COMPOSER_ROOT_VERSION=`git describe --abbrev=0` composer install
+```
+
+To run the test suite, you need PHPUnit. Go to the project root and run:
+
+```bash
+$ phpunit
+```
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,10 @@
         "react/event-loop": "0.4.*|0.3.*",
         "react/stream": "^0.4.2"
     },
+    "require-dev": {
+        "react/socket-client": "^0.5.1",
+        "clue/block-react": "^1.1"
+    },
     "autoload": {
         "psr-4": {
             "React\\Socket\\": "src"

--- a/tests/FunctionalServerTest.php
+++ b/tests/FunctionalServerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace React\Tests\Socket;
+
+use React\EventLoop\Factory;
+use React\SocketClient\TcpConnector;
+use React\Socket\Server;
+use Clue\React\Block;
+
+class FunctionalServerTest extends TestCase
+{
+    public function testEmitsConnectionForNewConnection()
+    {
+        $loop = Factory::create();
+
+        $server = new Server($loop);
+        $server->on('connection', $this->expectCallableOnce());
+        $server->listen(0);
+        $port = $server->getPort();
+
+        $connector = new TcpConnector($loop);
+        $promise = $connector->create('127.0.0.1', $port);
+
+        $promise->then($this->expectCallableOnce());
+
+        Block\sleep(0.1, $loop);
+    }
+
+    public function testEmitsConnectionEvenIfConnectionIsCancelled()
+    {
+        $loop = Factory::create();
+
+        $server = new Server($loop);
+        $server->on('connection', $this->expectCallableOnce());
+        $server->listen(0);
+        $port = $server->getPort();
+
+        $connector = new TcpConnector($loop);
+        $promise = $connector->create('127.0.0.1', $port);
+        $promise->cancel();
+
+        $promise->then(null, $this->expectCallableOnce());
+
+        Block\sleep(0.1, $loop);
+    }
+}


### PR DESCRIPTION
This simple PR aims to add a functional integration test (which also happens to be a prerequisite for implementing #24).

Unfortunately, this simple change introduces an indirect cyclic dependency between `socket -> socket-client -> dns -> socket` which causes the test setup to fail. I'm opening this PR in the hope to propose and discuss a possible solution.