### PR TITLE
Mark Server and SecureServer as final and mark internal connection handler as internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,13 +296,13 @@ If you want to typehint in your higher-level protocol implementation, you SHOULD
 use the generic [`ServerInterface`](#serverinterface) instead.
 
 > Advanced usage: Despite allowing any `ServerInterface` as first parameter,
-you SHOULD pass an unmodified `Server` instance as first parameter, unless you
+you SHOULD pass a `Server` instance as first parameter, unless you
 know what you're doing.
 Internally, the `SecureServer` has to set the required TLS context options on
 the underlying stream resources.
 These resources are not exposed through any of the interfaces defined in this
 package, but only through the `React\Stream\Stream` class.
-The unmodified `Server` class is guaranteed to emit connections that implement
+The `Server` class is guaranteed to emit connections that implement
 the `ConnectionInterface` and also extend the `Stream` class in order to
 expose these underlying resources.
 If you use a custom `ServerInterface` and its `connection` event does not

--- a/src/SecureServer.php
+++ b/src/SecureServer.php
@@ -52,7 +52,7 @@ use React\Stream\Stream;
  * @see ServerInterface
  * @see ConnectionInterface
  */
-class SecureServer extends EventEmitter implements ServerInterface
+final class SecureServer extends EventEmitter implements ServerInterface
 {
     private $tcp;
     private $encryption;
@@ -96,13 +96,13 @@ class SecureServer extends EventEmitter implements ServerInterface
      * Passing unknown context options has no effect.
      *
      * Advanced usage: Despite allowing any `ServerInterface` as first parameter,
-     * you SHOULD pass an unmodified `Server` instance as first parameter, unless you
+     * you SHOULD pass a `Server` instance as first parameter, unless you
      * know what you're doing.
      * Internally, the `SecureServer` has to set the required TLS context options on
      * the underlying stream resources.
      * These resources are not exposed through any of the interfaces defined in this
      * package, but only through the `React\Stream\Stream` class.
-     * The unmodified `Server` class is guaranteed to emit connections that implement
+     * The `Server` class is guaranteed to emit connections that implement
      * the `ConnectionInterface` and also extend the `Stream` class in order to
      * expose these underlying resources.
      * If you use a custom `ServerInterface` and its `connection` event does not

--- a/src/Server.php
+++ b/src/Server.php
@@ -34,7 +34,7 @@ use InvalidArgumentException;
  * @see ServerInterface
  * @see ConnectionInterface
  */
-class Server extends EventEmitter implements ServerInterface
+final class Server extends EventEmitter implements ServerInterface
 {
     private $master;
     private $loop;

--- a/src/Server.php
+++ b/src/Server.php
@@ -100,7 +100,7 @@ class Server extends EventEmitter implements ServerInterface
      * and/or PHP version.
      * Passing unknown context options has no effect.
      *
-     * @param string        $uri
+     * @param string|int    $uri
      * @param LoopInterface $loop
      * @param array         $context
      * @throws InvalidArgumentException if the listening address is invalid
@@ -165,15 +165,6 @@ class Server extends EventEmitter implements ServerInterface
         });
     }
 
-    public function handleConnection($socket)
-    {
-        stream_set_blocking($socket, 0);
-
-        $client = $this->createConnection($socket);
-
-        $this->emit('connection', array($client));
-    }
-
     public function getAddress()
     {
         if (!is_resource($this->master)) {
@@ -203,8 +194,11 @@ class Server extends EventEmitter implements ServerInterface
         $this->removeAllListeners();
     }
 
-    public function createConnection($socket)
+    /** @internal */
+    public function handleConnection($socket)
     {
-        return new Connection($socket, $this->loop);
+        $this->emit('connection', array(
+            new Connection($socket, $this->loop)
+        ));
     }
 }

--- a/tests/SecureServerTest.php
+++ b/tests/SecureServerTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Socket;
 
 use React\Socket\SecureServer;
+use React\Socket\Server;
 
 class SecureServerTest extends TestCase
 {
@@ -39,9 +40,9 @@ class SecureServerTest extends TestCase
 
     public function testConnectionWillBeEndedWithErrorIfItIsNotAStream()
     {
-        $tcp = $this->getMockBuilder('React\Socket\Server')->disableOriginalConstructor()->setMethods(null)->getMock();
-
         $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $tcp = new Server(0, $loop);
 
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $connection->expects($this->once())->method('end');
@@ -55,9 +56,9 @@ class SecureServerTest extends TestCase
 
     public function testSocketErrorWillBeForwarded()
     {
-        $tcp = $this->getMockBuilder('React\Socket\Server')->disableOriginalConstructor()->setMethods(null)->getMock();
-
         $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $tcp = new Server(0, $loop);
 
         $server = new SecureServer($tcp, $loop, array());
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -30,9 +30,7 @@ class ServerTest extends TestCase
     }
 
     /**
-     * @covers React\EventLoop\StreamSelectLoop::tick
      * @covers React\Socket\Server::handleConnection
-     * @covers React\Socket\Server::createConnection
      */
     public function testConnection()
     {
@@ -43,9 +41,7 @@ class ServerTest extends TestCase
     }
 
     /**
-     * @covers React\EventLoop\StreamSelectLoop::tick
      * @covers React\Socket\Server::handleConnection
-     * @covers React\Socket\Server::createConnection
      */
     public function testConnectionWithManyClients()
     {


### PR DESCRIPTION
Classes should be used via composition rather than extension.
This reduces our API footprint and avoids future BC breaks by avoiding
exposing its internal assumptions.

Builds on top of #70