### PR TITLE
Target evenement 3.0 a long side 2.0 and 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.0",
-        "evenement/evenement": "~2.0|~1.0",
+        "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/dns": "0.4.*|0.3.*",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
         "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.5",


### PR DESCRIPTION
Événement `3.0` is nearly fully backwards compatible with `2.0` and `1.0` and `react/socket` is fully compatible with all three so why not support it. It packs some neat performance upgrades without any code changes on `react/socket`'s side :shipit: .