### PR TITLE
Update DNS dependency to support hosts file on all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,12 +846,9 @@ If you want to typehint in your higher-level protocol implementation, you SHOULD
 use the generic [`ConnectorInterface`](#connectorinterface) instead.
 
 In particular, the `Connector` class uses Google's public DNS server `8.8.8.8`
-to resolve all hostnames into underlying IP addresses by default.
-This implies that it also ignores your `hosts` file and `resolve.conf`, which
-means you won't be able to connect to `localhost` and other non-public
-hostnames by default.
-If you want to use a custom DNS server (such as a local DNS relay), you can set
-up the `Connector` like this:
+to resolve all public hostnames into underlying IP addresses by default.
+If you want to use a custom DNS server (such as a local DNS relay or a company
+wide DNS server), you can set up the `Connector` like this:
 
 ```php
 $connector = new Connector($loop, array(

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/dns": "0.4.*|0.3.*",
+        "react/dns": "^0.4.11",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
         "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.5",
         "react/promise": "^2.1 || ^1.2",

--- a/tests/FunctionalConnectorTest.php
+++ b/tests/FunctionalConnectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace React\Tests\Socket;
+
+use Clue\React\Block;
+use React\EventLoop\StreamSelectLoop;
+use React\Socket\TcpServer;
+use React\Socket\Connector;
+
+class FunctionalConnectorTest extends TestCase
+{
+    const TIMEOUT = 1.0;
+
+    /** @test */
+    public function connectionToTcpServerShouldSucceedWithLocalhost()
+    {
+        $loop = new StreamSelectLoop();
+
+        $server = new TcpServer(9998, $loop);
+        $server->on('connection', $this->expectCallableOnce());
+        $server->on('connection', array($server, 'close'));
+
+        $connector = new Connector($loop);
+
+        $connection = Block\await($connector->connect('localhost:9998'), $loop, self::TIMEOUT);
+
+        $this->assertInstanceOf('React\Socket\ConnectionInterface', $connection);
+
+        $connection->close();
+        $server->close();
+    }
+}


### PR DESCRIPTION
The `Connector` (and underlying `DnsConnector`) now honors the hosts file on all platforms by default. This means that you can now connect to `localhost` etc..

Resolves / closes #88
Refs https://github.com/reactphp/dns/pull/75