### PR TITLE
Improve memory consumption for failed connection attempts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         "react/dns": "^0.4.13",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
         "react/stream": "^1.0 || ^0.7.1",
-        "react/promise": "^2.1 || ^1.2",
-        "react/promise-timer": "~1.0"
+        "react/promise": "^2.6.0 || ^1.2.1",
+        "react/promise-timer": "^1.4.0"
     },
     "require-dev": {
         "clue/block-react": "^1.2",

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -112,7 +112,7 @@ final class TcpConnector implements ConnectorInterface
                     $resolve(new Connection($stream, $loop));
                 }
             });
-        }, function ($resolve, $reject, $progress) use ($loop, $stream) {
+        }, function () use ($loop, $stream) {
             $loop->removeWriteStream($stream);
             fclose($stream);
 
@@ -123,7 +123,6 @@ final class TcpConnector implements ConnectorInterface
             }
             // @codeCoverageIgnoreEnd
 
-            $resolve = $reject = $progress = null;
             throw new RuntimeException('Cancelled while waiting for TCP/IP connection to be established');
         });
     }


### PR DESCRIPTION
While debugging some very odd memory issues in a live application, I noticed that this component shows some unexpected memory consumption and memory would not immediately be freed as expected. Let's not call this a "memory leak", because memory was eventually freed, but this clearly caused some unexpected and significant memory growth.

Parts of this issue have been resolved with #159 already which raised the discussion to address these issues in the upstream react/promise component. A number of patches have been filed via https://github.com/reactphp/promise/pull/113, https://github.com/reactphp/promise/pull/115, https://github.com/reactphp/promise/pull/116, https://github.com/reactphp/promise/pull/117, https://github.com/reactphp/promise/pull/118 and https://github.com/reactphp/promise-timer/pull/33.

I'm marking this PR as WIP because the referenced changes are yet to be released as part of react/promise v2.6.0. Once this release is out, I'll update the version reference and this should be ready to be shipped.

This PR actually includes a number of tests that show how garbage memory references are no longer an issue in any supported PHP version and how failed connection attempts no longer cause any such references on their own (unlike the previous changes in #159 this means that we can now test this and this requires no effort on the consumer side anymore).