### PR TITLE
Add link for previous version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![Build Status](https://secure.travis-ci.org/reactphp/socket.png?branch=master)](http://travis-ci.org/reactphp/socket)
 
+For previous versions, please see related documentation:
+
+| [0.3.x](https://github.com/reactphp/socket/tree/0.3/README.md) | [0.4.x](https://github.com/reactphp/socket/tree/0.4/README.md) | [0.5.x](https://github.com/reactphp/socket/tree/master/README.md) |
+|---|---|---|
+
 Async, streaming plaintext TCP/IP and secure TLS socket server for React PHP
 
 The socket component provides a more usable interface for a socket-layer


### PR DESCRIPTION
You have a good velocity in development theses days. But some projects use a previous version and the doc looks wrong but it's not!