### PR TITLE
Fix SecureServer to return null URI if server socket is already closed 

### DIFF
--- a/src/SecureServer.php
+++ b/src/SecureServer.php
@@ -121,7 +121,7 @@ final class SecureServer extends EventEmitter implements ServerInterface
             throw new \BadMethodCallException('Encryption not supported on your platform (HHVM < 3.8?)'); // @codeCoverageIgnore
         }
 
-        // default to empty passphrase to surpress blocking passphrase prompt
+        // default to empty passphrase to suppress blocking passphrase prompt
         $context += array(
             'passphrase' => ''
         );
@@ -141,7 +141,12 @@ final class SecureServer extends EventEmitter implements ServerInterface
 
     public function getAddress()
     {
-        return str_replace('tcp://' , 'tls://', $this->tcp->getAddress());
+        $address = $this->tcp->getAddress();
+        if ($address === null) {
+            return null;
+        }
+
+        return str_replace('tcp://' , 'tls://', $address);
     }
 
     public function pause()

--- a/tests/SecureServerTest.php
+++ b/tests/SecureServerTest.php
@@ -17,13 +17,13 @@ class SecureServerTest extends TestCase
     public function testGetAddressWillBePassedThroughToTcpServer()
     {
         $tcp = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();
-        $tcp->expects($this->once())->method('getAddress')->willReturn('127.0.0.1:1234');
+        $tcp->expects($this->once())->method('getAddress')->willReturn('tcp://127.0.0.1:1234');
 
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
         $server = new SecureServer($tcp, $loop, array());
 
-        $this->assertEquals('127.0.0.1:1234', $server->getAddress());
+        $this->assertEquals('tls://127.0.0.1:1234', $server->getAddress());
     }
 
     public function testGetAddressWillReturnNullIfTcpServerReturnsNull()

--- a/tests/SecureServerTest.php
+++ b/tests/SecureServerTest.php
@@ -26,6 +26,18 @@ class SecureServerTest extends TestCase
         $this->assertEquals('127.0.0.1:1234', $server->getAddress());
     }
 
+    public function testGetAddressWillReturnNullIfTcpServerReturnsNull()
+    {
+        $tcp = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();
+        $tcp->expects($this->once())->method('getAddress')->willReturn(null);
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $server = new SecureServer($tcp, $loop, array());
+
+        $this->assertNull($server->getAddress());
+    }
+
     public function testPauseWillBePassedThroughToTcpServer()
     {
         $tcp = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();


### PR DESCRIPTION
This simple PR fixes a minor bug where a closed secure TLS server returned an empty string URI instead of a `null` value as documented. This also cherry-picks some minimal changes from @the-eater from #128 to make the tests less misleading (this was a small oversight from #98).

Supersedes / closes #128