### PR TITLE
Do not expose $master property and accept any ServerInterface for SecureServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,14 +295,19 @@ Note that the `SecureServer` class is a concrete implementation for TLS sockets.
 If you want to typehint in your higher-level protocol implementation, you SHOULD
 use the generic [`ServerInterface`](#serverinterface) instead.
 
-> Advanced usage: Internally, the `SecureServer` has to set the required
-context options on the underlying stream resources.
-It should therefor be used with an unmodified `Server` instance as first
-parameter so that it can allocate an empty context resource which this
-class uses to set required TLS context options.
-Failing to do so may result in some hard to trace race conditions,
-because all stream resources will use a single, shared default context
-resource otherwise.
+> Advanced usage: Despite allowing any `ServerInterface` as first parameter,
+you SHOULD pass an unmodified `Server` instance as first parameter, unless you
+know what you're doing.
+Internally, the `SecureServer` has to set the required TLS context options on
+the underlying stream resources.
+These resources are not exposed through any of the interfaces defined in this
+package, but only through the `React\Stream\Stream` class.
+The unmodified `Server` class is guaranteed to emit connections that implement
+the `ConnectionInterface` and also extend the `Stream` class in order to
+expose these underlying resources.
+If you use a custom `ServerInterface` and its `connection` event does not
+meet this requirement, the `SecureServer` will emit an `error` event and
+then close the underlying connection.
 
 ### ConnectionInterface
 

--- a/src/SecureServer.php
+++ b/src/SecureServer.php
@@ -95,22 +95,27 @@ class SecureServer extends EventEmitter implements ServerInterface
      * and/or PHP version.
      * Passing unknown context options has no effect.
      *
-     * Advanced usage: Internally, the `SecureServer` has to set the required
-     * context options on the underlying stream resources.
-     * It should therefor be used with an unmodified `Server` instance as first
-     * parameter so that it can allocate an empty context resource which this
-     * class uses to set required TLS context options.
-     * Failing to do so may result in some hard to trace race conditions,
-     * because all stream resources will use a single, shared default context
-     * resource otherwise.
+     * Advanced usage: Despite allowing any `ServerInterface` as first parameter,
+     * you SHOULD pass an unmodified `Server` instance as first parameter, unless you
+     * know what you're doing.
+     * Internally, the `SecureServer` has to set the required TLS context options on
+     * the underlying stream resources.
+     * These resources are not exposed through any of the interfaces defined in this
+     * package, but only through the `React\Stream\Stream` class.
+     * The unmodified `Server` class is guaranteed to emit connections that implement
+     * the `ConnectionInterface` and also extend the `Stream` class in order to
+     * expose these underlying resources.
+     * If you use a custom `ServerInterface` and its `connection` event does not
+     * meet this requirement, the `SecureServer` will emit an `error` event and
+     * then close the underlying connection.
      *
-     * @param Server $tcp
+     * @param ServerInterface|Server $tcp
      * @param LoopInterface $loop
      * @param array $context
      * @see Server
      * @link http://php.net/manual/en/context.ssl.php for TLS context options
      */
-    public function __construct(Server $tcp, LoopInterface $loop, array $context)
+    public function __construct(ServerInterface $tcp, LoopInterface $loop, array $context)
     {
         // default to empty passphrase to surpress blocking passphrase prompt
         $context += array(

--- a/src/Server.php
+++ b/src/Server.php
@@ -36,7 +36,7 @@ use InvalidArgumentException;
  */
 class Server extends EventEmitter implements ServerInterface
 {
-    public $master;
+    private $master;
     private $loop;
 
     /**

--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -368,19 +368,6 @@ class FunctionalSecureServerTest extends TestCase
         Block\sleep(self::TIMEOUT, $loop);
     }
 
-    /**
-     * @expectedException React\Socket\ConnectionException
-     */
-    public function testFailsToCreateSecureServerOnClosedSocket()
-    {
-        $loop = Factory::create();
-
-        $server = new Server(0, $loop);
-        $server->close();
-
-        new SecureServer($server, $loop, array());
-    }
-
     private function getPort(ServerInterface $server)
     {
         return parse_url($server->getAddress(), PHP_URL_PORT);

--- a/tests/SecureServerTest.php
+++ b/tests/SecureServerTest.php
@@ -15,7 +15,7 @@ class SecureServerTest extends TestCase
 
     public function testGetAddressWillBePassedThroughToTcpServer()
     {
-        $tcp = $this->getMockBuilder('React\Socket\Server')->disableOriginalConstructor()->getMock();
+        $tcp = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();
         $tcp->expects($this->once())->method('getAddress')->willReturn('127.0.0.1:1234');
 
         $loop = $this->getMock('React\EventLoop\LoopInterface');
@@ -27,7 +27,7 @@ class SecureServerTest extends TestCase
 
     public function testCloseWillBePassedThroughToTcpServer()
     {
-        $tcp = $this->getMockBuilder('React\Socket\Server')->disableOriginalConstructor()->getMock();
+        $tcp = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();
         $tcp->expects($this->once())->method('close');
 
         $loop = $this->getMock('React\EventLoop\LoopInterface');

--- a/tests/SecureServerTest.php
+++ b/tests/SecureServerTest.php
@@ -17,7 +17,6 @@ class SecureServerTest extends TestCase
     {
         $tcp = $this->getMockBuilder('React\Socket\Server')->disableOriginalConstructor()->getMock();
         $tcp->expects($this->once())->method('getAddress')->willReturn('127.0.0.1:1234');
-        $tcp->master = stream_socket_server('tcp://localhost:0');
 
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
@@ -30,7 +29,6 @@ class SecureServerTest extends TestCase
     {
         $tcp = $this->getMockBuilder('React\Socket\Server')->disableOriginalConstructor()->getMock();
         $tcp->expects($this->once())->method('close');
-        $tcp->master = stream_socket_server('tcp://localhost:0');
 
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
@@ -42,7 +40,6 @@ class SecureServerTest extends TestCase
     public function testConnectionWillBeEndedWithErrorIfItIsNotAStream()
     {
         $tcp = $this->getMockBuilder('React\Socket\Server')->disableOriginalConstructor()->setMethods(null)->getMock();
-        $tcp->master = stream_socket_server('tcp://localhost:0');
 
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
@@ -59,7 +56,6 @@ class SecureServerTest extends TestCase
     public function testSocketErrorWillBeForwarded()
     {
         $tcp = $this->getMockBuilder('React\Socket\Server')->disableOriginalConstructor()->setMethods(null)->getMock();
-        $tcp->master = stream_socket_server('tcp://localhost:0');
 
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 


### PR DESCRIPTION
Interfering with this (previously public) property could introduce some very subtle bugs, so it's best to simply avoid exposing it.

Empirical evidence seems to suggest this isn't used much outside of this package anyway.

Inside this package, we can safely replace all references to it with references to child sockets created upon connection.

Also, the `SecureServer` now supports any underlying `ServerInterface` (advanced usage) and no longer relies on a concrete implementation.

Builds on top of #69