### PR TITLE
Rename Server to TcpServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ handle multiple concurrent connections without blocking.
     * [pause()](#pause)
     * [resume()](#resume)
     * [close()](#close)
-  * [Server](#server)
+  * [TcpServer](#tcpserver)
   * [SecureServer](#secureserver)
   * [LimitingServer](#limitingserver)
     * [getConnections()](#getconnections)
@@ -55,7 +55,7 @@ Here is a server that closes the connection if you send it anything:
 ```php
 $loop = React\EventLoop\Factory::create();
 
-$socket = new React\Socket\Server(8080, $loop);
+$socket = new React\Socket\TcpServer(8080, $loop);
 $socket->on('connection', function (ConnectionInterface $conn) {
     $conn->write("Hello " . $conn->getRemoteAddress() . "!\n");
     $conn->write("Welcome to this amazing server!\n");
@@ -173,7 +173,7 @@ Otherwise, it will return the full local address as a string value.
 
 This method complements the [`getRemoteAddress()`](#getremoteaddress) method,
 so they should not be confused.
-If your `Server` instance is listening on multiple interfaces (e.g. using
+If your `TcpServer` instance is listening on multiple interfaces (e.g. using
 the address `0.0.0.0`), you can use this method to find out which interface
 actually accepted this connection (such as a public or local interface).
 
@@ -319,13 +319,13 @@ $server->close();
 
 Calling this method more than once on the same instance is a NO-OP.
 
-### Server
+### TcpServer
 
-The `Server` class implements the [`ServerInterface`](#serverinterface) and
+The `TcpServer` class implements the [`ServerInterface`](#serverinterface) and
 is responsible for accepting plaintext TCP/IP connections.
 
 ```php
-$server = new Server(8080, $loop);
+$server = new TcpServer(8080, $loop);
 ```
 
 As above, the `$uri` parameter can consist of only a port, in which case the
@@ -335,7 +335,7 @@ which means it will not be reachable from outside of this system.
 In order to use a random port assignment, you can use the port `0`:
 
 ```php
-$server = new Server(0, $loop);
+$server = new TcpServer(0, $loop);
 $address = $server->getAddress();
 ```
 
@@ -344,14 +344,14 @@ address through the first parameter provided to the constructor, optionally
 preceded by the `tcp://` scheme:
 
 ```php
-$server = new Server('192.168.0.1:8080', $loop);
+$server = new TcpServer('192.168.0.1:8080', $loop);
 ```
 
 If you want to listen on an IPv6 address, you MUST enclose the host in square
 brackets:
 
 ```php
-$server = new Server('[::1]:8080', $loop);
+$server = new TcpServer('[::1]:8080', $loop);
 ```
 
 If the given URI is invalid, does not contain a port, any other scheme or if it
@@ -359,7 +359,7 @@ contains a hostname, it will throw an `InvalidArgumentException`:
 
 ```php
 // throws InvalidArgumentException due to missing port
-$server = new Server('127.0.0.1', $loop);
+$server = new TcpServer('127.0.0.1', $loop);
 ```
 
 If the given URI appears to be valid, but listening on it fails (such as if port
@@ -367,10 +367,10 @@ is already in use or port below 1024 may require root access etc.), it will
 throw a `RuntimeException`:
 
 ```php
-$first = new Server(8080, $loop);
+$first = new TcpServer(8080, $loop);
 
 // throws RuntimeException because port is already in use
-$second = new Server(8080, $loop);
+$second = new TcpServer(8080, $loop);
 ```
 
 > Note that these error conditions may vary depending on your system and/or
@@ -382,7 +382,7 @@ Optionally, you can specify [socket context options](http://php.net/manual/en/co
 for the underlying stream socket resource like this:
 
 ```php
-$server = new Server('[::1]:8080', $loop, array(
+$server = new TcpServer('[::1]:8080', $loop, array(
     'backlog' => 200,
     'so_reuseport' => true,
     'ipv6_v6only' => true
@@ -408,7 +408,7 @@ $server->on('connection', function (ConnectionInterface $connection) {
 
 See also the [`ServerInterface`](#serverinterface) for more details.
 
-Note that the `Server` class is a concrete implementation for TCP/IP sockets.
+Note that the `TcpServer` class is a concrete implementation for TCP/IP sockets.
 If you want to typehint in your higher-level protocol implementation, you SHOULD
 use the generic [`ServerInterface`](#serverinterface) instead.
 
@@ -417,14 +417,14 @@ use the generic [`ServerInterface`](#serverinterface) instead.
 The `SecureServer` class implements the [`ServerInterface`](#serverinterface)
 and is responsible for providing a secure TLS (formerly known as SSL) server.
 
-It does so by wrapping a [`Server`](#server) instance which waits for plaintext
+It does so by wrapping a [`TcpServer`](#tcpserver) instance which waits for plaintext
 TCP/IP connections and then performs a TLS handshake for each connection.
 It thus requires valid [TLS context options](http://php.net/manual/en/context.ssl.php),
 which in its most basic form may look something like this if you're using a
 PEM encoded certificate file:
 
 ```php
-$server = new Server(8000, $loop);
+$server = new TcpServer(8000, $loop);
 $server = new SecureServer($server, $loop, array(
     'local_cert' => 'server.pem'
 ));
@@ -439,7 +439,7 @@ If your private key is encrypted with a passphrase, you have to specify it
 like this:
 
 ```php
-$server = new Server(8000, $loop);
+$server = new TcpServer(8000, $loop);
 $server = new SecureServer($server, $loop, array(
     'local_cert' => 'server.pem',
     'passphrase' => 'secret'
@@ -479,13 +479,13 @@ If you want to typehint in your higher-level protocol implementation, you SHOULD
 use the generic [`ServerInterface`](#serverinterface) instead.
 
 > Advanced usage: Despite allowing any `ServerInterface` as first parameter,
-you SHOULD pass a `Server` instance as first parameter, unless you
+you SHOULD pass a `TcpServer` instance as first parameter, unless you
 know what you're doing.
 Internally, the `SecureServer` has to set the required TLS context options on
 the underlying stream resources.
 These resources are not exposed through any of the interfaces defined in this
 package, but only through the `React\Stream\Stream` class.
-The `Server` class is guaranteed to emit connections that implement
+The `TcpServer` class is guaranteed to emit connections that implement
 the `ConnectionInterface` and also extend the `Stream` class in order to
 expose these underlying resources.
 If you use a custom `ServerInterface` and its `connection` event does not

--- a/examples/01-echo.php
+++ b/examples/01-echo.php
@@ -12,7 +12,7 @@
 // $ openssl s_client -connect localhost:8000
 
 use React\EventLoop\Factory;
-use React\Socket\Server;
+use React\Socket\TcpServer;
 use React\Socket\ConnectionInterface;
 use React\Socket\SecureServer;
 
@@ -20,7 +20,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop);
+$server = new TcpServer(isset($argv[1]) ? $argv[1] : 0, $loop);
 
 // secure TLS mode if certificate is given as second parameter
 if (isset($argv[2])) {

--- a/examples/02-chat-server.php
+++ b/examples/02-chat-server.php
@@ -12,7 +12,7 @@
 // $ openssl s_client -connect localhost:8000
 
 use React\EventLoop\Factory;
-use React\Socket\Server;
+use React\Socket\TcpServer;
 use React\Socket\ConnectionInterface;
 use React\Socket\SecureServer;
 use React\Socket\LimitingServer;
@@ -21,7 +21,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop);
+$server = new TcpServer(isset($argv[1]) ? $argv[1] : 0, $loop);
 
 // secure TLS mode if certificate is given as second parameter
 if (isset($argv[2])) {

--- a/examples/03-benchmark.php
+++ b/examples/03-benchmark.php
@@ -17,7 +17,7 @@
 // $ dd if=/dev/zero bs=1M count=1000 | openssl s_client -connect localhost:8000
 
 use React\EventLoop\Factory;
-use React\Socket\Server;
+use React\Socket\TcpServer;
 use React\Socket\ConnectionInterface;
 use React\Socket\SecureServer;
 
@@ -25,7 +25,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop);
+$server = new TcpServer(isset($argv[1]) ? $argv[1] : 0, $loop);
 
 // secure TLS mode if certificate is given as second parameter
 if (isset($argv[2])) {

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -95,7 +95,7 @@ interface ConnectionInterface extends DuplexStreamInterface
      * This method complements the [`getRemoteAddress()`](#getremoteaddress) method,
      * so they should not be confused.
      *
-     * If your `Server` instance is listening on multiple interfaces (e.g. using
+     * If your `TcpServer` instance is listening on multiple interfaces (e.g. using
      * the address `0.0.0.0`), you can use this method to find out which interface
      * actually accepted this connection (such as a public or local interface).
      *

--- a/src/SecureServer.php
+++ b/src/SecureServer.php
@@ -4,7 +4,7 @@ namespace React\Socket;
 
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
-use React\Socket\Server;
+use React\Socket\TcpServer;
 use React\Socket\ConnectionInterface;
 use React\Stream\Stream;
 
@@ -12,11 +12,11 @@ use React\Stream\Stream;
  * The `SecureServer` class implements the `ServerInterface` and is responsible
  * for providing a secure TLS (formerly known as SSL) server.
  *
- * It does so by wrapping a `Server` instance which waits for plaintext
+ * It does so by wrapping a `TcpServer` instance which waits for plaintext
  * TCP/IP connections and then performs a TLS handshake for each connection.
  *
  * ```php
- * $server = new Server(8000, $loop);
+ * $server = new TcpServer(8000, $loop);
  * $server = new SecureServer($server, $loop, array(
  *     // tls context options here…
  * ));
@@ -61,14 +61,14 @@ final class SecureServer extends EventEmitter implements ServerInterface
     /**
      * Creates a secure TLS server and starts waiting for incoming connections
      *
-     * It does so by wrapping a `Server` instance which waits for plaintext
+     * It does so by wrapping a `TcpServer` instance which waits for plaintext
      * TCP/IP connections and then performs a TLS handshake for each connection.
      * It thus requires valid [TLS context options],
      * which in its most basic form may look something like this if you're using a
      * PEM encoded certificate file:
      *
      * ```php
-     * $server = new Server(8000, $loop);
+     * $server = new TcpServer(8000, $loop);
      * $server = new SecureServer($server, $loop, array(
      *     'local_cert' => 'server.pem'
      * ));
@@ -83,7 +83,7 @@ final class SecureServer extends EventEmitter implements ServerInterface
      * like this:
      *
      * ```php
-     * $server = new Server(8000, $loop);
+     * $server = new TcpServer(8000, $loop);
      * $server = new SecureServer($server, $loop, array(
      *     'local_cert' => 'server.pem',
      *     'passphrase' => 'secret'
@@ -96,24 +96,24 @@ final class SecureServer extends EventEmitter implements ServerInterface
      * Passing unknown context options has no effect.
      *
      * Advanced usage: Despite allowing any `ServerInterface` as first parameter,
-     * you SHOULD pass a `Server` instance as first parameter, unless you
+     * you SHOULD pass a `TcpServer` instance as first parameter, unless you
      * know what you're doing.
      * Internally, the `SecureServer` has to set the required TLS context options on
      * the underlying stream resources.
      * These resources are not exposed through any of the interfaces defined in this
      * package, but only through the `React\Stream\Stream` class.
-     * The `Server` class is guaranteed to emit connections that implement
+     * The `TcpServer` class is guaranteed to emit connections that implement
      * the `ConnectionInterface` and also extend the `Stream` class in order to
      * expose these underlying resources.
      * If you use a custom `ServerInterface` and its `connection` event does not
      * meet this requirement, the `SecureServer` will emit an `error` event and
      * then close the underlying connection.
      *
-     * @param ServerInterface|Server $tcp
+     * @param ServerInterface|TcpServer $tcp
      * @param LoopInterface $loop
      * @param array $context
      * @throws \BadMethodCallException for legacy HHVM < 3.8 due to lack of support
-     * @see Server
+     * @see TcpServer
      * @link http://php.net/manual/en/context.ssl.php for TLS context options
      */
     public function __construct(ServerInterface $tcp, LoopInterface $loop, array $context)

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -8,11 +8,11 @@ use InvalidArgumentException;
 use RuntimeException;
 
 /**
- * The `Server` class implements the `ServerInterface` and
+ * The `TcpServer` class implements the `ServerInterface` and
  * is responsible for accepting plaintext TCP/IP connections.
  *
  * ```php
- * $server = new Server(8080, $loop);
+ * $server = new TcpServer(8080, $loop);
  * ```
  *
  * Whenever a client connects, it will emit a `connection` event with a connection
@@ -28,14 +28,14 @@ use RuntimeException;
  *
  * See also the `ServerInterface` for more details.
  *
- * Note that the `Server` class is a concrete implementation for TCP/IP sockets.
+ * Note that the `TcpServer` class is a concrete implementation for TCP/IP sockets.
  * If you want to typehint in your higher-level protocol implementation, you SHOULD
  * use the generic `ServerInterface` instead.
  *
  * @see ServerInterface
  * @see ConnectionInterface
  */
-final class Server extends EventEmitter implements ServerInterface
+final class TcpServer extends EventEmitter implements ServerInterface
 {
     private $master;
     private $loop;
@@ -49,7 +49,7 @@ final class Server extends EventEmitter implements ServerInterface
      * for more details.
      *
      * ```php
-     * $server = new Server(8080, $loop);
+     * $server = new TcpServer(8080, $loop);
      * ```
      *
      * As above, the `$uri` parameter can consist of only a port, in which case the
@@ -59,7 +59,7 @@ final class Server extends EventEmitter implements ServerInterface
      * In order to use a random port assignment, you can use the port `0`:
      *
      * ```php
-     * $server = new Server(0, $loop);
+     * $server = new TcpServer(0, $loop);
      * $address = $server->getAddress();
      * ```
      *
@@ -68,14 +68,14 @@ final class Server extends EventEmitter implements ServerInterface
      * preceded by the `tcp://` scheme:
      *
      * ```php
-     * $server = new Server('192.168.0.1:8080', $loop);
+     * $server = new TcpServer('192.168.0.1:8080', $loop);
      * ```
      *
      * If you want to listen on an IPv6 address, you MUST enclose the host in square
      * brackets:
      *
      * ```php
-     * $server = new Server('[::1]:8080', $loop);
+     * $server = new TcpServer('[::1]:8080', $loop);
      * ```
      *
      * If the given URI is invalid, does not contain a port, any other scheme or if it
@@ -83,7 +83,7 @@ final class Server extends EventEmitter implements ServerInterface
      *
      * ```php
      * // throws InvalidArgumentException due to missing port
-     * $server = new Server('127.0.0.1', $loop);
+     * $server = new TcpServer('127.0.0.1', $loop);
      * ```
      *
      * If the given URI appears to be valid, but listening on it fails (such as if port
@@ -91,10 +91,10 @@ final class Server extends EventEmitter implements ServerInterface
      * throw a `RuntimeException`:
      *
      * ```php
-     * $first = new Server(8080, $loop);
+     * $first = new TcpServer(8080, $loop);
      *
      * // throws RuntimeException because port is already in use
-     * $second = new Server(8080, $loop);
+     * $second = new TcpServer(8080, $loop);
      * ```
      *
      * Note that these error conditions may vary depending on your system and/or
@@ -106,7 +106,7 @@ final class Server extends EventEmitter implements ServerInterface
      * for the underlying stream socket resource like this:
      *
      * ```php
-     * $server = new Server('[::1]:8080', $loop, array(
+     * $server = new TcpServer('[::1]:8080', $loop, array(
      *     'backlog' => 200,
      *     'so_reuseport' => true,
      *     'ipv6_v6only' => true

--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -6,7 +6,7 @@ use React\EventLoop\Factory;
 use React\Stream\Stream;
 use React\Socket\SecureServer;
 use React\Socket\ConnectionInterface;
-use React\Socket\Server;
+use React\Socket\TcpServer;
 use React\Socket\TcpConnector;
 use React\Socket\SecureConnector;
 use Clue\React\Block;
@@ -26,7 +26,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
@@ -44,7 +44,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
@@ -71,7 +71,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
@@ -103,7 +103,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
@@ -131,7 +131,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
@@ -163,7 +163,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
@@ -197,7 +197,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost_swordfish.pem',
             'passphrase' => 'swordfish'
@@ -216,7 +216,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => 'invalid.pem'
         ));
@@ -236,7 +236,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost_swordfish.pem'
         ));
@@ -256,7 +256,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost_swordfish.pem',
             'passphrase' => 'nope'
@@ -277,7 +277,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
@@ -297,7 +297,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
@@ -318,7 +318,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
@@ -336,7 +336,7 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));

--- a/tests/FunctionalTcpServerTest.php
+++ b/tests/FunctionalTcpServerTest.php
@@ -3,18 +3,18 @@
 namespace React\Tests\Socket;
 
 use React\EventLoop\Factory;
-use React\Socket\Server;
+use React\Socket\TcpServer;
 use React\Socket\ConnectionInterface;
 use React\Socket\TcpConnector;
 use Clue\React\Block;
 
-class FunctionalServerTest extends TestCase
+class FunctionalTcpServerTest extends TestCase
 {
     public function testEmitsConnectionForNewConnection()
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server->on('connection', $this->expectCallableOnce());
 
         $connector = new TcpConnector($loop);
@@ -29,7 +29,7 @@ class FunctionalServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server->on('connection', $this->expectCallableNever());
         $server->pause();
 
@@ -45,7 +45,7 @@ class FunctionalServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server->on('connection', $this->expectCallableOnce());
         $server->pause();
         $server->resume();
@@ -62,7 +62,7 @@ class FunctionalServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $peer = null;
         $server->on('connection', function (ConnectionInterface $conn) use (&$peer) {
             $peer = $conn->getRemoteAddress();
@@ -82,7 +82,7 @@ class FunctionalServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $local = null;
         $server->on('connection', function (ConnectionInterface $conn) use (&$local) {
             $local = $conn->getLocalAddress();
@@ -103,7 +103,7 @@ class FunctionalServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server('0.0.0.0:0', $loop);
+        $server = new TcpServer('0.0.0.0:0', $loop);
         $local = null;
         $server->on('connection', function (ConnectionInterface $conn) use (&$local) {
             $local = $conn->getLocalAddress();
@@ -123,7 +123,7 @@ class FunctionalServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $peer = null;
         $server->on('connection', function (ConnectionInterface $conn) use (&$peer) {
             $conn->on('close', function () use ($conn, &$peer) {
@@ -146,7 +146,7 @@ class FunctionalServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $peer = null;
         $server->on('connection', function (ConnectionInterface $conn) use (&$peer) {
             $conn->close();
@@ -167,7 +167,7 @@ class FunctionalServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server->on('connection', $this->expectCallableOnce());
 
         $connector = new TcpConnector($loop);
@@ -184,7 +184,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
 
         try {
-            $server = new Server('[::1]:0', $loop);
+            $server = new TcpServer('[::1]:0', $loop);
         } catch (\RuntimeException $e) {
             $this->markTestSkipped('Unable to start IPv6 server socket (not available on your platform?)');
         }
@@ -204,7 +204,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
 
         try {
-            $server = new Server('[::1]:0', $loop);
+            $server = new TcpServer('[::1]:0', $loop);
         } catch (\RuntimeException $e) {
             $this->markTestSkipped('Unable to start IPv6 server socket (not available on your platform?)');
         }
@@ -229,7 +229,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
 
         try {
-            $server = new Server('[::1]:0', $loop);
+            $server = new TcpServer('[::1]:0', $loop);
         } catch (\RuntimeException $e) {
             $this->markTestSkipped('Unable to start IPv6 server socket (not available on your platform?)');
         }
@@ -259,7 +259,7 @@ class FunctionalServerTest extends TestCase
 
         $loop = Factory::create();
 
-        $server = new Server(0, $loop, array(
+        $server = new TcpServer(0, $loop, array(
             'backlog' => 4
         ));
 
@@ -285,7 +285,7 @@ class FunctionalServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        new Server('///', $loop);
+        new TcpServer('///', $loop);
     }
 
     /**
@@ -295,7 +295,7 @@ class FunctionalServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        new Server('127.0.0.1', $loop);
+        new TcpServer('127.0.0.1', $loop);
     }
 
     /**
@@ -305,7 +305,7 @@ class FunctionalServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        new Server('udp://127.0.0.1:0', $loop);
+        new TcpServer('udp://127.0.0.1:0', $loop);
     }
 
     /**
@@ -315,6 +315,6 @@ class FunctionalServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        new Server('localhost:8080', $loop);
+        new TcpServer('localhost:8080', $loop);
     }
 }

--- a/tests/LimitingServerTest.php
+++ b/tests/LimitingServerTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use React\Socket\LimitingServer;
-use React\Socket\Server;
+use React\Socket\TcpServer;
 use React\EventLoop\Factory;
 use Clue\React\Block;
 
@@ -77,7 +77,7 @@ class LimitingServerTest extends TestCase
     {
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
-        $tcp = new Server(0, $loop);
+        $tcp = new TcpServer(0, $loop);
 
         $server = new LimitingServer($tcp, 100);
 
@@ -92,7 +92,7 @@ class LimitingServerTest extends TestCase
 
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
-        $tcp = new Server(0, $loop);
+        $tcp = new TcpServer(0, $loop);
 
         $server = new LimitingServer($tcp, 100);
         $server->on('connection', $this->expectCallableOnceWith($connection));
@@ -112,7 +112,7 @@ class LimitingServerTest extends TestCase
 
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
-        $tcp = new Server(0, $loop);
+        $tcp = new TcpServer(0, $loop);
 
         $server = new LimitingServer($tcp, 1);
         $server->on('connection', $this->expectCallableOnceWith($first));
@@ -128,7 +128,7 @@ class LimitingServerTest extends TestCase
         $loop->expects($this->once())->method('addReadStream');
         $loop->expects($this->once())->method('removeReadStream');
 
-        $tcp = new Server(0, $loop);
+        $tcp = new TcpServer(0, $loop);
 
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
@@ -141,7 +141,7 @@ class LimitingServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $tcp = new Server(0, $loop);
+        $tcp = new TcpServer(0, $loop);
 
         $socket = stream_socket_client('tcp://' . $tcp->getAddress());
         fclose($socket);
@@ -159,7 +159,7 @@ class LimitingServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new LimitingServer($server, 1, true);
         $server->on('connection', $this->expectCallableOnce());
         $server->on('error', $this->expectCallableNever());
@@ -180,7 +180,7 @@ class LimitingServerTest extends TestCase
         $twice = $this->createCallableMock();
         $twice->expects($this->exactly(2))->method('__invoke');
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server = new LimitingServer($server, 1, true);
         $server->on('connection', $twice);
         $server->on('error', $this->expectCallableNever());

--- a/tests/SecureIntegrationTest.php
+++ b/tests/SecureIntegrationTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use React\EventLoop\Factory as LoopFactory;
-use React\Socket\Server;
+use React\Socket\TcpServer;
 use React\Socket\SecureServer;
 use React\Socket\TcpConnector;
 use React\Socket\SecureConnector;
@@ -30,7 +30,7 @@ class SecureIntegrationTest extends TestCase
         }
 
         $this->loop = LoopFactory::create();
-        $this->server = new Server(0, $this->loop);
+        $this->server = new TcpServer(0, $this->loop);
         $this->server = new SecureServer($this->server, $this->loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));

--- a/tests/SecureServerTest.php
+++ b/tests/SecureServerTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use React\Socket\SecureServer;
-use React\Socket\Server;
+use React\Socket\TcpServer;
 
 class SecureServerTest extends TestCase
 {
@@ -66,7 +66,7 @@ class SecureServerTest extends TestCase
     {
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
-        $tcp = new Server(0, $loop);
+        $tcp = new TcpServer(0, $loop);
 
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $connection->expects($this->once())->method('end');
@@ -82,7 +82,7 @@ class SecureServerTest extends TestCase
     {
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
-        $tcp = new Server(0, $loop);
+        $tcp = new TcpServer(0, $loop);
 
         $server = new SecureServer($tcp, $loop, array());
 

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use React\EventLoop\StreamSelectLoop;
-use React\Socket\Server;
+use React\Socket\TcpServer;
 use React\Socket\TcpConnector;
 use React\Socket\ConnectionInterface;
 use Clue\React\Block;
@@ -29,7 +29,7 @@ class TcpConnectorTest extends TestCase
     {
         $loop = new StreamSelectLoop();
 
-        $server = new Server(9999, $loop);
+        $server = new TcpServer(9999, $loop);
         $server->on('connection', $this->expectCallableOnce());
         $server->on('connection', array($server, 'close'));
 
@@ -47,7 +47,7 @@ class TcpConnectorTest extends TestCase
     {
         $loop = new StreamSelectLoop();
 
-        $server = new Server(9999, $loop);
+        $server = new TcpServer(9999, $loop);
         $server->on('connection', array($server, 'close'));
 
         $connector = new TcpConnector($loop);
@@ -65,7 +65,7 @@ class TcpConnectorTest extends TestCase
     {
         $loop = new StreamSelectLoop();
 
-        $server = new Server(9999, $loop);
+        $server = new TcpServer(9999, $loop);
         $server->on('connection', array($server, 'close'));
 
         $connector = new TcpConnector($loop);
@@ -84,7 +84,7 @@ class TcpConnectorTest extends TestCase
     {
         $loop = new StreamSelectLoop();
 
-        $server = new Server(9999, $loop);
+        $server = new TcpServer(9999, $loop);
         $server->on('connection', array($server, 'close'));
 
         $connector = new TcpConnector($loop);
@@ -117,7 +117,7 @@ class TcpConnectorTest extends TestCase
         $loop = new StreamSelectLoop();
 
         try {
-            $server = new Server('[::1]:9999', $loop);
+            $server = new TcpServer('[::1]:9999', $loop);
         } catch (\Exception $e) {
             $this->markTestSkipped('Unable to start IPv6 server socket (IPv6 not supported on this system?)');
         }
@@ -194,7 +194,7 @@ class TcpConnectorTest extends TestCase
         $loop = new StreamSelectLoop();
         $connector = new TcpConnector($loop);
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
 
         $promise = $connector->connect($server->getAddress());
         $promise->cancel();

--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -4,9 +4,9 @@ namespace React\Tests\Socket;
 
 use React\EventLoop\StreamSelectLoop;
 use React\Stream\Stream;
-use React\Socket\Server;
+use React\Socket\TcpServer;
 
-class ServerTest extends TestCase
+class TcpServerTest extends TestCase
 {
     private $loop;
     private $server;
@@ -18,19 +18,19 @@ class ServerTest extends TestCase
     }
 
     /**
-     * @covers React\Socket\Server::__construct
-     * @covers React\Socket\Server::getAddress
+     * @covers React\Socket\TcpServer::__construct
+     * @covers React\Socket\TcpServer::getAddress
      */
     public function setUp()
     {
         $this->loop = $this->createLoop();
-        $this->server = new Server(0, $this->loop);
+        $this->server = new TcpServer(0, $this->loop);
 
         $this->port = parse_url($this->server->getAddress(), PHP_URL_PORT);
     }
 
     /**
-     * @covers React\Socket\Server::handleConnection
+     * @covers React\Socket\TcpServer::handleConnection
      */
     public function testConnection()
     {
@@ -41,7 +41,7 @@ class ServerTest extends TestCase
     }
 
     /**
-     * @covers React\Socket\Server::handleConnection
+     * @covers React\Socket\TcpServer::handleConnection
      */
     public function testConnectionWithManyClients()
     {
@@ -237,7 +237,7 @@ class ServerTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->once())->method('addReadStream');
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
     }
 
     public function testResumeWithoutPauseIsNoOp()
@@ -245,7 +245,7 @@ class ServerTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->once())->method('addReadStream');
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server->resume();
     }
 
@@ -254,7 +254,7 @@ class ServerTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->once())->method('removeReadStream');
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server->pause();
     }
 
@@ -263,7 +263,7 @@ class ServerTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->once())->method('removeReadStream');
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server->pause();
         $server->pause();
     }
@@ -273,7 +273,7 @@ class ServerTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->once())->method('removeReadStream');
 
-        $server = new Server(0, $loop);
+        $server = new TcpServer(0, $loop);
         $server->close();
     }
 
@@ -286,11 +286,11 @@ class ServerTest extends TestCase
             $this->markTestSkipped('Windows supports listening on same port multiple times');
         }
 
-        $another = new Server($this->port, $this->loop);
+        $another = new TcpServer($this->port, $this->loop);
     }
 
     /**
-     * @covers React\Socket\Server::close
+     * @covers React\Socket\TcpServer::close
      */
     public function tearDown()
     {


### PR DESCRIPTION
This simple PR renames the `Server` class to `TcpServer`.

A follow-up PR will introduce a new `Server` class which acts as a facade for the existing server classes. This class allows to start a `TcpServer` as-is and will prepare the code for the upcoming Unix domain socket server (#25) and upcoming `SecureServer` with auto-generated certificates (#95). This will work very similar to how the `Connector` class is a facade for the client side connector classes.

In other words, the follow-up PR will restore compatibility with consumer code so this does in fact not result in a BC break for most users.