### PR TITLE
Add FixedUriConnector decorator to use fixed, preconfigured URI instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ handle multiple concurrent connections without blocking.
     * [SecureConnector](#secureconnector)
     * [TimeoutConnector](#timeoutconnector)
     * [UnixConnector](#unixconnector)
+    * [FixUriConnector](#fixeduriconnector)
 * [Install](#install)
 * [Tests](#tests)
 * [License](#license)
@@ -1219,6 +1220,26 @@ As such, calling `cancel()` on the resulting promise has no effect.
   with the `unix://` scheme, for example `unix:///tmp/demo.sock`.
   The [`getLocalAddress()`](#getlocaladdress) method will most likely return a
   `null` value as this value is not applicable to UDS connections here.
+
+#### FixedUriConnector
+
+The `FixedUriConnector` class implements the
+[`ConnectorInterface`](#connectorinterface) and decorates an existing Connector
+to always use a fixed, preconfigured URI.
+
+This can be useful for consumers that do not support certain URIs, such as
+when you want to explicitly connect to a Unix domain socket (UDS) path
+instead of connecting to a default address assumed by an higher-level API:
+
+```php
+$connector = new FixedUriConnector(
+    'unix:///var/run/docker.sock',
+    new UnixConnector($loop)
+);
+
+// destination will be ignored, actually connects to Unix domain socket
+$promise = $connector->connect('localhost:80');
+```
 
 ## Install
 

--- a/src/FixedUriConnector.php
+++ b/src/FixedUriConnector.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace React\Socket;
+
+use React\Socket\ConnectorInterface;
+
+/**
+ * Decorates an existing Connector to always use a fixed, preconfigured URI
+ *
+ * This can be useful for consumers that do not support certain URIs, such as
+ * when you want to explicitly connect to a Unix domain socket (UDS) path
+ * instead of connecting to a default address assumed by an higher-level API:
+ *
+ * ```php
+ * $connector = new FixedUriConnector(
+ *     'unix:///var/run/docker.sock',
+ *     new UnixConnector($loop)
+ * );
+ *
+ * // destination will be ignored, actually connects to Unix domain socket
+ * $promise = $connector->connect('localhost:80');
+ * ```
+ */
+class FixedUriConnector implements ConnectorInterface
+{
+    private $uri;
+    private $connector;
+
+    /**
+     * @param string $uri
+     * @param ConnectorInterface $connector
+     */
+    public function __construct($uri, ConnectorInterface $connector)
+    {
+        $this->uri = $uri;
+        $this->connector = $connector;
+    }
+
+    public function connect($_)
+    {
+        return $this->connector->connect($this->uri);
+    }
+}

--- a/tests/FixedUriConnectorTest.php
+++ b/tests/FixedUriConnectorTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace React\Tests\Socket;
+
+use React\Socket\FixedUriConnector;
+use React\Tests\Socket\TestCase;
+
+class FixedUriConnectorTest extends TestCase
+{
+    public function testWillInvokeGivenConnector()
+    {
+        $base = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $base->expects($this->once())->method('connect')->with('test')->willReturn('ret');
+
+        $connector = new FixedUriConnector('test', $base);
+
+        $this->assertEquals('ret', $connector->connect('ignored'));
+    }
+}


### PR DESCRIPTION
The `FixedUriConnector` class implements the
[`ConnectorInterface`](#connectorinterface) and decorates an existing Connector
to always use a fixed, preconfigured URI.

This can be useful for consumers that do not support certain URIs, such as
when you want to explicitly connect to a Unix domain socket (UDS) path
instead of connecting to a default address assumed by an higher-level API:

```php
$connector = new FixedUriConnector(
    'unix:///var/run/docker.sock',
    new UnixConnector($loop)
);

// destination will be ignored, actually connects to Unix domain socket
$promise = $connector->connect('localhost:80');
```

Required to bring Unix domain socket (UDS) path support to our HttpClient (https://github.com/reactphp/http-client/issues/46)

Supersedes https://github.com/reactphp/socket-client/pull/42