### PR TITLE
Ignore HHVM errors when closing connection that is already closing

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -20,8 +20,11 @@ class Connection extends Stream implements ConnectionInterface
             return;
         }
 
-        // http://chat.stackoverflow.com/transcript/message/7727858#7727858
-        stream_socket_shutdown($this->stream, STREAM_SHUT_RDWR);
+        // Try to cleanly shut down socket and ignore any errors in case other
+        // side already closed. Shutting down may return to blocking mode on
+        // some legacy versions, so reset to non-blocking just in case before
+        // continuing to close the socket resource.
+        @stream_socket_shutdown($this->stream, STREAM_SHUT_RDWR);
         stream_set_blocking($this->stream, false);
         fclose($this->stream);
     }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -82,6 +82,24 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function gettingPlaintextStuffFromEncryptedGoogleShouldNotWork()
+    {
+        $loop = new StreamSelectLoop();
+        $connector = new Connector($loop);
+
+        $conn = Block\await($connector->connect('google.com:443'), $loop);
+
+        $this->assertContains(':443', $conn->getRemoteAddress());
+        $this->assertNotEquals('google.com:443', $conn->getRemoteAddress());
+
+        $conn->write("GET / HTTP/1.0\r\n\r\n");
+
+        $response = Block\await(BufferedSink::createPromise($conn), $loop, self::TIMEOUT);
+
+        $this->assertNotRegExp('#^HTTP/1\.0#', $response);
+    }
+
+    /** @test */
     public function testConnectingFailsIfDnsUsesInvalidResolver()
     {
         $loop = new StreamSelectLoop();


### PR DESCRIPTION
HHVM raises a PHP warning when trying to shut down a socket that is already closing because the other side closed the connection. This does not happen for any other PHP version, so simply ignore this error as part of the shut down procedure.

Refs https://github.com/clue/php-http-proxy-react/pull/9 and https://travis-ci.org/clue/php-http-proxy-react/jobs/220595506