### PR TITLE
Added GracefulFiniteServer wrapper

### DIFF
--- a/src/GracefulFiniteServer.php
+++ b/src/GracefulFiniteServer.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace React\Socket;
+
+use Evenement\EventEmitter;
+
+/**
+ * The `GracefulFiniteServer` decorator wraps a given `ServerInterface` and is
+ * responsible to die in a graceful way when an specific file exists.
+ *
+ * Before dying, this file is properly removed.
+ *
+ * ```php
+ * $server = new GracefulFiniteServer($server, '/tmp/server.txt);
+ * $server->on('connection', function (ConnectionInterface $connection) {
+ *     $connection->write('hello there!' . PHP_EOL);
+ *     …
+ * });
+ * ```
+ *
+ * See also the `ServerInterface` for more details.
+ *
+ * @see ServerInterface
+ * @see ConnectionInterface
+ */
+class GracefulFiniteServer extends EventEmitter implements ServerInterface
+{
+    private $server;
+    private $file;
+
+    /**
+     * @param ServerInterface $server
+     * @param string $file
+     */
+    public function __construct(ServerInterface $server, $file)
+    {
+        $this->file = $file;
+        $this->server = $server;
+        $this->server->on('connection', array($this, 'handleConnection'));
+        $this->server->on('error', array($this, 'handleError'));
+    }
+
+    public function getAddress()
+    {
+        return $this->server->getAddress();
+    }
+
+    public function pause()
+    {
+        $this->server->pause();
+    }
+
+    public function resume()
+    {
+        $this->server->resume();
+    }
+
+    public function close()
+    {
+        $this->server->close();
+    }
+
+    /** @internal */
+    public function handleConnection(ConnectionInterface $connection)
+    {
+        if (
+            file_exists($this->file) &&
+            is_writable($this->file)
+        ) {
+            unlink($this->file);
+            $connection->on('close', function() {
+                $this->server->close();
+            });
+        }
+
+        $this->emit('connection', array($connection));
+    }
+
+    /** @internal */
+    public function handleError(\Exception $error)
+    {
+        $this->emit('error', array($error));
+    }
+}

--- a/tests/GracefulFiniteServerTest.php
+++ b/tests/GracefulFiniteServerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace React\Tests\Socket;
+
+use React\Socket\GracefulFiniteServer;
+use React\Socket\TcpServer;
+
+class GracefulFiniteServerTest extends TestCase
+{
+    public function testSocketConnectionWillBeForwarded()
+    {
+        $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $connection
+            ->expects($this->never())
+            ->method('on')
+            ->with($this->equalTo('close'), $this->anything());
+
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $fileName = tempnam('/tmp', 'test');
+        unlink($fileName);
+        $this->assertFalse(file_exists($fileName));
+
+        $tcp = new TcpServer(0, $loop);
+        new GracefulFiniteServer($tcp, $fileName);
+        $tcp->emit('connection', array($connection));
+    }
+
+    public function testSocketConnectionWillBeClosed()
+    {
+        $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $connection
+            ->expects($this->once())
+            ->method('on')
+            ->with($this->equalTo('close'), $this->anything());
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $fileName = tempnam('/tmp', 'test');
+        $this->assertTrue(file_exists($fileName));
+
+        $tcp = new TcpServer(0, $loop);
+        new GracefulFiniteServer($tcp, $fileName);
+        $tcp->emit('connection', array($connection));
+        $this->assertFalse(file_exists($fileName));
+    }
+}


### PR DESCRIPTION
* The server will die gracefuly when an specific file exists.
  Then, the server will remove the file, and will die.

* Motivation
  ReactPHP server can run on production, of course. In order to
  be more production friendly, this implementation appends a new
  behavior for deploy-time. Without this implementation, new code
  is only executed when:

    - Supervisor service restart - If the supervisor configuration
        is the same, that options seems to be the worst. All processes
        then will be stopped and restarted. If any thread is being served,
        will be killed and no response will be served.

    - Kill manually the processes. Same as last option, but without
        supervisor. Same thread effects.

    - Use #138, and wait for thread auto-die. If you expect real-time
        changes in production, then you should add a low iterations
        number, or a high production petitions. Neither a valid option.

With this implementation, a new deploy could be something like

- pull project
- clear cache
- touch(file/s)