### PR TITLE
Add Server facade for existing server classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ handle multiple concurrent connections without blocking.
     * [resume()](#resume)
     * [close()](#close)
   * [Server](#server)
-  * [TcpServer](#tcpserver)
-  * [SecureServer](#secureserver)
-  * [LimitingServer](#limitingserver)
-    * [getConnections()](#getconnections)
+  * [Advanced server usage](#advanced-server-usage)
+    * [TcpServer](#tcpserver)
+    * [SecureServer](#secureserver)
+    * [LimitingServer](#limitingserver)
+      * [getConnections()](#getconnections)
 * [Client usage](#client-usage)
   * [ConnectorInterface](#connectorinterface)
     * [connect()](#connect)
@@ -55,8 +56,8 @@ Here is a server that closes the connection if you send it anything:
 
 ```php
 $loop = React\EventLoop\Factory::create();
+$socket = new React\Socket\Server('127.0.0.1:8080', $loop);
 
-$socket = new React\Socket\TcpServer(8080, $loop);
 $socket->on('connection', function (ConnectionInterface $conn) {
     $conn->write("Hello " . $conn->getRemoteAddress() . "!\n");
     $conn->write("Welcome to this amazing server!\n");
@@ -322,10 +323,9 @@ Calling this method more than once on the same instance is a NO-OP.
 
 ### Server
 
-The `Server` class implements the [`ServerInterface`](#serverinterface) and
-is responsible for accepting plaintext TCP/IP connections.
-It acts as a facade for the underlying [`TcpServer`](#tcpserver) and follows
-its exact semantics.
+The `Server` class is the main class in this package that implements the
+[`ServerInterface`](#serverinterface) and allows you to accept incoming
+streaming connections, such as plaintext TCP/IP or secure TLS connection streams.
 
 ```php
 $server = new Server(8080, $loop);
@@ -461,7 +461,9 @@ See also the [`ServerInterface`](#serverinterface) for more details.
   If you want to typehint in your higher-level protocol implementation, you SHOULD
   use the generic [`ServerInterface`](#serverinterface) instead.
 
-### TcpServer
+### Advanced server usage
+
+#### TcpServer
 
 The `TcpServer` class implements the [`ServerInterface`](#serverinterface) and
 is responsible for accepting plaintext TCP/IP connections.
@@ -550,7 +552,7 @@ $server->on('connection', function (ConnectionInterface $connection) {
 
 See also the [`ServerInterface`](#serverinterface) for more details.
 
-### SecureServer
+#### SecureServer
 
 The `SecureServer` class implements the [`ServerInterface`](#serverinterface)
 and is responsible for providing a secure TLS (formerly known as SSL) server.
@@ -630,7 +632,7 @@ If you use a custom `ServerInterface` and its `connection` event does not
 meet this requirement, the `SecureServer` will emit an `error` event and
 then close the underlying connection.
 
-### LimitingServer
+#### LimitingServer
 
 The `LimitingServer` decorator wraps a given `ServerInterface` and is responsible
 for limiting and keeping track of open connections to this server instance.
@@ -697,7 +699,7 @@ $server->on('connection', function (ConnectionInterface $connection) {
 });
 ```
 
-#### getConnections()
+##### getConnections()
 
 The `getConnections(): ConnectionInterface[]` method can be used to
 return an array with all currently active connections.

--- a/README.md
+++ b/README.md
@@ -377,25 +377,29 @@ $second = new Server(8080, $loop);
 ```
 
 > Note that these error conditions may vary depending on your system and/or
-configuration.
-See the exception message and code for more details about the actual error
-condition.
+  configuration.
+  See the exception message and code for more details about the actual error
+  condition.
 
-Optionally, you can specify [socket context options](http://php.net/manual/en/context.socket.php)
+Optionally, you can specify [TCP socket context options](http://php.net/manual/en/context.socket.php)
 for the underlying stream socket resource like this:
 
 ```php
 $server = new Server('[::1]:8080', $loop, array(
-    'backlog' => 200,
-    'so_reuseport' => true,
-    'ipv6_v6only' => true
+    'tcp' => array(
+        'backlog' => 200,
+        'so_reuseport' => true,
+        'ipv6_v6only' => true
+    )
 ));
 ```
 
 > Note that available [socket context options](http://php.net/manual/en/context.socket.php),
-their defaults and effects of changing these may vary depending on your system
-and/or PHP version.
-Passing unknown context options has no effect.
+  their defaults and effects of changing these may vary depending on your system
+  and/or PHP version.
+  Passing unknown context options has no effect.
+  For BC reasons, you can also pass the TCP socket context options as a simple
+  array without wrapping this in another array under the `tcp` key.
 
 Whenever a client connects, it will emit a `connection` event with a connection
 instance implementing [`ConnectionInterface`](#connectioninterface):

--- a/README.md
+++ b/README.md
@@ -401,6 +401,48 @@ $server = new Server('[::1]:8080', $loop, array(
   For BC reasons, you can also pass the TCP socket context options as a simple
   array without wrapping this in another array under the `tcp` key.
 
+You can start a secure TLS (formerly known as SSL) server by simply prepending
+the `tls://` URI scheme.
+Internally, it will wait for plaintext TCP/IP connections and then performs a
+TLS handshake for each connection.
+It thus requires valid [TLS context options](http://php.net/manual/en/context.ssl.php),
+which in its most basic form may look something like this if you're using a
+PEM encoded certificate file:
+
+```php
+$server = new Server('tls://127.0.0.1:8080', $loop, array(
+    'tls' => array(
+        'local_cert' => 'server.pem'
+    )
+));
+```
+
+> Note that the certificate file will not be loaded on instantiation but when an
+  incoming connection initializes its TLS context.
+  This implies that any invalid certificate file paths or contents will only cause
+  an `error` event at a later time.
+
+If your private key is encrypted with a passphrase, you have to specify it
+like this:
+
+```php
+$server = new Server('tls://127.0.0.1:8000', $loop, array(
+    'tls' => array(
+        'local_cert' => 'server.pem',
+        'passphrase' => 'secret'
+    )
+));
+```
+
+> Note that available [TLS context options](http://php.net/manual/en/context.ssl.php),
+  their defaults and effects of changing these may vary depending on your system
+  and/or PHP version.
+  The outer context array allows you to also use `tcp` (and possibly more)
+  context options at the same time.
+  Passing unknown context options has no effect.
+  If you do not use the `tls://` scheme, then passing `tls` context options
+  has no effect.
+
 Whenever a client connects, it will emit a `connection` event with a connection
 instance implementing [`ConnectionInterface`](#connectioninterface):
 

--- a/examples/01-echo.php
+++ b/examples/01-echo.php
@@ -8,26 +8,22 @@
 //
 // You can also run a secure TLS echo server like this:
 //
-// $ php examples/01-echo.php 8000 examples/localhost.pem
+// $ php examples/01-echo.php tls://127.0.0.1:8000 examples/localhost.pem
 // $ openssl s_client -connect localhost:8000
 
 use React\EventLoop\Factory;
-use React\Socket\TcpServer;
+use React\Socket\Server;
 use React\Socket\ConnectionInterface;
-use React\Socket\SecureServer;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new TcpServer(isset($argv[1]) ? $argv[1] : 0, $loop);
-
-// secure TLS mode if certificate is given as second parameter
-if (isset($argv[2])) {
-    $server = new SecureServer($server, $loop, array(
-        'local_cert' => $argv[2]
-    ));
-}
+$server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop, array(
+    'tls' => array(
+        'local_cert' => isset($argv[2]) ? $argv[2] : (__DIR__ . '/localhost.pem')
+    )
+));
 
 $server->on('connection', function (ConnectionInterface $conn) {
     echo '[connected]' . PHP_EOL;

--- a/examples/02-chat-server.php
+++ b/examples/02-chat-server.php
@@ -8,27 +8,23 @@
 //
 // You can also run a secure TLS chat server like this:
 //
-// $ php examples/02-chat-server.php 8000 examples/localhost.pem
+// $ php examples/02-chat-server.php tls://127.0.0.1:8000 examples/localhost.pem
 // $ openssl s_client -connect localhost:8000
 
 use React\EventLoop\Factory;
-use React\Socket\TcpServer;
+use React\Socket\Server;
 use React\Socket\ConnectionInterface;
-use React\Socket\SecureServer;
 use React\Socket\LimitingServer;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new TcpServer(isset($argv[1]) ? $argv[1] : 0, $loop);
-
-// secure TLS mode if certificate is given as second parameter
-if (isset($argv[2])) {
-    $server = new SecureServer($server, $loop, array(
-        'local_cert' => $argv[2]
-    ));
-}
+$server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop, array(
+    'tls' => array(
+        'local_cert' => isset($argv[2]) ? $argv[2] : (__DIR__ . '/localhost.pem')
+    )
+));
 
 $server = new LimitingServer($server, null);
 

--- a/examples/03-benchmark.php
+++ b/examples/03-benchmark.php
@@ -11,28 +11,24 @@
 //
 // You can also run a secure TLS benchmarking server like this:
 //
-// $ php examples/03-benchmark.php 8000 examples/localhost.pem
+// $ php examples/03-benchmark.php tls://127.0.0.1:8000 examples/localhost.pem
 // $ openssl s_client -connect localhost:8000
 // $ echo hello world | openssl s_client -connect localhost:8000
 // $ dd if=/dev/zero bs=1M count=1000 | openssl s_client -connect localhost:8000
 
 use React\EventLoop\Factory;
-use React\Socket\TcpServer;
+use React\Socket\Server;
 use React\Socket\ConnectionInterface;
-use React\Socket\SecureServer;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new TcpServer(isset($argv[1]) ? $argv[1] : 0, $loop);
-
-// secure TLS mode if certificate is given as second parameter
-if (isset($argv[2])) {
-    $server = new SecureServer($server, $loop, array(
-        'local_cert' => $argv[2]
-    ));
-}
+$server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop, array(
+    'tls' => array(
+        'local_cert' => isset($argv[2]) ? $argv[2] : (__DIR__ . '/localhost.pem')
+    )
+));
 
 $server->on('connection', function (ConnectionInterface $conn) use ($loop) {
     echo '[connected]' . PHP_EOL;

--- a/src/Server.php
+++ b/src/Server.php
@@ -11,7 +11,17 @@ final class Server extends EventEmitter implements ServerInterface
 
     public function __construct($uri, LoopInterface $loop, array $context = array())
     {
-        $server = new TcpServer($uri, $loop, $context);
+        // sanitize TCP context options if not properly wrapped
+        if ($context && !isset($context['tcp'])) {
+            $context = array('tcp' => $context);
+        }
+
+        // apply default options if not explicitly given
+        $context += array(
+            'tcp' => array(),
+        );
+
+        $server = new TcpServer($uri, $loop, $context['tcp']);
         $this->server = $server;
 
         $that = $this;

--- a/src/Server.php
+++ b/src/Server.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace React\Socket;
+
+use Evenement\EventEmitter;
+use React\EventLoop\LoopInterface;
+
+final class Server extends EventEmitter implements ServerInterface
+{
+    private $server;
+
+    public function __construct($uri, LoopInterface $loop, array $context = array())
+    {
+        $server = new TcpServer($uri, $loop, $context);
+        $this->server = $server;
+
+        $that = $this;
+        $server->on('connection', function (ConnectionInterface $conn) use ($that) {
+            $that->emit('connection', array($conn));
+        });
+        $server->on('error', function (\Exception $error) use ($that) {
+            $that->emit('error', array($error));
+        });
+    }
+
+    public function getAddress()
+    {
+        return $this->server->getAddress();
+    }
+
+    public function pause()
+    {
+        $this->server->pause();
+    }
+
+    public function resume()
+    {
+        $this->server->resume();
+    }
+
+    public function close()
+    {
+        $this->server->close();
+    }
+}

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -28,10 +28,6 @@ use RuntimeException;
  *
  * See also the `ServerInterface` for more details.
  *
- * Note that the `TcpServer` class is a concrete implementation for TCP/IP sockets.
- * If you want to typehint in your higher-level protocol implementation, you SHOULD
- * use the generic `ServerInterface` instead.
- *
  * @see ServerInterface
  * @see ConnectionInterface
  */

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -107,4 +107,24 @@ class ServerTest extends TestCase
 
         $this->assertEquals(array('socket' => array('backlog' => 4)), $all);
     }
+
+    public function testDoesNotEmitSecureConnectionForNewPlainConnection()
+    {
+        if (!function_exists('stream_socket_enable_crypto')) {
+            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        }
+
+        $loop = Factory::create();
+
+        $server = new Server('tls://127.0.0.1:0', $loop, array(
+            'tls' => array(
+                'local_cert' => __DIR__ . '/../examples/localhost.pem'
+            )
+        ));
+        $server->on('connection', $this->expectCallableNever());
+
+        $client = stream_socket_client($server->getAddress());
+
+        Block\sleep(0.1, $loop);
+    }
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace React\Tests\Socket;
+
+use React\EventLoop\Factory;
+use React\Socket\Server;
+use Clue\React\Block;
+
+class ServerTest extends TestCase
+{
+    public function testCreateServer()
+    {
+        $loop = Factory::create();
+
+        $server = new Server(0, $loop);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testConstructorThrowsForInvalidUri()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $server = new Server('invalid URI', $loop);
+    }
+
+    public function testEmitsConnectionForNewConnection()
+    {
+        $loop = Factory::create();
+
+        $server = new Server(0, $loop);
+        $server->on('connection', $this->expectCallableOnce());
+
+        $client = stream_socket_client($server->getAddress());
+
+        Block\sleep(0.1, $loop);
+    }
+
+    public function testDoesNotEmitConnectionForNewConnectionToPausedServer()
+    {
+        $loop = Factory::create();
+
+        $server = new Server(0, $loop);
+        $server->pause();
+
+
+        $client = stream_socket_client($server->getAddress());
+
+        Block\sleep(0.1, $loop);
+    }
+
+    public function testDoesEmitConnectionForNewConnectionToResumedServer()
+    {
+        $loop = Factory::create();
+
+        $server = new Server(0, $loop);
+        $server->pause();
+        $server->on('connection', $this->expectCallableOnce());
+
+        $client = stream_socket_client($server->getAddress());
+
+        Block\sleep(0.1, $loop);
+
+        $server->resume();
+        Block\sleep(0.1, $loop);
+    }
+
+    public function testDoesNotAllowConnectionToClosedServer()
+    {
+        $loop = Factory::create();
+
+        $server = new Server(0, $loop);
+        $server->on('connection', $this->expectCallableNever());
+        $address = $server->getAddress();
+        $server->close();
+
+        $client = @stream_socket_client($address);
+
+        Block\sleep(0.1, $loop);
+
+        $this->assertFalse($client);
+    }
+}


### PR DESCRIPTION
This is a follow-up PR to #96 which introduces a new Server class which acts as a facade for the existing server classes. This class allows to start a TcpServer and SecureServer as-is and will prepare the code for the upcoming Unix domain socket server (#25) and upcoming SecureServer with auto-generated certificates (#95). This works very similar to how the Connector class is a facade for the client side connector classes.

This also *fixes* the intentional BC break introduced in #96 so that consumer code does not have to be updated.

Builds on top of #96