### PR TITLE
Fix closing socket resource before removing from loop

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -128,9 +128,10 @@ class Connection extends EventEmitter implements ConnectionInterface
         // side already closed. Shutting down may return to blocking mode on
         // some legacy versions, so reset to non-blocking just in case before
         // continuing to close the socket resource.
+        // Underlying Stream implementation will take care of closing file
+        // handle, so we otherwise keep this open here.
         @stream_socket_shutdown($this->stream, STREAM_SHUT_RDWR);
         stream_set_blocking($this->stream, false);
-        fclose($this->stream);
     }
 
     public function getRemoteAddress()

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -8,6 +8,10 @@ class ConnectionTest extends TestCase
 {
     public function testCloseConnectionWillCloseSocketResource()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('HHVM does not support socket operation on test memory stream');
+        }
+
         $resource = fopen('php://memory', 'r+');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
@@ -19,6 +23,10 @@ class ConnectionTest extends TestCase
 
     public function testCloseConnectionWillRemoveResourceFromLoopBeforeClosingResource()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('HHVM does not support socket operation on test memory stream');
+        }
+
         $resource = fopen('php://memory', 'r+');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->once())->method('addWriteStream')->with($resource);

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace React\Tests\Socket;
+
+use React\Socket\Connection;
+
+class ConnectionTest extends TestCase
+{
+    public function testCloseConnectionWillCloseSocketResource()
+    {
+        $resource = fopen('php://memory', 'r+');
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connection = new Connection($resource, $loop);
+        $connection->close();
+
+        $this->assertFalse(is_resource($resource));
+    }
+
+    public function testCloseConnectionWillRemoveResourceFromLoopBeforeClosingResource()
+    {
+        $resource = fopen('php://memory', 'r+');
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addWriteStream')->with($resource);
+
+        $onRemove = null;
+        $loop->expects($this->once())->method('removeWriteStream')->with($this->callback(function ($param) use (&$onRemove) {
+            $onRemove = is_resource($param);
+            return true;
+        }));
+
+        $connection = new Connection($resource, $loop);
+        $connection->write('test');
+        $connection->close();
+
+        $this->assertTrue($onRemove);
+        $this->assertFalse(is_resource($resource));
+    }
+}


### PR DESCRIPTION
Currently, this component implicitly calls `fclose()` on the underlying socket resource before actually closing the stream (and removing it from the event loop). This code is in place ever since #99 has been merged, but the error didn't really manifest itself until recently, when https://github.com/reactphp/stream/pull/121 landed.

This issue can easily be reproduced by using latest react/stream with `ext-event` installed. If you have outgoing data pending on a connection, but the connection is detected to be closed by the remote peer, this would cause an uncaught exception.

This PR ensures we do not call `fclose()` on the socket resource prior to actually invoking the close logic and removing it from the event loop. I've added some tests to try to highlight this issue to avoid any future regressions.

Note that we've recently introduced a related fix in the underlying event loop via https://github.com/reactphp/event-loop/pull/139. That one ensure the loop will not actually complain about this situation and silently remove the invalid stream resource. Despite this relevant fix, it still makes sense to fix the root cause here.

Fixes https://github.com/reactphp/event-loop/issues/136