### PR TITLE
Created a UnixConnection to represent UDS connections which has the ability to retrieve the local/remote PID

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -20,13 +20,6 @@ use React\Stream\WritableStreamInterface;
 class Connection extends EventEmitter implements ConnectionInterface
 {
     /**
-     * Internal flag whether this is a Unix domain socket (UDS) connection
-     *
-     * @internal
-     */
-    public $unix = false;
-
-    /**
      * Internal flag whether encryption has been enabled on this connection
      *
      * Mostly used by internal StreamEncryption so that connection returns
@@ -144,26 +137,10 @@ class Connection extends EventEmitter implements ConnectionInterface
         return $this->parseAddress(@stream_socket_get_name($this->stream, false));
     }
 
-    private function parseAddress($address)
+    protected function parseAddress($address)
     {
         if ($address === false) {
             return null;
-        }
-
-        if ($this->unix) {
-            // remove trailing colon from address for HHVM < 3.19: https://3v4l.org/5C1lo
-            // note that technically ":" is a valid address, so keep this in place otherwise
-            if (substr($address, -1) === ':' && defined('HHVM_VERSION_ID') && HHVM_VERSION_ID < 31900) {
-                $address = (string)substr($address, 0, -1);
-            }
-
-            // work around unknown addresses should return null value: https://3v4l.org/5C1lo and https://bugs.php.net/bug.php?id=74556
-            // PHP uses "\0" string and HHVM uses empty string (colon removed above)
-            if ($address === '' || $address[0] === "\x00" ) {
-                return null;
-            }
-
-            return 'unix://' . $address;
         }
 
         // check if this is an IPv6 address which includes multiple colons but no square brackets

--- a/src/UnixConnection.php
+++ b/src/UnixConnection.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace React\Socket;
+
+/**
+ * A UnixConnection is a specific implementation of a Connection for Unix connections.
+ *
+ * Unix connections have the ability to retrieve the PID of the local and remote side of the socket.
+ *
+ * @see Connection
+ */
+class UnixConnection extends Connection
+{
+    /**
+     * @see http://php.net/manual/en/function.get-resource-type.php
+     */
+    const RESOURCE_TYPE_STREAM = 'stream';
+
+    /**
+     * PHP has no built in constant for retrieving the credentials of the peer process.
+     *
+     * @see http://php.net/manual/en/sockets.constants.php
+     * @see http://php.net/manual/en/function.socket-get-option.php#101380
+     */
+    const SO_PEERCRED = 17;
+
+    /**
+     * @var int|null Variable to cache the remote pid.
+     */
+    private $remote_pid;
+
+    /**
+     * @var int|null Variable to cache the local pid.
+     */
+    private $local_pid;
+
+    protected function parseAddress($address)
+    {
+        if ($address === false) {
+            return null;
+        }
+
+        // remove trailing colon from address for HHVM < 3.19: https://3v4l.org/5C1lo
+        // note that technically ":" is a valid address, so keep this in place otherwise
+        if (substr($address, -1) === ':' && defined('HHVM_VERSION_ID') && HHVM_VERSION_ID < 31900) {
+            $address = (string)substr($address, 0, -1);
+        }
+
+        // work around unknown addresses should return null value: https://3v4l.org/5C1lo and https://bugs.php.net/bug.php?id=74556
+        // PHP uses "\0" string and HHVM uses empty string (colon removed above)
+        if ($address === '' || $address[0] === "\x00") {
+            return null;
+        }
+
+        return 'unix://' . $address;
+    }
+
+    /**
+     * Retrieve the PID (process identifier) of the remote side of the Connection. The pid will be cached to avoid
+     * requesting the value multiple times. If the remote pid was not cached before the connection is closed, the remote
+     * pid cannot be retrieved anymore.
+     *
+     * Warning: Process IDs are not unique, thus they are a weak entropy source. Relying on pids in security-dependent
+     * contexts should be avoided.
+     *
+     * @return int|null
+     */
+    public function getRemotePid()
+    {
+        // If the remote pid has already been cached, return that value.
+        if ($this->remote_pid !== null) {
+            return $this->remote_pid;
+        }
+
+        if (get_resource_type($this->stream) !== self::RESOURCE_TYPE_STREAM) {
+            return null;
+        }
+
+        $socket = socket_import_stream($this->stream);
+
+        if ($socket === false || $socket === null) {
+            return null;
+        }
+
+        // Get the PID of the remote side of the socket.
+        $pid = socket_get_option($socket, SOL_SOCKET, self::SO_PEERCRED);
+
+        if ($pid === false) {
+            return null;
+        }
+
+        $this->remote_pid = (int)$pid;
+
+        return $this->remote_pid;
+    }
+
+    /**
+     * Retrieve the PID (process identifier) of the local side of the Connection.
+     *
+     * Warning: Process IDs are not unique, thus they are a weak entropy source. Relying on pids in security-dependent
+     * contexts should be avoided.
+     *
+     * @return int|null
+     */
+    public function getLocalPid()
+    {
+        if ($this->local_pid !== null) {
+            return $this->local_pid;
+        }
+
+        $pid = getmypid();
+        if ($pid === false) {
+            return null;
+        }
+
+        $this->local_pid = $pid;
+
+        return $this->local_pid;
+    }
+}

--- a/src/UnixConnector.php
+++ b/src/UnixConnector.php
@@ -36,8 +36,7 @@ final class UnixConnector implements ConnectorInterface
             return Promise\reject(new RuntimeException('Unable to connect to unix domain socket "' . $path . '": ' . $errstr, $errno));
         }
 
-        $connection = new Connection($resource, $this->loop);
-        $connection->unix = true;
+        $connection = new UnixConnection($resource, $this->loop);
 
         return Promise\resolve($connection);
     }

--- a/src/UnixServer.php
+++ b/src/UnixServer.php
@@ -120,8 +120,7 @@ final class UnixServer extends EventEmitter implements ServerInterface
     /** @internal */
     public function handleConnection($socket)
     {
-        $connection = new Connection($socket, $this->loop);
-        $connection->unix = true;
+        $connection = new UnixConnection($socket, $this->loop);
 
         $this->emit('connection', array(
             $connection

--- a/tests/FunctionalUnixServerTest.php
+++ b/tests/FunctionalUnixServerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace React\Tests\Socket;
+
+use Clue\React\Block;
+use React\EventLoop\Factory;
+use React\Socket\UnixConnection;
+use React\Socket\UnixConnector;
+use React\Socket\UnixServer;
+
+class FunctionalUnixServerTest extends TestCase
+{
+    public function testEmitsConnectionForNewConnection()
+    {
+        $loop = Factory::create();
+
+        $server = new UnixServer($this->getRandomSocketUri(), $loop);
+        $server->on('connection', $this->expectCallableOnce());
+
+        $connector = new UnixConnector($loop);
+        $promise = $connector->connect($server->getAddress());
+
+        $promise->then($this->expectCallableOnce());
+
+        Block\sleep(0.1, $loop);
+    }
+
+    public function testEmitsNoConnectionForNewConnectionWhenPaused()
+    {
+        $loop = Factory::create();
+
+        $server = new UnixServer($this->getRandomSocketUri(), $loop);
+        $server->on('connection', $this->expectCallableNever());
+        $server->pause();
+
+        $connector = new UnixConnector($loop);
+        $promise = $connector->connect($server->getAddress());
+
+        $promise->then($this->expectCallableOnce());
+
+        Block\sleep(0.1, $loop);
+    }
+
+    public function testEmitsConnectionForNewConnectionWhenResumedAfterPause()
+    {
+        $loop = Factory::create();
+
+        $server = new UnixServer($this->getRandomSocketUri(), $loop);
+        $server->on('connection', $this->expectCallableOnce());
+        $server->pause();
+        $server->resume();
+
+        $connector = new UnixConnector($loop);
+        $promise = $connector->connect($server->getAddress());
+
+        $promise->then($this->expectCallableOnce());
+
+        Block\sleep(0.1, $loop);
+    }
+
+    public function testConnectionDetailsCanBeRetrieved()
+    {
+        $loop = Factory::create();
+
+        $server = new UnixServer($this->getRandomSocketUri(), $loop);
+        $remote_address = null;
+        $remote_pid = null;
+        $local_address = null;
+        $local_pid = null;
+        $server->on('connection', function (UnixConnection $conn) use (&$remote_address, &$remote_pid, &$local_address, &$local_pid) {
+            $remote_address = $conn->getRemoteAddress();
+            $remote_pid = $conn->getRemotePid();
+            $local_address = $conn->getLocalAddress();
+            $local_pid = $conn->getLocalPid();
+        });
+
+        $connector = new UnixConnector($loop);
+        $promise = $connector->connect($server->getAddress());
+
+        $promise->then($this->expectCallableOnce());
+
+        Block\sleep(0.1, $loop);
+
+        $this->assertNull($remote_address);
+        $this->assertValidPid($remote_pid);
+        $this->assertContains('unix:///tmp/', $local_address);
+        $this->assertSame($server->getAddress(), $local_address);
+        $this->assertValidPid($local_pid);
+    }
+
+    public function testRemotePidCannotBeRetrievedAfterConnectionIsClosedLocally()
+    {
+        $loop = Factory::create();
+
+        $server = new UnixServer($this->getRandomSocketUri(), $loop);
+        $remote_pid = false;
+        $server->on('connection', function (UnixConnection $conn) use (&$remote_pid) {
+            $conn->close();
+            $remote_pid = $conn->getRemotePid();
+        });
+
+        $connector = new UnixConnector($loop);
+        $promise = $connector->connect($server->getAddress());
+
+        $promise->then($this->expectCallableOnce());
+
+        Block\sleep(0.1, $loop);
+
+        // Will be null since the connection was closed before the pid was requested.
+        $this->assertNull($remote_pid);
+    }
+
+    public function testRemotePidCanBeRetrievedAfterConnectionIsClosedLocallyIfRemotePidWasCachedBeforeClose()
+    {
+        $loop = Factory::create();
+
+        $server = new UnixServer($this->getRandomSocketUri(), $loop);
+        $remote_pid = false;
+        $server->on('connection', function (UnixConnection $conn) use (&$remote_pid) {
+            $conn->getRemotePid();
+            $conn->close();
+            $remote_pid = $conn->getRemotePid();
+        });
+
+        $connector = new UnixConnector($loop);
+        $promise = $connector->connect($server->getAddress());
+
+        $promise->then($this->expectCallableOnce());
+
+        Block\sleep(0.1, $loop);
+
+        // The cached value will be used so it is known.
+        $this->assertValidPid($remote_pid);
+    }
+}

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -165,9 +165,4 @@ class ServerTest extends TestCase
 
         Block\sleep(0.1, $loop);
     }
-
-    private function getRandomSocketUri()
-    {
-        return "unix://" . sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid(rand(), true) . '.sock';
-    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,6 +51,12 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
+    protected function assertValidPid($pid)
+    {
+        $this->assertGreaterThan(1, $pid);
+        $this->assertInternalType("int", $pid);
+    }
+
     protected function createCallableMock()
     {
         return $this->getMockBuilder('React\Tests\Socket\Stub\CallableStub')->getMock();
@@ -97,5 +103,10 @@ class TestCase extends BaseTestCase
             // legacy PHPUnit 4
             parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
         }
+    }
+
+    protected function getRandomSocketUri()
+    {
+        return "unix://" . sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid(rand(), true) . '.sock';
     }
 }

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -271,11 +271,6 @@ class UnixServerTest extends TestCase
         }
     }
 
-    private function getRandomSocketUri()
-    {
-        return "unix://" . sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid(rand(), true) . '.sock';
-    }
-
     private function tick()
     {
         Block\sleep(0, $this->loop);


### PR DESCRIPTION
Connections through a Unix Domain Socket will now be represented by a `UnixConnection` (which extends a regular `Connection`). This `UnixConnection` contains the custom logic for parsing parsing the address and has the new ability to retrieve the local and remote PID.

From the server side a client has no "remote address". The remote PID can for example be used to distinguish multiple clients.

See #150 