### PR TITLE
Reject listening on hostnames and document valid URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,38 @@ is responsible for accepting plaintext TCP/IP connections.
 $server = new Server(8080, $loop);
 ```
 
-By default, the server will listen on the localhost address and will not be
-reachable from the outside.
-You can change the host the socket is listening on through a first parameter 
-provided to the constructor:
+As above, the `$uri` parameter can consist of only a port, in which case the
+server will default to listening on the localhost address `127.0.0.1` and thus
+it will not be reachable from outside of this system.
+
+In order to use a random port assignment, you can use the port `0`:
+
+```php
+$server = new Server(0, $loop);
+$port = $server->getPort();
+```
+
+In order to change the host the socket is listening on, you can provide an IP
+addres through the first parameter provided to the constructor, optionally
+preceded by the `tcp://` scheme:
 
 ```php
 $server = new Server('192.168.0.1:8080', $loop);
+```
+
+If you want to listen on an IPv6 address, you MUST enclose the host in square
+brackets:
+
+```php
+$server = new Server('[::1]:8080', $loop);
+```
+
+If the given URI is invalid, does not contain a port, any other scheme or if it
+contains a hostname, it will throw an `InvalidArgumentException`:
+
+```php
+// throws InvalidArgumentException due to missing port
+$server = new Server('127.0.0.1', $loop);
 ```
 
 Optionally, you can specify [socket context options](http://php.net/manual/en/context.socket.php)

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ $server = new Server(8080, $loop);
 ```
 
 As above, the `$uri` parameter can consist of only a port, in which case the
-server will default to listening on the localhost address `127.0.0.1` and thus
-it will not be reachable from outside of this system.
+server will default to listening on the localhost address `127.0.0.1`,
+which means it will not be reachable from outside of this system.
 
 In order to use a random port assignment, you can use the port `0`:
 
@@ -163,7 +163,7 @@ $port = $server->getPort();
 ```
 
 In order to change the host the socket is listening on, you can provide an IP
-addres through the first parameter provided to the constructor, optionally
+address through the first parameter provided to the constructor, optionally
 preceded by the `tcp://` scheme:
 
 ```php

--- a/src/Server.php
+++ b/src/Server.php
@@ -51,8 +51,8 @@ class Server extends EventEmitter implements ServerInterface
      * ```
      *
      * As above, the `$uri` parameter can consist of only a port, in which case the
-     * server will default to listening on the localhost address `127.0.0.1` and thus
-     * it will not be reachable from outside of this system.
+     * server will default to listening on the localhost address `127.0.0.1`,
+     * which means it will not be reachable from outside of this system.
      *
      * In order to use a random port assignment, you can use the port `0`:
      *
@@ -62,7 +62,7 @@ class Server extends EventEmitter implements ServerInterface
      * ```
      *
      * In order to change the host the socket is listening on, you can provide an IP
-     * addres through the first parameter provided to the constructor, optionally
+     * address through the first parameter provided to the constructor, optionally
      * preceded by the `tcp://` scheme:
      *
      * ```php

--- a/src/Server.php
+++ b/src/Server.php
@@ -50,13 +50,38 @@ class Server extends EventEmitter implements ServerInterface
      * $server = new Server(8080, $loop);
      * ```
      *
-     * By default, the server will listen on the localhost address and will not be
-     * reachable from the outside.
-     * You can change the host the socket is listening on through the first parameter
-     * provided to the constructor.
+     * As above, the `$uri` parameter can consist of only a port, in which case the
+     * server will default to listening on the localhost address `127.0.0.1` and thus
+     * it will not be reachable from outside of this system.
+     *
+     * In order to use a random port assignment, you can use the port `0`:
+     *
+     * ```php
+     * $server = new Server(0, $loop);
+     * $port = $server->getPort();
+     * ```
+     *
+     * In order to change the host the socket is listening on, you can provide an IP
+     * addres through the first parameter provided to the constructor, optionally
+     * preceded by the `tcp://` scheme:
      *
      * ```php
      * $server = new Server('192.168.0.1:8080', $loop);
+     * ```
+     *
+     * If you want to listen on an IPv6 address, you MUST enclose the host in square
+     * brackets:
+     *
+     * ```php
+     * $server = new Server('[::1]:8080', $loop);
+     * ```
+     *
+     * If the given URI is invalid, does not contain a port, any other scheme or if it
+     * contains a hostname, it will throw an `InvalidArgumentException`:
+     *
+     * ```php
+     * // throws InvalidArgumentException due to missing port
+     * $server = new Server('127.0.0.1', $loop);
      * ```
      *
      * Optionally, you can specify [socket context options](http://php.net/manual/en/context.socket.php)
@@ -108,6 +133,10 @@ class Server extends EventEmitter implements ServerInterface
         // ensure URI contains TCP scheme, host and port
         if (!$parts || !isset($parts['scheme'], $parts['host'], $parts['port']) || $parts['scheme'] !== 'tcp') {
             throw new InvalidArgumentException('Invalid URI "' . $uri . '" given');
+        }
+
+        if (false === filter_var(trim($parts['host'], '[]'), FILTER_VALIDATE_IP)) {
+            throw new \InvalidArgumentException('Given URI "' . $uri . '" does not contain a valid host IP');
         }
 
         $this->master = @stream_socket_server(

--- a/tests/FunctionalServerTest.php
+++ b/tests/FunctionalServerTest.php
@@ -175,4 +175,44 @@ class FunctionalServerTest extends TestCase
 
         $this->assertEquals(array('socket' => array('backlog' => 4)), $all);
     }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testFailsToListenOnInvalidUri()
+    {
+        $loop = Factory::create();
+
+        new Server('///', $loop);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testFailsToListenOnUriWithoutPort()
+    {
+        $loop = Factory::create();
+
+        new Server('127.0.0.1', $loop);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testFailsToListenOnUriWithWrongScheme()
+    {
+        $loop = Factory::create();
+
+        new Server('udp://127.0.0.1:0', $loop);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testFailsToListenOnUriWIthHostname()
+    {
+        $loop = Factory::create();
+
+        new Server('localhost:8080', $loop);
+    }
 }


### PR DESCRIPTION
Listening on a hostname such as `example.com` or `localhost` is a blocking operation. This simple PR enforces the host to consists of an IP address.

Fixes / closes #7
Refs / builds on top of #65