### PR TITLE
Work around write chunk size for TLS streams for PHP < 7.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1259,6 +1259,13 @@ IRC over TLS, but should not affect HTTP over TLS (HTTPS).
 Further investigation of this issue is needed.
 For more insights, this issue is also covered by our test suite.
 
+PHP < 7.1.4 (and PHP < 7.0.18) suffers from a bug when writing big
+chunks of data over TLS streams at once.
+We try to work around this by limiting the write chunk size to 8192
+bytes for older PHP versions only.
+This is only a work-around and has a noticable performance penalty on
+affected versions.
+
 This project also supports running on HHVM.
 Note that really old HHVM < 3.8 does not support secure TLS connections, as it
 lacks the required `stream_socket_enable_crypto()` function.

--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,13 @@
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/dns": "^0.4.11",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
-        "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.5",
+        "react/stream": "^1.0 || ^0.7.1",
         "react/promise": "^2.1 || ^1.2",
         "react/promise-timer": "~1.0"
     },
     "require-dev": {
         "clue/block-react": "^1.1",
-        "phpunit/phpunit": "~4.8",
-        "react/stream": "^1.0 || ^0.7 || ^0.6"
+        "phpunit/phpunit": "~4.8"
     },
     "autoload": {
         "psr-4": {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -5,9 +5,9 @@ namespace React\Socket;
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 use React\Stream\DuplexResourceStream;
-use React\Stream\Stream;
 use React\Stream\Util;
 use React\Stream\WritableStreamInterface;
+use React\Stream\WritableResourceStream;
 
 /**
  * The actual connection implementation for ConnectionInterface
@@ -50,20 +50,24 @@ class Connection extends EventEmitter implements ConnectionInterface
         // See https://bugs.php.net/bug.php?id=65137
         // https://bugs.php.net/bug.php?id=41631
         // https://github.com/reactphp/socket-client/issues/24
-        $clearCompleteBuffer = (version_compare(PHP_VERSION, '5.6.8', '<'));
+        $clearCompleteBuffer = PHP_VERSION_ID < 50608;
 
-        // @codeCoverageIgnoreStart
-        if (class_exists('React\Stream\Stream')) {
-            // legacy react/stream < 0.7 requires additional buffer property
-            $this->input = new Stream($resource, $loop);
-            if ($clearCompleteBuffer) {
-                $this->input->bufferSize = null;
-            }
-        } else {
-            // preferred react/stream >= 0.7 accepts buffer parameter
-            $this->input = new DuplexResourceStream($resource, $loop, $clearCompleteBuffer ? -1 : null);
-        }
-        // @codeCoverageIgnoreEnd
+        // PHP < 7.1.4 (and PHP < 7.0.18) suffers from a bug when writing big
+        // chunks of data over TLS streams at once.
+        // We try to work around this by limiting the write chunk size to 8192
+        // bytes for older PHP versions only.
+        // This is only a work-around and has a noticable performance penalty on
+        // affected versions. Please update your PHP version.
+        // This applies to all streams because TLS may be enabled later on.
+        // See https://github.com/reactphp/socket/issues/105
+        $limitWriteChunks = (PHP_VERSION_ID < 70018 || (PHP_VERSION_ID >= 70100 && PHP_VERSION_ID < 70104));
+
+        $this->input = new DuplexResourceStream(
+            $resource,
+            $loop,
+            $clearCompleteBuffer ? -1 : null,
+            new WritableResourceStream($resource, $loop, null, $limitWriteChunks ? 8192 : null)
+        );
 
         $this->stream = $resource;
 


### PR DESCRIPTION
PHP < 7.1.4 (and PHP < 7.0.18) suffers from a bug when writing big chunks of data over TLS streams at once. We try to work around this by limiting the write chunk size to 8192 bytes for older PHP versions only. This is only a work-around and has a noticable performance penalty on affected versions. Please update your PHP version.

Closes / resolves #105