### PR TITLE
Replace custom ConnectionException with generic RuntimeException

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,22 @@ contains a hostname, it will throw an `InvalidArgumentException`:
 $server = new Server('127.0.0.1', $loop);
 ```
 
+If the given URI appears to be valid, but listening on it fails (such as if port
+is already in use or port below 1024 may require root access etc.), it will
+throw a `RuntimeException`:
+
+```php
+$first = new Server(8080, $loop);
+
+// throws RuntimeException because port is already in use
+$second = new Server(8080, $loop);
+```
+
+> Note that these error conditions may vary depending on your system and/or
+configuration.
+See the exception message and code for more details about the actual error
+condition.
+
 Optionally, you can specify [socket context options](http://php.net/manual/en/context.socket.php)
 for the underlying stream socket resource like this:
 

--- a/src/ConnectionException.php
+++ b/src/ConnectionException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace React\Socket;
-
-class ConnectionException extends \ErrorException
-{
-}

--- a/tests/FunctionalServerTest.php
+++ b/tests/FunctionalServerTest.php
@@ -4,7 +4,6 @@ namespace React\Tests\Socket;
 
 use React\EventLoop\Factory;
 use React\Socket\Server;
-use React\Socket\ConnectionException;
 use React\Socket\ConnectionInterface;
 use React\Socket\ServerInterface;
 use React\SocketClient\TcpConnector;
@@ -161,7 +160,7 @@ class FunctionalServerTest extends TestCase
 
         try {
             $server = new Server('[::1]:0', $loop);
-        } catch (ConnectionException $e) {
+        } catch (\RuntimeException $e) {
             $this->markTestSkipped('Unable to start IPv6 server socket (not available on your platform?)');
         }
 
@@ -182,7 +181,7 @@ class FunctionalServerTest extends TestCase
 
         try {
             $server = new Server('[::1]:0', $loop);
-        } catch (ConnectionException $e) {
+        } catch (\RuntimeException $e) {
             $this->markTestSkipped('Unable to start IPv6 server socket (not available on your platform?)');
         }
 
@@ -208,7 +207,7 @@ class FunctionalServerTest extends TestCase
 
         try {
             $server = new Server('[::1]:0', $loop);
-        } catch (ConnectionException $e) {
+        } catch (\RuntimeException $e) {
             $this->markTestSkipped('Unable to start IPv6 server socket (not available on your platform?)');
         }
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -237,10 +237,14 @@ class ServerTest extends TestCase
     }
 
     /**
-     * @expectedException React\Socket\ConnectionException
+     * @expectedException RuntimeException
      */
     public function testListenOnBusyPortThrows()
     {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Windows supports listening on same port multiple times');
+        }
+
         $another = new Server($this->port, $this->loop);
     }
 


### PR DESCRIPTION
This simple PR replaces the undocumented `ConnectionException` with a generic `RuntimeException`.
Also adds some documentation for when this occurs and is now in line with other exceptions described in #60 and #61.

Extending the `ErrorException` doesn't really make any sense, because we never actually supported any of its properties.

This change introduces a small BC break, but I figured it's worth it because it reduces the API footprint further (refs #71 and #70) and makes sure our exception usage is consistent across this project.

Also closes #56 while we're at it :shipit: 