### PR TITLE
Fix forward compatibility with upcoming EventLoop releases in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "react/promise-timer": "~1.0"
     },
     "require-dev": {
-        "clue/block-react": "^1.1",
+        "clue/block-react": "^1.2",
         "phpunit/phpunit": "^5.0 || ^4.8"
     },
     "autoload": {

--- a/tests/FunctionalConnectorTest.php
+++ b/tests/FunctionalConnectorTest.php
@@ -3,9 +3,9 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\StreamSelectLoop;
-use React\Socket\TcpServer;
+use React\EventLoop\Factory;
 use React\Socket\Connector;
+use React\Socket\TcpServer;
 
 class FunctionalConnectorTest extends TestCase
 {
@@ -14,7 +14,7 @@ class FunctionalConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceedWithLocalhost()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
         $server = new TcpServer(9998, $loop);
         $server->on('connection', $this->expectCallableOnce());

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -2,13 +2,13 @@
 
 namespace React\Tests\Socket;
 
-use React\Dns\Resolver\Factory;
-use React\EventLoop\StreamSelectLoop;
+use Clue\React\Block;
+use React\Dns\Resolver\Factory as ResolverFactory;
+use React\EventLoop\Factory;
 use React\Socket\Connector;
+use React\Socket\DnsConnector;
 use React\Socket\SecureConnector;
 use React\Socket\TcpConnector;
-use Clue\React\Block;
-use React\Socket\DnsConnector;
 
 class IntegrationTest extends TestCase
 {
@@ -17,7 +17,7 @@ class IntegrationTest extends TestCase
     /** @test */
     public function gettingStuffFromGoogleShouldWork()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
         $connector = new Connector($loop);
 
         $conn = Block\await($connector->connect('google.com:80'), $loop);
@@ -39,7 +39,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
         }
 
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
         $secureConnector = new Connector($loop);
 
         $conn = Block\await($secureConnector->connect('tls://google.com:443'), $loop);
@@ -58,9 +58,9 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
         }
 
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
-        $factory = new Factory();
+        $factory = new ResolverFactory();
         $dns = $factory->create('8.8.8.8', $loop);
 
         $connector = new DnsConnector(
@@ -83,7 +83,7 @@ class IntegrationTest extends TestCase
     /** @test */
     public function gettingPlaintextStuffFromEncryptedGoogleShouldNotWork()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
         $connector = new Connector($loop);
 
         $conn = Block\await($connector->connect('google.com:443'), $loop);
@@ -101,9 +101,9 @@ class IntegrationTest extends TestCase
     /** @test */
     public function testConnectingFailsIfDnsUsesInvalidResolver()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
-        $factory = new Factory();
+        $factory = new ResolverFactory();
         $dns = $factory->create('demo.invalid', $loop);
 
         $connector = new Connector($loop, array(
@@ -121,7 +121,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
         }
 
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
         $connector = new Connector($loop, array(
             'timeout' => 0.001
@@ -138,7 +138,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
         }
 
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
         $connector = new Connector($loop, array(
             'tls' => array(
@@ -157,7 +157,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
         }
 
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
         $connector = new Connector($loop, array(
             'tls' => array(
@@ -171,7 +171,7 @@ class IntegrationTest extends TestCase
 
     public function testCancelPendingConnection()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
         $connector = new TcpConnector($loop);
         $pending = $connector->connect('8.8.8.8:80');

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -2,11 +2,11 @@
 
 namespace React\Tests\Socket;
 
-use React\EventLoop\StreamSelectLoop;
-use React\Socket\TcpServer;
-use React\Socket\TcpConnector;
-use React\Socket\ConnectionInterface;
 use Clue\React\Block;
+use React\EventLoop\Factory;
+use React\Socket\ConnectionInterface;
+use React\Socket\TcpConnector;
+use React\Socket\TcpServer;
 
 class TcpConnectorTest extends TestCase
 {
@@ -15,7 +15,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToEmptyPortShouldFail()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
         $connector = new TcpConnector($loop);
         $connector->connect('127.0.0.1:9999')
@@ -27,7 +27,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceed()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
         $server = new TcpServer(9999, $loop);
         $server->on('connection', $this->expectCallableOnce());
@@ -45,7 +45,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceedWithRemoteAdressSameAsTarget()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
         $server = new TcpServer(9999, $loop);
         $server->on('connection', array($server, 'close'));
@@ -63,7 +63,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceedWithLocalAdressOnLocalhost()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
         $server = new TcpServer(9999, $loop);
         $server->on('connection', array($server, 'close'));
@@ -82,7 +82,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceedWithNullAddressesAfterConnectionClosed()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
         $server = new TcpServer(9999, $loop);
         $server->on('connection', array($server, 'close'));
@@ -101,7 +101,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToEmptyIp6PortShouldFail()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
         $connector = new TcpConnector($loop);
         $connector
@@ -114,7 +114,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToIp6TcpServerShouldSucceed()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
 
         try {
             $server = new TcpServer('[::1]:9999', $loop);
@@ -191,7 +191,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function cancellingConnectionShouldRejectPromise()
     {
-        $loop = new StreamSelectLoop();
+        $loop = Factory::create();
         $connector = new TcpConnector($loop);
 
         $server = new TcpServer(0, $loop);

--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\StreamSelectLoop;
+use React\EventLoop\Factory;
 use React\Socket\TcpServer;
 use React\Stream\DuplexResourceStream;
 
@@ -15,7 +15,7 @@ class TcpServerTest extends TestCase
 
     private function createLoop()
     {
-        return new StreamSelectLoop();
+        return Factory::create();
     }
 
     /**

--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Socket;
 
+use Clue\React\Block;
 use React\EventLoop\StreamSelectLoop;
 use React\Socket\TcpServer;
 use React\Stream\DuplexResourceStream;
@@ -37,7 +38,8 @@ class TcpServerTest extends TestCase
         $client = stream_socket_client('tcp://localhost:'.$this->port);
 
         $this->server->on('connection', $this->expectCallableOnce());
-        $this->loop->tick();
+
+        $this->tick();
     }
 
     /**
@@ -50,9 +52,9 @@ class TcpServerTest extends TestCase
         $client3 = stream_socket_client('tcp://localhost:'.$this->port);
 
         $this->server->on('connection', $this->expectCallableExactly(3));
-        $this->loop->tick();
-        $this->loop->tick();
-        $this->loop->tick();
+        $this->tick();
+        $this->tick();
+        $this->tick();
     }
 
     public function testDataEventWillNotBeEmittedWhenClientSendsNoData()
@@ -79,8 +81,8 @@ class TcpServerTest extends TestCase
         $this->server->on('connection', function ($conn) use ($mock) {
             $conn->on('data', $mock);
         });
-        $this->loop->tick();
-        $this->loop->tick();
+        $this->tick();
+        $this->tick();
     }
 
     public function testDataWillBeEmittedEvenWhenClientShutsDownAfterSending()
@@ -94,8 +96,8 @@ class TcpServerTest extends TestCase
         $this->server->on('connection', function ($conn) use ($mock) {
             $conn->on('data', $mock);
         });
-        $this->loop->tick();
-        $this->loop->tick();
+        $this->tick();
+        $this->tick();
     }
 
     public function testLoopWillEndWhenServerIsClosed()
@@ -169,9 +171,6 @@ class TcpServerTest extends TestCase
         $this->assertEquals($bytes, $received);
     }
 
-    /**
-     * @covers React\EventLoop\StreamSelectLoop::tick
-     */
     public function testConnectionDoesNotEndWhenClientDoesNotClose()
     {
         $client = stream_socket_client('tcp://localhost:'.$this->port);
@@ -181,12 +180,11 @@ class TcpServerTest extends TestCase
         $this->server->on('connection', function ($conn) use ($mock) {
             $conn->on('end', $mock);
         });
-        $this->loop->tick();
-        $this->loop->tick();
+        $this->tick();
+        $this->tick();
     }
 
     /**
-     * @covers React\EventLoop\StreamSelectLoop::tick
      * @covers React\Socket\Connection::end
      */
     public function testConnectionDoesEndWhenClientCloses()
@@ -200,8 +198,8 @@ class TcpServerTest extends TestCase
         $this->server->on('connection', function ($conn) use ($mock) {
             $conn->on('end', $mock);
         });
-        $this->loop->tick();
-        $this->loop->tick();
+        $this->tick();
+        $this->tick();
     }
 
     public function testCtorAddsResourceToLoop()
@@ -269,5 +267,10 @@ class TcpServerTest extends TestCase
         if ($this->server) {
             $this->server->close();
         }
+    }
+
+    private function tick()
+    {
+        Block\sleep(0, $this->loop);
     }
 }

--- a/tests/UnixConnectorTest.php
+++ b/tests/UnixConnectorTest.php
@@ -2,9 +2,8 @@
 
 namespace React\Tests\Socket;
 
-use React\Socket\UnixConnector;
-use Clue\React\Block;
 use React\Socket\ConnectionInterface;
+use React\Socket\UnixConnector;
 
 class UnixConnectorTest extends TestCase
 {


### PR DESCRIPTION
This fixes a small oversight from #104: The test suite still used the deprecated `tick()` method which will be removed in the upcoming EventLoop release.

Builds on top of #104