### PR TITLE
 Improve DNS error messages and cancellation forwarding after DNS lookup

### DIFF
--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -40,73 +40,72 @@ final class DnsConnector implements ConnectorInterface
             return $connector->connect($uri);
         }
 
-        return $this
-            ->resolveHostname($host, $uri)
-            ->then(function ($ip) use ($connector, $host, $parts) {
-                $uri = '';
-
-                // prepend original scheme if known
-                if (isset($parts['scheme'])) {
-                    $uri .= $parts['scheme'] . '://';
-                }
-
-                if (strpos($ip, ':') !== false) {
-                    // enclose IPv6 addresses in square brackets before appending port
-                    $uri .= '[' . $ip . ']';
-                } else {
-                    $uri .= $ip;
-                }
-
-                // append original port if known
-                if (isset($parts['port'])) {
-                    $uri .= ':' . $parts['port'];
-                }
-
-                // append orignal path if known
-                if (isset($parts['path'])) {
-                    $uri .= $parts['path'];
-                }
-
-                // append original query if known
-                if (isset($parts['query'])) {
-                    $uri .= '?' . $parts['query'];
-                }
-
-                // append original hostname as query if resolved via DNS and if
-                // destination URI does not contain "hostname" query param already
-                $args = array();
-                parse_str(isset($parts['query']) ? $parts['query'] : '', $args);
-                if ($host !== $ip && !isset($args['hostname'])) {
-                    $uri .= (isset($parts['query']) ? '&' : '?') . 'hostname=' . rawurlencode($host);
-                }
-
-                // append original fragment if known
-                if (isset($parts['fragment'])) {
-                    $uri .= '#' . $parts['fragment'];
-                }
-
-                return $connector->connect($uri);
-            });
-    }
-
-    private function resolveHostname($host, $uri)
-    {
         $promise = $this->resolver->resolve($host);
+        $resolved = null;
 
         return new Promise\Promise(
-            function ($resolve, $reject) use ($promise, $uri) {
+            function ($resolve, $reject) use (&$promise, &$resolved, $uri, $connector, $host, $parts) {
                 // resolve/reject with result of DNS lookup
-                $promise->then($resolve, function ($e) use ($uri, $reject) {
-                    $reject(new RuntimeException('Connection to ' . $uri .' failed during DNS lookup: ' . $e->getMessage(), 0, $e));
-                });
-            },
-            function ($_, $reject) use ($promise, $uri) {
-                // cancellation should reject connection attempt
-                $reject(new RuntimeException('Connection to ' . $uri . ' cancelled during DNS lookup'));
+                $promise->then(function ($ip) use (&$promise, &$resolved, $connector, $host, $parts) {
+                    $resolved = $ip;
+                    $uri = '';
 
-                // (try to) cancel pending DNS lookup
+                    // prepend original scheme if known
+                    if (isset($parts['scheme'])) {
+                        $uri .= $parts['scheme'] . '://';
+                    }
+
+                    if (strpos($ip, ':') !== false) {
+                        // enclose IPv6 addresses in square brackets before appending port
+                        $uri .= '[' . $ip . ']';
+                    } else {
+                        $uri .= $ip;
+                    }
+
+                    // append original port if known
+                    if (isset($parts['port'])) {
+                        $uri .= ':' . $parts['port'];
+                    }
+
+                    // append orignal path if known
+                    if (isset($parts['path'])) {
+                        $uri .= $parts['path'];
+                    }
+
+                    // append original query if known
+                    if (isset($parts['query'])) {
+                        $uri .= '?' . $parts['query'];
+                    }
+
+                    // append original hostname as query if resolved via DNS and if
+                    // destination URI does not contain "hostname" query param already
+                    $args = array();
+                    parse_str(isset($parts['query']) ? $parts['query'] : '', $args);
+                    if ($host !== $ip && !isset($args['hostname'])) {
+                        $uri .= (isset($parts['query']) ? '&' : '?') . 'hostname=' . rawurlencode($host);
+                    }
+
+                    // append original fragment if known
+                    if (isset($parts['fragment'])) {
+                        $uri .= '#' . $parts['fragment'];
+                    }
+
+                    return $promise = $connector->connect($uri);
+                }, function ($e) use ($uri, $reject) {
+                    $reject(new RuntimeException('Connection to ' . $uri .' failed during DNS lookup: ' . $e->getMessage(), 0, $e));
+                })->then($resolve, $reject);
+            },
+            function ($_, $reject) use (&$promise, &$resolved, $uri) {
+                // cancellation should reject connection attempt
+                // reject DNS resolution with custom reason, otherwise rely on connection cancellation below
+                if ($resolved === null) {
+                    $reject(new RuntimeException('Connection to ' . $uri . ' cancelled during DNS lookup'));
+                }
+
+                // (try to) cancel pending DNS lookup / connection attempt
                 if ($promise instanceof CancellablePromiseInterface) {
                     $promise->cancel();
+                    $promise = null;
                 }
             }
         );

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -2,8 +2,9 @@
 
 namespace React\Tests\Socket;
 
-use React\Socket\DnsConnector;
 use React\Promise;
+use React\Promise\Deferred;
+use React\Socket\DnsConnector;
 
 class DnsConnectorTest extends TestCase
 {
@@ -79,6 +80,38 @@ class DnsConnectorTest extends TestCase
 
     /**
      * @expectedException RuntimeException
+     * @expectedExceptionMessage Connection failed
+     */
+    public function testRejectsWithTcpConnectorRejectionIfGivenIp()
+    {
+        $promise = Promise\reject(new \RuntimeException('Connection failed'));
+        $this->resolver->expects($this->never())->method('resolve');
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80'))->willReturn($promise);
+
+        $promise = $this->connector->connect('1.2.3.4:80');
+        $promise->cancel();
+
+        $this->throwRejection($promise);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Connection failed
+     */
+    public function testRejectsWithTcpConnectorRejectionAfterDnsIsResolved()
+    {
+        $promise = Promise\reject(new \RuntimeException('Connection failed'));
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->willReturn(Promise\resolve('1.2.3.4'));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80?hostname=example.com'))->willReturn($promise);
+
+        $promise = $this->connector->connect('example.com:80');
+        $promise->cancel();
+
+        $this->throwRejection($promise);
+    }
+
+    /**
+     * @expectedException RuntimeException
      * @expectedExceptionMessage Connection to example.invalid:80 failed during DNS lookup: DNS error
      */
     public function testSkipConnectionIfDnsFails()
@@ -121,16 +154,144 @@ class DnsConnectorTest extends TestCase
         $this->throwRejection($promise);
     }
 
-    public function testCancelDuringTcpConnectionCancelsTcpConnection()
+    public function testCancelDuringTcpConnectionCancelsTcpConnectionIfGivenIp()
     {
-        $pending = new Promise\Promise(function () { }, function () { throw new \Exception(); });
-        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
-        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80?hostname=example.com'))->will($this->returnValue($pending));
+        $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
+        $this->resolver->expects($this->never())->method('resolve');
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80'))->willReturn($pending);
+
+        $promise = $this->connector->connect('1.2.3.4:80');
+        $promise->cancel();
+    }
+
+    public function testCancelDuringTcpConnectionCancelsTcpConnectionAfterDnsIsResolved()
+    {
+        $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->willReturn(Promise\resolve('1.2.3.4'));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80?hostname=example.com'))->willReturn($pending);
 
         $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
+    }
 
-        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Connection cancelled
+     */
+    public function testCancelDuringTcpConnectionCancelsTcpConnectionWithTcpRejectionAfterDnsIsResolved()
+    {
+        $first = new Deferred();
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->willReturn($first->promise());
+        $pending = new Promise\Promise(function () { }, function () {
+            throw new \RuntimeException('Connection cancelled');
+        });
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80?hostname=example.com'))->willReturn($pending);
+
+        $promise = $this->connector->connect('example.com:80');
+        $first->resolve('1.2.3.4');
+
+        $promise->cancel();
+
+        $this->throwRejection($promise);
+    }
+
+    /**
+     * @requires PHP 7
+     */
+    public function testRejectionDuringDnsLookupShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $dns = new Deferred();
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->willReturn($dns->promise());
+        $this->tcp->expects($this->never())->method('connect');
+
+        $promise = $this->connector->connect('example.com:80');
+        $dns->reject(new \RuntimeException('DNS failed'));
+        unset($promise, $dns);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    /**
+     * @requires PHP 7
+     */
+    public function testRejectionAfterDnsLookupShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $dns = new Deferred();
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->willReturn($dns->promise());
+
+        $tcp = new Deferred();
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80?hostname=example.com'))->willReturn($tcp->promise());
+
+        $promise = $this->connector->connect('example.com:80');
+        $dns->resolve('1.2.3.4');
+        $tcp->reject(new \RuntimeException('Connection failed'));
+        unset($promise, $dns, $tcp);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    /**
+     * @requires PHP 7
+     */
+    public function testCancelDuringDnsLookupShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $dns = new Deferred(function () {
+            throw new \RuntimeException();
+        });
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->willReturn($dns->promise());
+        $this->tcp->expects($this->never())->method('connect');
+
+        $promise = $this->connector->connect('example.com:80');
+
+        $promise->cancel();
+        unset($promise, $dns);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    /**
+     * @requires PHP 7
+     */
+    public function testCancelDuringTcpConnectionShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $dns = new Deferred();
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->willReturn($dns->promise());
+        $tcp = new Promise\Promise(function () { }, function () {
+            throw new \RuntimeException('Connection cancelled');
+        });
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80?hostname=example.com'))->willReturn($tcp);
+
+        $promise = $this->connector->connect('example.com:80');
+        $dns->resolve('1.2.3.4');
+
+        $promise->cancel();
+        unset($promise, $dns);
+
+        $this->assertEquals(0, gc_collect_cycles());
     }
 
     private function throwRejection($promise)


### PR DESCRIPTION
This PR improves DNS error messages (if connector fails due to DNS lookup) and improves (fixes) cancellation forwarding after the DNS lookup. This ensures that cancelling a pending connection attempt will properly cancel the underlying TCP/IP connection attempt.

The cancellation forwarding will eventually also be addressed upstream via reactphp/promise#99, but it's currently not decided when this version will be tagged. In the meantime, this PR works around this issue and improves cancellation semantics somewhat.

Refs #168 and #169