### PR TITLE
Update DNS dependency and load system default DNS config on all supported platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
       curl -s http://getcomposer.org/installer | php
       mv composer.phar /usr/local/bin/composer
     fi
-  - COMPOSER_ROOT_VERSION=`git describe --abbrev=0` composer install --no-interaction
+  - composer install --no-interaction
 
 script:
   - ./vendor/bin/phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -1394,12 +1394,10 @@ on affected versions.
 ## Tests
 
 To run the test suite, you first need to clone this repo and then install all
-dependencies [through Composer](https://getcomposer.org).
-Because the test suite contains some circular dependencies, you may have to
-manually specify the root package version like this:
+dependencies [through Composer](https://getcomposer.org):
 
 ```bash
-$ COMPOSER_ROOT_VERSION=`git describe --abbrev=0` composer install
+$ composer install
 ```
 
 To run the test suite, go to the project root and run:

--- a/README.md
+++ b/README.md
@@ -918,10 +918,12 @@ also shares all of their features and implementation details.
 If you want to typehint in your higher-level protocol implementation, you SHOULD
 use the generic [`ConnectorInterface`](#connectorinterface) instead.
 
-In particular, the `Connector` class uses Google's public DNS server `8.8.8.8`
-to resolve all public hostnames into underlying IP addresses by default.
-If you want to use a custom DNS server (such as a local DNS relay or a company
-wide DNS server), you can set up the `Connector` like this:
+The `Connector` class will try to detect your system DNS settings (and uses
+Google's public DNS server `8.8.8.8` as a fallback if unable to determine your
+system settings) to resolve all public hostnames into underlying IP addresses by
+default.
+If you explicitly want to use a custom DNS server (such as a local DNS relay or
+a company wide DNS server), you can set up the `Connector` like this:
 
 ```php
 $connector = new Connector($loop, array(

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/dns": "^0.4.11",
+        "react/dns": "^0.4.13",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
         "react/stream": "^1.0 || ^0.7.1",
         "react/promise": "^2.1 || ^1.2",

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -2,6 +2,7 @@
 
 namespace React\Socket;
 
+use React\Dns\Config\Config;
 use React\Dns\Resolver\Factory;
 use React\Dns\Resolver\Resolver;
 use React\EventLoop\LoopInterface;
@@ -56,9 +57,17 @@ final class Connector implements ConnectorInterface
             if ($options['dns'] instanceof Resolver) {
                 $resolver = $options['dns'];
             } else {
+                if ($options['dns'] !== true) {
+                    $server = $options['dns'];
+                } else {
+                    // try to load nameservers from system config or default to Google's public DNS
+                    $config = Config::loadSystemConfigBlocking();
+                    $server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+                }
+
                 $factory = new Factory();
                 $resolver = $factory->create(
-                    $options['dns'] === true ? '8.8.8.8' : $options['dns'],
+                    $server,
                     $loop
                 );
             }


### PR DESCRIPTION
This simple PR updates the DNS dependency to take advantage of the new config loader to apply the system default DNS config on all supported platforms. The previous default DNS server `8.8.8.8` will only be used as a fallback if no other DNS server could be found.

Also, this PR targets https://github.com/reactphp/dns/pull/96 which removed the dependency from react/dns to react/socket, which in turn depends on react/dns again. By removing this cyclic dependency, we can ensure Composer will automatically and correctly pick the latest installed version without having to specify the root package version. This change includes documentation updates and effectively reverts (the bad) parts of #54.

![composer dependency graph](https://user-images.githubusercontent.com/776829/36730205-df05cde0-1bc6-11e8-939e-7fa3a2d33601.png)

Resolves / closes #90 
Refs https://github.com/reactphp/dns/pull/93
Refs https://github.com/reactphp/dns/pull/96