### PR TITLE
Fix forward compatibility with upcoming EventLoop releases in tests

### DIFF
--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -66,8 +66,8 @@ class TcpServerTest extends TestCase
         $this->server->on('connection', function ($conn) use ($mock) {
             $conn->on('data', $mock);
         });
-        $this->loop->tick();
-        $this->loop->tick();
+        $this->tick();
+        $this->tick();
     }
 
     public function testDataWillBeEmittedWithDataClientSends()


### PR DESCRIPTION
This fixes a small oversight from #125: The test suite still used the deprecated tick() method which will be removed in the upcoming EventLoop release.

Builds on top of #125