### PR TITLE
Use fully qualified type annotation

### DIFF
--- a/src/ConnectorInterface.php
+++ b/src/ConnectorInterface.php
@@ -51,7 +51,7 @@ interface ConnectorInterface
      * ```
      *
      * @param string $uri
-     * @return React\Promise\PromiseInterface resolves with a stream implementing ConnectionInterface on success or rejects with an Exception on error
+     * @return \React\Promise\PromiseInterface resolves with a stream implementing ConnectionInterface on success or rejects with an Exception on error
      * @see ConnectionInterface
      */
     public function connect($uri);


### PR DESCRIPTION
Fixes #102 Type annotations misinterpreted by phpstan

When using this library in a project which uses [phpstan][] for code analysis it gives the following error.

Call to method then() on an unknown class     
React\Socket\React\Promise\PromiseInterface.