### PR TITLE
Improve Unix domain socket (UDS) server error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,14 @@ $first = new UnixServer('/tmp/same.sock', $loop);
 $second = new UnixServer('/tmp/same.sock', $loop);
 ```
 
+> Note that these error conditions may vary depending on your system and/or
+  configuration.
+  In particular, Zend PHP does only report "Unknown error" when the UDS path
+  already exists and can not be bound. You may want to check `is_file()` on the
+  given UDS path to report a more user-friendly error message in this case.
+  See the exception message and code for more details about the actual error
+  condition.
+
 Whenever a client connects, it will emit a `connection` event with a connection
 instance implementing [`ConnectionInterface`](#connectioninterface):
 

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -19,6 +19,10 @@ class UnixServerTest extends TestCase
      */
     public function setUp()
     {
+        if (!in_array('unix', stream_get_transports())) {
+            $this->markTestSkipped('Unix domain sockets (UDS) not supported on your platform (Windows?)');
+        }
+
         $this->loop = Factory::create();
         $this->uds = $this->getRandomSocketUri();
         $this->server = new UnixServer($this->uds, $this->loop);


### PR DESCRIPTION
PHP does not seem to report errno/errstr for Unix domain sockets (UDS) right now. This only applies to UDS server sockets, see also https://3v4l.org/NAhpr. Let's parse PHP warning message containing unknown error, HHVM reports proper info at least.