### PR TITLE
Add pause() and resume() methods to limit active connections

### DIFF
--- a/src/SecureServer.php
+++ b/src/SecureServer.php
@@ -140,6 +140,16 @@ final class SecureServer extends EventEmitter implements ServerInterface
         return $this->tcp->getAddress();
     }
 
+    public function pause()
+    {
+        $this->tcp->pause();
+    }
+
+    public function resume()
+    {
+        $this->tcp->resume();
+    }
+
     public function close()
     {
         return $this->tcp->close();

--- a/src/ServerInterface.php
+++ b/src/ServerInterface.php
@@ -73,6 +73,67 @@ interface ServerInterface extends EventEmitterInterface
     public function getAddress();
 
     /**
+     * Pauses accepting new incoming connections.
+     *
+     * Removes the socket resource from the EventLoop and thus stop accepting
+     * new connections. Note that the listening socket stays active and is not
+     * closed.
+     *
+     * This means that new incoming connections will stay pending in the
+     * operating system backlog until its configurable backlog is filled.
+     * Once the backlog is filled, the operating system may reject further
+     * incoming connections until the backlog is drained again by resuming
+     * to accept new connections.
+     *
+     * Once the server is paused, no futher `connection` events SHOULD
+     * be emitted.
+     *
+     * ```php
+     * $server->pause();
+     *
+     * $server->on('connection', assertShouldNeverCalled());
+     * ```
+     *
+     * This method is advisory-only, though generally not recommended, the
+     * server MAY continue emitting `connection` events.
+     *
+     * Unless otherwise noted, a successfully opened server SHOULD NOT start
+     * in paused state.
+     *
+     * You can continue processing events by calling `resume()` again.
+     *
+     * Note that both methods can be called any number of times, in particular
+     * calling `pause()` more than once SHOULD NOT have any effect.
+     * Similarly, calling this after `close()` is a NO-OP.
+     *
+     * @see self::resume()
+     * @return void
+     */
+    public function pause();
+
+    /**
+     * Resumes accepting new incoming connections.
+     *
+     * Re-attach the socket resource to the EventLoop after a previous `pause()`.
+     *
+     * ```php
+     * $server->pause();
+     *
+     * $loop->addTimer(1.0, function () use ($server) {
+     *     $server->resume();
+     * });
+     * ```
+     *
+     * Note that both methods can be called any number of times, in particular
+     * calling `resume()` without a prior `pause()` SHOULD NOT have any effect.
+     * Similarly, calling this after `close()` is a NO-OP.
+     *
+     * @see self::pause()
+     * @return void
+     */
+    public function resume();
+
+    /**
      * Shuts down this listening socket
      *
      * This will stop listening for new incoming connections on this socket.

--- a/tests/FunctionalServerTest.php
+++ b/tests/FunctionalServerTest.php
@@ -25,6 +25,39 @@ class FunctionalServerTest extends TestCase
         Block\sleep(0.1, $loop);
     }
 
+    public function testEmitsNoConnectionForNewConnectionWhenPaused()
+    {
+        $loop = Factory::create();
+
+        $server = new Server(0, $loop);
+        $server->on('connection', $this->expectCallableNever());
+        $server->pause();
+
+        $connector = new TcpConnector($loop);
+        $promise = $connector->connect($server->getAddress());
+
+        $promise->then($this->expectCallableOnce());
+
+        Block\sleep(0.1, $loop);
+    }
+
+    public function testEmitsConnectionForNewConnectionWhenResumedAfterPause()
+    {
+        $loop = Factory::create();
+
+        $server = new Server(0, $loop);
+        $server->on('connection', $this->expectCallableOnce());
+        $server->pause();
+        $server->resume();
+
+        $connector = new TcpConnector($loop);
+        $promise = $connector->connect($server->getAddress());
+
+        $promise->then($this->expectCallableOnce());
+
+        Block\sleep(0.1, $loop);
+    }
+
     public function testEmitsConnectionWithRemoteIp()
     {
         $loop = Factory::create();

--- a/tests/SecureServerTest.php
+++ b/tests/SecureServerTest.php
@@ -26,6 +26,30 @@ class SecureServerTest extends TestCase
         $this->assertEquals('127.0.0.1:1234', $server->getAddress());
     }
 
+    public function testPauseWillBePassedThroughToTcpServer()
+    {
+        $tcp = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();
+        $tcp->expects($this->once())->method('pause');
+
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $server = new SecureServer($tcp, $loop, array());
+
+        $server->pause();
+    }
+
+    public function testResumeWillBePassedThroughToTcpServer()
+    {
+        $tcp = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();
+        $tcp->expects($this->once())->method('resume');
+
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $server = new SecureServer($tcp, $loop, array());
+
+        $server->resume();
+    }
+
     public function testCloseWillBePassedThroughToTcpServer()
     {
         $tcp = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -232,6 +232,51 @@ class ServerTest extends TestCase
         $this->loop->tick();
     }
 
+    public function testCtorAddsResourceToLoop()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addReadStream');
+
+        $server = new Server(0, $loop);
+    }
+
+    public function testResumeWithoutPauseIsNoOp()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addReadStream');
+
+        $server = new Server(0, $loop);
+        $server->resume();
+    }
+
+    public function testPauseRemovesResourceFromLoop()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('removeReadStream');
+
+        $server = new Server(0, $loop);
+        $server->pause();
+    }
+
+    public function testPauseAfterPauseIsNoOp()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('removeReadStream');
+
+        $server = new Server(0, $loop);
+        $server->pause();
+        $server->pause();
+    }
+
+    public function testCloseRemovesResourceFromLoop()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('removeReadStream');
+
+        $server = new Server(0, $loop);
+        $server->close();
+    }
+
     /**
      * @expectedException RuntimeException
      */


### PR DESCRIPTION
The `pause()` and `resume()` methods can be used to limit the number of active connections.

This can be used to stop accepting incoming connections once a certain limit is reached, so that the operating system backlog is responsible for managing pending connections.

I've prepared a follow-up PR for adds a simple API to control the maximum number of active connections.