### PR TITLE
Rename shutdown() to close() for consistency throughout React

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and [`Stream`](https://github.com/reactphp/stream) components.
     * [error event](#error-event)
     * [listen()](#listen)
     * [getPort()](#getport)
-    * [shutdown()](#shutdown)
+    * [close()](#close)
   * [Server](#server)
   * [SecureServer](#secureserver)
   * [ConnectionInterface](#connectioninterface)
@@ -146,22 +146,22 @@ echo 'Server listening on port ' . $port . PHP_EOL;
 ```
 
 This method MUST NOT be called before calling [`listen()`](#listen).
-This method MUST NOT be called after calling [`shutdown()`](#shutdown).
+This method MUST NOT be called after calling [`close()`](#close).
 
-#### shutdown()
+#### close()
 
-The `shutdown(): void` method can be used to
+The `close(): void` method can be used to
 shut down this listening socket.
 
 This will stop listening for new incoming connections on this socket.
 
 ```php
 echo 'Shutting down server socket' . PHP_EOL;
-$server->shutdown();
+$server->close();
 ```
 
 This method MUST NOT be called before calling [`listen()`](#listen).
-This method MUST NOT be called after calling [`shutdown()`](#shutdown).
+This method MUST NOT be called after calling [`close()`](#close).
 
 ### Server
 

--- a/src/SecureServer.php
+++ b/src/SecureServer.php
@@ -78,9 +78,9 @@ class SecureServer extends EventEmitter implements ServerInterface
         return $this->tcp->getPort();
     }
 
-    public function shutdown()
+    public function close()
     {
-        return $this->tcp->shutdown();
+        return $this->tcp->close();
     }
 
     /** @internal */

--- a/src/Server.php
+++ b/src/Server.php
@@ -88,7 +88,7 @@ class Server extends EventEmitter implements ServerInterface
         return (int) substr(strrchr($name, ':'), 1);
     }
 
-    public function shutdown()
+    public function close()
     {
         $this->loop->removeStream($this->master);
         fclose($this->master);

--- a/src/ServerInterface.php
+++ b/src/ServerInterface.php
@@ -72,7 +72,7 @@ interface ServerInterface extends EventEmitterInterface
      * Returns the port this server is currently listening on
      *
      * This method MUST NOT be called before calling listen().
-     * This method MUST NOT be called after calling shutdown().
+     * This method MUST NOT be called after calling close().
      *
      * @return int the port number
      */
@@ -84,9 +84,9 @@ interface ServerInterface extends EventEmitterInterface
      * This will stop listening for new incoming connections on this socket.
      *
      * This method MUST NOT be called before calling listen().
-     * This method MUST NOT be called after calling shutdown().
+     * This method MUST NOT be called after calling close().
      *
      * @return void
      */
-    public function shutdown();
+    public function close();
 }

--- a/tests/SecureServerTest.php
+++ b/tests/SecureServerTest.php
@@ -25,15 +25,15 @@ class SecureServerTest extends TestCase
         $this->assertEquals(1234, $server->getPort());
     }
 
-    public function testShutdownWillBePassedThroughToTcpServer()
+    public function testCloseWillBePassedThroughToTcpServer()
     {
         $tcp = $this->getMockBuilder('React\Socket\Server')->disableOriginalConstructor()->getMock();
-        $tcp->expects($this->once())->method('shutdown');
+        $tcp->expects($this->once())->method('close');
 
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
         $server = new SecureServer($tcp, $loop, array());
 
-        $server->shutdown();
+        $server->close();
     }
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -132,27 +132,27 @@ class ServerTest extends TestCase
         $this->loop->tick();
     }
 
-    public function testLoopWillEndWhenServerIsShutDown()
+    public function testLoopWillEndWhenServerIsClosed()
     {
-        // explicitly unset server because we already call shutdown()
-        $this->server->shutdown();
+        // explicitly unset server because we already call close()
+        $this->server->close();
         $this->server = null;
 
         $this->loop->run();
     }
 
-    public function testLoopWillEndWhenServerIsShutDownAfterSingleConnection()
+    public function testLoopWillEndWhenServerIsClosedAfterSingleConnection()
     {
         $client = stream_socket_client('tcp://localhost:' . $this->port);
 
         // explicitly unset server because we only accept a single connection
-        // and then already call shutdown()
+        // and then already call close()
         $server = $this->server;
         $this->server = null;
 
         $server->on('connection', function ($conn) use ($server) {
             $conn->close();
-            $server->shutdown();
+            $server->close();
         });
 
         $this->loop->run();
@@ -169,7 +169,7 @@ class ServerTest extends TestCase
         $mock = $this->expectCallableOnce();
 
         // explicitly unset server because we only accept a single connection
-        // and then already call shutdown()
+        // and then already call close()
         $server = $this->server;
         $this->server = null;
 
@@ -183,7 +183,7 @@ class ServerTest extends TestCase
             $conn->on('end', $mock);
 
             // do not await any further connections in order to let the loop terminate
-            $server->shutdown();
+            $server->close();
         });
 
         $this->loop->run();
@@ -236,12 +236,12 @@ class ServerTest extends TestCase
     }
 
     /**
-     * @covers React\Socket\Server::shutdown
+     * @covers React\Socket\Server::close
      */
     public function tearDown()
     {
         if ($this->server) {
-            $this->server->shutdown();
+            $this->server->close();
         }
     }
 }

--- a/tests/Stub/ServerStub.php
+++ b/tests/Stub/ServerStub.php
@@ -16,7 +16,7 @@ class ServerStub extends EventEmitter implements ServerInterface
         return 80;
     }
 
-    public function shutdown()
+    public function close()
     {
     }
 }


### PR DESCRIPTION
This very simple PR renames the `shutdown()` method to `close()` in order to achieve consistency throughout React's components.

The term "shutdown" is actually an implementation detail of sockets and does not really apply to closing a server socket.

FWIW, Node also uses "close".