### PR TITLE
Add PHPUnit 4.8 to require-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
   - COMPOSER_ROOT_VERSION=`git describe --abbrev=0` composer install --no-interaction
 
 script:
-  - phpunit --coverage-text
+  - ./vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     },
     "require-dev": {
         "react/socket-client": "^0.5.1",
-        "clue/block-react": "^1.1"
+        "clue/block-react": "^1.1",
+        "phpunit/phpunit": "~4.8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As mentioned in reactphp/react#354

Added phpunit 4.8 to require-dev section of composer.json
Modified travisci config  to perform a composer selfupdate and to use local phpunit.