### PR TITLE
Improve TLS error messages and cancellation forwarding during TLS handshake after TCP/IP connection

### DIFF
--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -62,8 +62,7 @@ final class SecureConnector implements ConnectorInterface
 
                 throw new \RuntimeException(
                     'Connection to ' . $uri . ' failed during TLS handshake: ' . $error->getMessage(),
-                    0,
-                    $error
+                    $error->getCode()
                 );
             });
         });

--- a/src/SecureServer.php
+++ b/src/SecureServer.php
@@ -186,8 +186,7 @@ final class SecureServer extends EventEmitter implements ServerInterface
             function ($error) use ($that, $connection) {
                 $error = new \RuntimeException(
                     'Connection from ' . $connection->getRemoteAddress() . ' failed during TLS handshake: ' . $error->getMessage(),
-                    $error->getCode(),
-                    $error
+                    $error->getCode()
                 );
 
                 $that->emit('error', array($error));

--- a/src/SecureServer.php
+++ b/src/SecureServer.php
@@ -184,6 +184,12 @@ final class SecureServer extends EventEmitter implements ServerInterface
                 $that->emit('connection', array($conn));
             },
             function ($error) use ($that, $connection) {
+                $error = new \RuntimeException(
+                    'Connection from ' . $connection->getRemoteAddress() . ' failed during TLS handshake: ' . $error->getMessage(),
+                    $error->getCode(),
+                    $error
+                );
+
                 $that->emit('error', array($error));
                 $connection->end();
             }

--- a/src/StreamEncryption.php
+++ b/src/StreamEncryption.php
@@ -136,15 +136,20 @@ class StreamEncryption
         if (true === $result) {
             $deferred->resolve();
         } else if (false === $result) {
+            // overwrite callback arguments for PHP7+ only, so they do not show
+            // up in the Exception trace and do not cause a possible cyclic reference.
+            $d = $deferred;
+            $deferred = null;
+
             if (\feof($socket) || $error === null) {
                 // EOF or failed without error => connection closed during handshake
-                $deferred->reject(new UnexpectedValueException(
+                $d->reject(new UnexpectedValueException(
                     'Connection lost during TLS handshake',
                     \defined('SOCKET_ECONNRESET') ? \SOCKET_ECONNRESET : 0
                 ));
             } else {
                 // handshake failed with error message
-                $deferred->reject(new UnexpectedValueException(
+                $d->reject(new UnexpectedValueException(
                     'Unable to complete TLS handshake: ' . $error
                 ));
             }

--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -425,6 +425,7 @@ class FunctionalSecureServerTest extends TestCase
         $this->assertStringStartsWith('Connection from tcp://', $error->getMessage());
         $this->assertStringEndsWith('failed during TLS handshake: Connection lost during TLS handshake', $error->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 0, $error->getCode());
+        $this->assertNull($error->getPrevious());
     }
 
     public function testEmitsErrorIfConnectionIsClosedWithIncompleteHandshake()
@@ -452,6 +453,7 @@ class FunctionalSecureServerTest extends TestCase
         $this->assertStringStartsWith('Connection from tcp://', $error->getMessage());
         $this->assertStringEndsWith('failed during TLS handshake: Connection lost during TLS handshake', $error->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 0, $error->getCode());
+        $this->assertNull($error->getPrevious());
     }
 
     public function testEmitsNothingIfConnectionIsIdle()

--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -420,8 +420,10 @@ class FunctionalSecureServerTest extends TestCase
 
         $error = Block\await($errorEvent, $loop, self::TIMEOUT);
 
+        // Connection from tcp://127.0.0.1:39528 failed during TLS handshake: Connection lost during TLS handshak
         $this->assertTrue($error instanceof \RuntimeException);
-        $this->assertEquals('Connection lost during TLS handshake', $error->getMessage());
+        $this->assertStringStartsWith('Connection from tcp://', $error->getMessage());
+        $this->assertStringEndsWith('failed during TLS handshake: Connection lost during TLS handshake', $error->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 0, $error->getCode());
     }
 
@@ -445,8 +447,10 @@ class FunctionalSecureServerTest extends TestCase
 
         $error = Block\await($errorEvent, $loop, self::TIMEOUT);
 
+        // Connection from tcp://127.0.0.1:39528 failed during TLS handshake: Connection lost during TLS handshak
         $this->assertTrue($error instanceof \RuntimeException);
-        $this->assertEquals('Connection lost during TLS handshake', $error->getMessage());
+        $this->assertStringStartsWith('Connection from tcp://', $error->getMessage());
+        $this->assertStringEndsWith('failed during TLS handshake: Connection lost during TLS handshake', $error->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 0, $error->getCode());
     }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -280,6 +280,46 @@ class IntegrationTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
+    /**
+     * @requires PHP 7
+     */
+    public function testWaitingForInvalidTlsConnectionShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        $loop = Factory::create();
+        $connector = new Connector($loop, array(
+            'tls' => array(
+                'verify_peer' => true
+            )
+        ));
+
+        gc_collect_cycles();
+
+        $wait = true;
+        $promise = $connector->connect('tls://self-signed.badssl.com:443')->then(
+            null,
+            function ($e) use (&$wait) {
+                $wait = false;
+                throw $e;
+            }
+        );
+
+        // run loop for short period to ensure we detect DNS error
+        Block\sleep(0.1, $loop);
+        if ($wait) {
+            Block\sleep(0.4, $loop);
+            if ($wait) {
+                $this->fail('Connection attempt did not fail');
+            }
+        }
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
     public function testWaitingForSuccessfullyClosedConnectionShouldNotCreateAnyGarbageReferences()
     {
         if (class_exists('React\Promise\When')) {
@@ -303,10 +343,6 @@ class IntegrationTest extends TestCase
 
     public function testConnectingFailsIfTimeoutIsTooSmall()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
-        }
-
         $loop = Factory::create();
 
         $connector = new Connector($loop, array(

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Socket;
 
 use React\Promise;
+use React\Promise\Deferred;
 use React\Socket\SecureConnector;
 
 class SecureConnectorTest extends TestCase
@@ -47,6 +48,15 @@ class SecureConnectorTest extends TestCase
         $promise = $this->connector->connect('tcp://example.com:80');
 
         $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testCancelDuringTcpConnectionCancelsTcpConnection()
+    {
+        $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
+        $this->tcp->expects($this->once())->method('connect')->with('example.com:80')->willReturn($pending);
+
+        $promise = $this->connector->connect('example.com:80');
+        $promise->cancel();
     }
 
     /**
@@ -119,6 +129,80 @@ class SecureConnectorTest extends TestCase
         $promise = $this->connector->connect('example.com:80');
 
         $this->throwRejection($promise);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Connection to example.com:80 cancelled during TLS handshake
+     */
+    public function testCancelDuringStreamEncryptionCancelsEncryptionAndClosesConnection()
+    {
+        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->getMock();
+        $connection->expects($this->once())->method('close');
+
+        $pending = new Promise\Promise(function () { }, function () {
+            throw new \Exception('Ignored');
+        });
+        $encryption = $this->getMockBuilder('React\Socket\StreamEncryption')->disableOriginalConstructor()->getMock();
+        $encryption->expects($this->once())->method('enable')->willReturn($pending);
+
+        $ref = new \ReflectionProperty($this->connector, 'streamEncryption');
+        $ref->setAccessible(true);
+        $ref->setValue($this->connector, $encryption);
+
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com:80'))->willReturn(Promise\resolve($connection));
+
+        $promise = $this->connector->connect('example.com:80');
+        $promise->cancel();
+
+        $this->throwRejection($promise);
+    }
+
+    public function testRejectionDuringConnectionShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $tcp = new Deferred();
+        $this->tcp->expects($this->once())->method('connect')->willReturn($tcp->promise());
+
+        $promise = $this->connector->connect('example.com:80');
+        $tcp->reject(new \RuntimeException());
+        unset($promise, $tcp);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testRejectionDuringTlsHandshakeShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->getMock();
+
+        $tcp = new Deferred();
+        $this->tcp->expects($this->once())->method('connect')->willReturn($tcp->promise());
+
+        $tls = new Deferred();
+        $encryption = $this->getMockBuilder('React\Socket\StreamEncryption')->disableOriginalConstructor()->getMock();
+        $encryption->expects($this->once())->method('enable')->willReturn($tls->promise());
+
+        $ref = new \ReflectionProperty($this->connector, 'streamEncryption');
+        $ref->setAccessible(true);
+        $ref->setValue($this->connector, $encryption);
+
+        $promise = $this->connector->connect('example.com:80');
+        $tcp->resolve($connection);
+        $tls->reject(new \RuntimeException());
+        unset($promise, $tcp, $tls);
+
+        $this->assertEquals(0, gc_collect_cycles());
     }
 
     private function throwRejection($promise)


### PR DESCRIPTION
This PR improves TLS error messages (if connector fails due to TLS handshake errors) and improves (fixes) cancellation forwarding after the TCP/IP connection. This ensures that cancelling a pending connection attempt will properly cancel the underlying TCP/IP connection attempt and/or the TLS handshake.

The cancellation forwarding will eventually also be addressed upstream via reactphp/promise#99, but it's currently not decided when this version will be tagged. In the meantime, this PR works around this issue and improves cancellation semantics somewhat.

Refs #168, #169, #170, #171 and #176