### PR TITLE
Fix HHVM build for now again and ignore future HHVM build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,14 @@ php:
   - 5.5
   - 5.6
   - 7
-  - hhvm
+
+# also test against HHVM, but require "trusty" and ignore errors
+matrix:
+  include:
+    - php: hhvm
+      dist: trusty
+  allow_failures:
+    - php: hhvm
 
 sudo: false
 


### PR DESCRIPTION
The HHVM build reports an error once again. Let's fix this once again by updating the base distro from precise to trusty and ignore any future HHVM build errors.

See https://github.com/travis-ci/travis-ci/issues/7712#issuecomment-300553336
Originally from https://github.com/clue/php-http-proxy-react/pull/12