### PR TITLE
Work around latest PHP 7.0.18 and 7.1.4 no longer accepting full URIs

### DIFF
--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -66,14 +66,12 @@ final class TcpConnector implements ConnectorInterface
             }
         }
 
-        // HHVM fails to parse URIs with a query but no path, so let's add a dummy path
-        // See also https://3v4l.org/jEhLF
-        if (defined('HHVM_VERSION') && isset($parts['query']) && !isset($parts['path'])) {
-            $uri = str_replace('?', '/?', $uri); // @codeCoverageIgnore
-        }
+        // latest versions of PHP no longer accept any other URI components and
+        // HHVM fails to parse URIs with a query but no path, so let's simplify our URI here
+        $remote = 'tcp://' . $parts['host'] . ':' . $parts['port'];
 
         $socket = @stream_socket_client(
-            $uri,
+            $remote,
             $errno,
             $errstr,
             0,


### PR DESCRIPTION
Noticed this tweet by @nrk: https://twitter.com/JoL1hAHN/status/854332152791654401?s=09

This currently only affects PHP 7.0.18 and 7.1.4: https://3v4l.org/ivR7T
Apparently introduced via https://bugs.php.net/bug.php?id=74216
This issue has already been reported upstream: https://bugs.php.net/bug.php?id=74429