### PR TITLE
add getMasterStream method

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -181,6 +181,13 @@ final class Server extends EventEmitter implements ServerInterface
         });
     }
 
+    /**
+     * @return resource master stream
+     */
+    public function getMasterStream(){
+        return $this->master;
+    }
+    
     public function getAddress()
     {
         if (!is_resource($this->master)) {


### PR DESCRIPTION
I'm writing forking TCP server with master and forked worker processes. I need the way to detach all socket listeners after process forked.
I see no other way to do it (except using Reflection), so would be good to add this functional.

Sample code when i forced to use Reflection: https://github.com/Tatikoma/react-mst/blob/b80be508093f09ae7e6d82a32274c7e4b5c948fa/src/tatikoma/react-mst/Server.php#L195

Or maybe i missed something then i 'll be happy if someone 'll show me other way :-)