### PR TITLE
Improve timeout error messages

### DIFF
--- a/src/TimeoutConnector.php
+++ b/src/TimeoutConnector.php
@@ -4,6 +4,7 @@ namespace React\Socket;
 
 use React\EventLoop\LoopInterface;
 use React\Promise\Timer;
+use React\Promise\Timer\TimeoutException;
 
 final class TimeoutConnector implements ConnectorInterface
 {
@@ -20,6 +21,30 @@ final class TimeoutConnector implements ConnectorInterface
 
     public function connect($uri)
     {
-        return Timer\timeout($this->connector->connect($uri), $this->timeout, $this->loop);
+        return Timer\timeout($this->connector->connect($uri), $this->timeout, $this->loop)->then(null, self::handler($uri));
+    }
+
+    /**
+     * Creates a static rejection handler that reports a proper error message in case of a timeout.
+     *
+     * This uses a private static helper method to ensure this closure is not
+     * bound to this instance and the exception trace does not include a
+     * reference to this instance and its connector stack as a result.
+     *
+     * @param string $uri
+     * @return callable
+     */
+    private static function handler($uri)
+    {
+        return function (\Exception $e) use ($uri) {
+            if ($e instanceof TimeoutException) {
+                throw new \RuntimeException(
+                    'Connection to ' . $uri . ' timed out after ' . $e->getTimeout() . ' seconds',
+                    \defined('SOCKET_ETIMEDOUT') ? \SOCKET_ETIMEDOUT : 0
+                );
+            }
+
+            throw $e;
+        };
     }
 }

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -195,9 +195,6 @@ class DnsConnectorTest extends TestCase
         $this->throwRejection($promise);
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testRejectionDuringDnsLookupShouldNotCreateAnyGarbageReferences()
     {
         if (class_exists('React\Promise\When')) {
@@ -217,9 +214,6 @@ class DnsConnectorTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testRejectionAfterDnsLookupShouldNotCreateAnyGarbageReferences()
     {
         if (class_exists('React\Promise\When')) {
@@ -242,9 +236,6 @@ class DnsConnectorTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testRejectionAfterDnsLookupShouldNotCreateAnyGarbageReferencesAgain()
     {
         if (class_exists('React\Promise\When')) {
@@ -270,9 +261,6 @@ class DnsConnectorTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testCancelDuringDnsLookupShouldNotCreateAnyGarbageReferences()
     {
         if (class_exists('React\Promise\When')) {
@@ -295,9 +283,6 @@ class DnsConnectorTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testCancelDuringTcpConnectionShouldNotCreateAnyGarbageReferences()
     {
         if (class_exists('React\Promise\When')) {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -181,9 +181,6 @@ class IntegrationTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testWaitingForConnectionTimeoutDuringDnsLookupShouldNotCreateAnyGarbageReferences()
     {
         if (class_exists('React\Promise\When')) {
@@ -217,9 +214,6 @@ class IntegrationTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testWaitingForConnectionTimeoutDuringTcpConnectionShouldNotCreateAnyGarbageReferences()
     {
         if (class_exists('React\Promise\When')) {


### PR DESCRIPTION
This simple PR improves timeout error messages for failed and cancelled connection attempts slightly. In particular, the Exception message now always consistently includes the connection target URI.

Refs #168, #169, #170 and #171