### PR TITLE
[WIP] Add FiniteServer to limit number of accepted connections

### DIFF
--- a/src/FiniteServer.php
+++ b/src/FiniteServer.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace React\Socket;
+
+use Evenement\EventEmitter;
+use React\Socket\ServerInterface;
+use React\Socket\ConnectionInterface;
+
+/**
+ * The `FiniteServer` decorator wraps a given `ServerInterface` and is
+ * responsible for limiting the server to serve, maximum, n times.
+ *
+ * This is crucial if there is a master system member, like Supervisord,
+ * always checking that there's an instance running, by creating always a new
+ * one if the last one dies.
+ *
+ * In that case, the Server will close itself once served n responses.
+ *
+ * In this example, once the server has served 1000 instances, will close
+ * itself.
+ *
+ * ```php
+ * $server = new FiniteServer($server, 1000);
+ * $server->on('connection', function (ConnectionInterface $connection) {
+ *     $connection->write('hello there!' . PHP_EOL);
+ *     …
+ * });
+ * ```
+ *
+ * See also the `ServerInterface` for more details.
+ *
+ * @see ServerInterface
+ * @see ConnectionInterface
+ */
+class FiniteServer extends EventEmitter implements ServerInterface
+{
+    const NEVER_STOP = 0;
+    private $server;
+    private $iterations = 1;
+    private $maxIterations;
+
+    /**
+     * @param ServerInterface $server
+     */
+    public function __construct(ServerInterface $server, $maxIterations = self::NEVER_STOP)
+    {
+        $maxIterations = is_int($maxIterations)
+            ? $maxIterations
+            : self::NEVER_STOP;
+
+        $this->server = $server;
+        $this->maxIterations = $maxIterations;
+        $this->server->on('connection', array($this, 'handleConnection'));
+        $this->server->on('error', array($this, 'handleError'));
+    }
+
+    public function getAddress()
+    {
+        return $this->server->getAddress();
+    }
+
+    public function pause()
+    {
+        $this->server->pause();
+    }
+
+    public function resume()
+    {
+        $this->server->resume();
+    }
+
+    public function close()
+    {
+        $this->server->close();
+    }
+
+    /** @internal */
+    public function handleConnection(ConnectionInterface $connection)
+    {
+        if (
+            $this->maxIterations > 0 &&
+            $this->iterations >= $this->maxIterations
+        ) {
+            $connection->on('close', function() {
+                $this->server->close();
+            });
+        }
+        $this->emit('connection', array($connection));
+        $this->iterations++;
+    }
+
+    /** @internal */
+    public function handleError(\Exception $error)
+    {
+        $this->emit('error', array($error));
+    }
+}

--- a/tests/FiniteServerTest.php
+++ b/tests/FiniteServerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace React\Tests\Socket;
+
+use React\Socket\FiniteServer;
+
+class FiniteServerTest extends TestCase
+{
+    public function testDefaultTimes()
+    {
+        $socketServer = $this->getMockBuilder('\React\Socket\ServerInterface')->getMock();
+        $tcpConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $tcpConnection->expects($this->exactly(0))->method('on');
+        $server = new FiniteServer($socketServer);
+        $server->handleConnection($tcpConnection);
+        $server->handleConnection($tcpConnection);
+        $server->handleConnection($tcpConnection);
+        $server->handleConnection($tcpConnection);
+        $server->handleConnection($tcpConnection);
+    }
+
+    public function testInvalidTimesWorkingAsNeverStop()
+    {
+        $socketServer = $this->getMockBuilder('\React\Socket\ServerInterface')->getMock();
+        $tcpConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $tcpConnection->expects($this->exactly(0))->method('on');
+        $server = new FiniteServer($socketServer, -1);
+        $server->handleConnection($tcpConnection);
+        $server->handleConnection($tcpConnection);
+    }
+
+    public function testNeverStop()
+    {
+        $socketServer = $this->getMockBuilder('\React\Socket\ServerInterface')->getMock();
+        $tcpConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $tcpConnection->expects($this->exactly(0))->method('on');
+        $server = new FiniteServer($socketServer, FiniteServer::NEVER_STOP);
+        $server->handleConnection($tcpConnection);
+        $server->handleConnection($tcpConnection);
+        $server->handleConnection($tcpConnection);
+        $server->handleConnection($tcpConnection);
+        $server->handleConnection($tcpConnection);
+    }
+
+    public function testRunAndStop()
+    {
+        $socketServer = $this->getMockBuilder('\React\Socket\ServerInterface')->getMock();
+        $tcpConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $tcpConnection->expects($this->exactly(1))->method('on');
+        $server = new FiniteServer($socketServer, 1);
+        $server->handleConnection($tcpConnection);
+    }
+
+    public function testRunNTimes()
+    {
+        $socketServer = $this->getMockBuilder('\React\Socket\ServerInterface')->getMock();
+        $tcpConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $tcpConnection->expects($this->exactly(1))->method('on');
+        $server = new FiniteServer($socketServer, 3);
+        $server->handleConnection($tcpConnection);
+        $server->handleConnection($tcpConnection);
+        $server->handleConnection($tcpConnection);
+    }
+}


### PR DESCRIPTION
FiniteServer is a Server Decorator that allow final user create a Server that will able to serve a maximum of n requests. After that, will be closed.

So useful when working with supervisord.
Using that, you can control so much the memory leak that a server can cause in the long term :)

PR not finished yet.
Waiting for #137 in order to add some green tests