### PR TITLE
Forward compatibility with PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.2",
-        "phpunit/phpunit": "^5.0 || ^4.8"
+        "phpunit/phpunit": "^5.7 || ^4.8.35"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.2",
-        "phpunit/phpunit": "^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
     },
     "autoload": {
         "psr-4": {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -98,7 +98,6 @@ class IntegrationTest extends TestCase
         $this->assertNotRegExp('#^HTTP/1\.0#', $response);
     }
 
-    /** @test */
     public function testConnectingFailsIfDnsUsesInvalidResolver()
     {
         $loop = Factory::create();
@@ -114,7 +113,6 @@ class IntegrationTest extends TestCase
         Block\await($connector->connect('google.com:80'), $loop, self::TIMEOUT);
     }
 
-    /** @test */
     public function testConnectingFailsIfTimeoutIsTooSmall()
     {
         if (!function_exists('stream_socket_enable_crypto')) {
@@ -131,7 +129,6 @@ class IntegrationTest extends TestCase
         Block\await($connector->connect('google.com:80'), $loop, self::TIMEOUT);
     }
 
-    /** @test */
     public function testSelfSignedRejectsIfVerificationIsEnabled()
     {
         if (!function_exists('stream_socket_enable_crypto')) {
@@ -150,7 +147,6 @@ class IntegrationTest extends TestCase
         Block\await($connector->connect('tls://self-signed.badssl.com:443'), $loop, self::TIMEOUT);
     }
 
-    /** @test */
     public function testSelfSignedResolvesIfVerificationIsDisabled()
     {
         if (!function_exists('stream_socket_enable_crypto')) {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -163,6 +163,9 @@ class IntegrationTest extends TestCase
 
         $conn = Block\await($connector->connect('tls://self-signed.badssl.com:443'), $loop, self::TIMEOUT);
         $conn->close();
+
+        // if we reach this, then everything is good
+        $this->assertNull(null);
     }
 
     public function testCancelPendingConnection()

--- a/tests/SecureIntegrationTest.php
+++ b/tests/SecureIntegrationTest.php
@@ -51,6 +51,9 @@ class SecureIntegrationTest extends TestCase
         /* @var $client ConnectionInterface */
 
         $client->close();
+
+        // if we reach this, then everything is good
+        $this->assertNull(null);
     }
 
     public function testConnectToServerEmitsConnection()

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -13,11 +13,13 @@ class ServerTest extends TestCase
 {
     const TIMEOUT = 0.1;
 
-    public function testCreateServer()
+    public function testCreateServerWithZeroPortAssignsRandomPort()
     {
         $loop = Factory::create();
 
         $server = new Server(0, $loop);
+        $this->assertNotEquals(0, $server->getAddress());
+        $server->close();
     }
 
     /**
@@ -80,7 +82,7 @@ class ServerTest extends TestCase
 
         $server = new Server(0, $loop);
         $server->pause();
-
+        $server->on('connection', $this->expectCallableNever());
 
         $client = stream_socket_client($server->getAddress());
 

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -175,20 +175,6 @@ class TcpConnectorTest extends TestCase
     }
 
     /** @test */
-    public function connectionWithInvalidContextShouldFailImmediately()
-    {
-        $this->markTestIncomplete();
-
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-
-        $connector = new TcpConnector($loop, array('bindto' => 'invalid.invalid:123456'));
-        $connector->connect('127.0.0.1:80')->then(
-            $this->expectCallableNever(),
-            $this->expectCallableOnce()
-        );
-    }
-
-    /** @test */
     public function cancellingConnectionShouldRejectPromise()
     {
         $loop = Factory::create();

--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -107,12 +107,18 @@ class TcpServerTest extends TestCase
         $this->server = null;
 
         $this->loop->run();
+
+        // if we reach this, then everything is good
+        $this->assertNull(null);
     }
 
     public function testCloseTwiceIsNoOp()
     {
         $this->server->close();
         $this->server->close();
+
+        // if we reach this, then everything is good
+        $this->assertNull(null);
     }
 
     public function testGetAddressAfterCloseReturnsNull()
@@ -136,6 +142,9 @@ class TcpServerTest extends TestCase
         });
 
         $this->loop->run();
+
+        // if we reach this, then everything is good
+        $this->assertNull(null);
     }
 
     public function testDataWillBeEmittedInMultipleChunksWhenClientSendsExcessiveAmounts()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,8 +6,9 @@ use React\Stream\ReadableStreamInterface;
 use React\EventLoop\LoopInterface;
 use Clue\React\Block;
 use React\Promise\Promise;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends BaseTestCase
 {
     protected function expectCallableExactly($amount)
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -81,4 +81,21 @@ class TestCase extends BaseTestCase
             }
         ), $loop, $timeout);
     }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
 }

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -100,12 +100,18 @@ class UnixServerTest extends TestCase
         $this->server = null;
 
         $this->loop->run();
+
+        // if we reach this, then everything is good
+        $this->assertNull(null);
     }
 
     public function testCloseTwiceIsNoOp()
     {
         $this->server->close();
         $this->server->close();
+
+        // if we reach this, then everything is good
+        $this->assertNull(null);
     }
 
     public function testGetAddressAfterCloseReturnsNull()
@@ -129,6 +135,9 @@ class UnixServerTest extends TestCase
         });
 
         $this->loop->run();
+
+        // if we reach this, then everything is good
+        $this->assertNull(null);
     }
 
     public function testDataWillBeEmittedInMultipleChunksWhenClientSendsExcessiveAmounts()
@@ -164,9 +173,6 @@ class UnixServerTest extends TestCase
         $this->assertEquals($bytes, $received);
     }
 
-    /**
-     * @covers React\EventLoop\StreamSelectLoop::tick
-     */
     public function testConnectionDoesNotEndWhenClientDoesNotClose()
     {
         $client = stream_socket_client($this->uds);
@@ -181,7 +187,6 @@ class UnixServerTest extends TestCase
     }
 
     /**
-     * @covers React\EventLoop\StreamSelectLoop::tick
      * @covers React\Socket\Connection::end
      */
     public function testConnectionDoesEndWhenClientCloses()


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.