### PR TITLE
Improve memory consumption for cancelled connection attempts

### DIFF
--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -112,10 +112,11 @@ final class TcpConnector implements ConnectorInterface
                     $resolve(new Connection($stream, $loop));
                 }
             });
-        }, function () use ($loop, $stream) {
+        }, function ($resolve, $reject, $progress) use ($loop, $stream) {
             $loop->removeWriteStream($stream);
             fclose($stream);
 
+            $resolve = $reject = $progress = null;
             throw new RuntimeException('Cancelled while waiting for TCP/IP connection to be established');
         });
     }


### PR DESCRIPTION
While debugging some very odd memory issues in a live application, I noticed that this component shows some unexpected memory consumption and memory would not immediately be freed as expected when a connection attempt is cancelled. Let's not call this a "memory leak", because memory was eventually freed, but this clearly caused some unexpected and significant memory growth.

One of the core issues has been located and addressed via https://github.com/reactphp/event-loop/pull/164, but even with that patch applied, cancelling a pending connection attempt behaved a bit unexpected.

I've used the following script to demonstrate unreasonable memory growth:

```php
<?php

use React\EventLoop\Factory;
use React\Socket\Connector;

require __DIR__ . '/../vendor/autoload.php';

$loop = Factory::create();
$connector = new Connector($loop, array('timeout' => false));

$loop->addPeriodicTimer(0.001, function () use ($connector) {
    $promise = $connector->connect('192.168.2.1:8080');
    $promise->cancel();
});

$loop->addPeriodicTimer(1.0, function () {
    echo memory_get_usage() . PHP_EOL;
});

$loop->run();

```

Initially this peaked at around 320 MB on my system. After applying the referenced patch, this went down significantly and fluctuated somewhere between 2 MB and 12 MB. After applying this patch, this script reports a constant memory consumption of around 1.2 MB.

This implementation includes some of the ideas discussed in https://github.com/reactphp/promise-timer/pull/32, https://github.com/reactphp/promise/issues/46 and https://github.com/reactphp/socket/pull/113. Eventually, we should look into providing a way to address this within our promise implementation.

My vote would to be get this in here now as it addresses a relevant memory issue and eventually address this in the upstream component (at which point this changeset also does no harm). :shipit: 