### PR TITLE
Improve performance by prefixing all global functions calls with \ to skip the look up and resolve process and go straight to the global function

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -50,7 +50,7 @@ class Connection extends EventEmitter implements ConnectionInterface
         // See https://bugs.php.net/bug.php?id=65137
         // https://bugs.php.net/bug.php?id=41631
         // https://github.com/reactphp/socket-client/issues/24
-        $clearCompleteBuffer = PHP_VERSION_ID < 50608;
+        $clearCompleteBuffer = \PHP_VERSION_ID < 50608;
 
         // PHP < 7.1.4 (and PHP < 7.0.18) suffers from a bug when writing big
         // chunks of data over TLS streams at once.
@@ -60,7 +60,7 @@ class Connection extends EventEmitter implements ConnectionInterface
         // affected versions. Please update your PHP version.
         // This applies to all streams because TLS may be enabled later on.
         // See https://github.com/reactphp/socket/issues/105
-        $limitWriteChunks = (PHP_VERSION_ID < 70018 || (PHP_VERSION_ID >= 70100 && PHP_VERSION_ID < 70104));
+        $limitWriteChunks = (\PHP_VERSION_ID < 70018 || (\PHP_VERSION_ID >= 70100 && \PHP_VERSION_ID < 70104));
 
         $this->input = new DuplexResourceStream(
             $resource,
@@ -120,7 +120,7 @@ class Connection extends EventEmitter implements ConnectionInterface
 
     public function handleClose()
     {
-        if (!is_resource($this->stream)) {
+        if (!\is_resource($this->stream)) {
             return;
         }
 
@@ -130,18 +130,18 @@ class Connection extends EventEmitter implements ConnectionInterface
         // continuing to close the socket resource.
         // Underlying Stream implementation will take care of closing file
         // handle, so we otherwise keep this open here.
-        @stream_socket_shutdown($this->stream, STREAM_SHUT_RDWR);
-        stream_set_blocking($this->stream, false);
+        @\stream_socket_shutdown($this->stream, \STREAM_SHUT_RDWR);
+        \stream_set_blocking($this->stream, false);
     }
 
     public function getRemoteAddress()
     {
-        return $this->parseAddress(@stream_socket_get_name($this->stream, true));
+        return $this->parseAddress(@\stream_socket_get_name($this->stream, true));
     }
 
     public function getLocalAddress()
     {
-        return $this->parseAddress(@stream_socket_get_name($this->stream, false));
+        return $this->parseAddress(@\stream_socket_get_name($this->stream, false));
     }
 
     private function parseAddress($address)
@@ -153,8 +153,8 @@ class Connection extends EventEmitter implements ConnectionInterface
         if ($this->unix) {
             // remove trailing colon from address for HHVM < 3.19: https://3v4l.org/5C1lo
             // note that technically ":" is a valid address, so keep this in place otherwise
-            if (substr($address, -1) === ':' && defined('HHVM_VERSION_ID') && HHVM_VERSION_ID < 31900) {
-                $address = (string)substr($address, 0, -1);
+            if (\substr($address, -1) === ':' && \defined('HHVM_VERSION_ID') && \HHVM_VERSION_ID < 31900) {
+                $address = (string)\substr($address, 0, -1);
             }
 
             // work around unknown addresses should return null value: https://3v4l.org/5C1lo and https://bugs.php.net/bug.php?id=74556
@@ -167,10 +167,10 @@ class Connection extends EventEmitter implements ConnectionInterface
         }
 
         // check if this is an IPv6 address which includes multiple colons but no square brackets
-        $pos = strrpos($address, ':');
-        if ($pos !== false && strpos($address, ':') < $pos && substr($address, 0, 1) !== '[') {
-            $port = substr($address, $pos + 1);
-            $address = '[' . substr($address, 0, $pos) . ']:' . $port;
+        $pos = \strrpos($address, ':');
+        if ($pos !== false && \strpos($address, ':') < $pos && \substr($address, 0, 1) !== '[') {
+            $port = \substr($address, $pos + 1);
+            $address = '[' . \substr($address, 0, $pos) . ']:' . $port;
         }
 
         return ($this->encryptionEnabled ? 'tls' : 'tcp') . '://' . $address;

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -41,7 +41,7 @@ final class Connector implements ConnectorInterface
         );
 
         if ($options['timeout'] === true) {
-            $options['timeout'] = (float)ini_get("default_socket_timeout");
+            $options['timeout'] = (float)\ini_get("default_socket_timeout");
         }
 
         if ($options['tcp'] instanceof ConnectorInterface) {
@@ -49,7 +49,7 @@ final class Connector implements ConnectorInterface
         } else {
             $tcp = new TcpConnector(
                 $loop,
-                is_array($options['tcp']) ? $options['tcp'] : array()
+                \is_array($options['tcp']) ? $options['tcp'] : array()
             );
         }
 
@@ -62,7 +62,7 @@ final class Connector implements ConnectorInterface
                 } else {
                     // try to load nameservers from system config or default to Google's public DNS
                     $config = Config::loadSystemConfigBlocking();
-                    $server = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+                    $server = $config->nameservers ? \reset($config->nameservers) : '8.8.8.8';
                 }
 
                 $factory = new Factory();
@@ -94,7 +94,7 @@ final class Connector implements ConnectorInterface
                 $options['tls'] = new SecureConnector(
                     $tcp,
                     $loop,
-                    is_array($options['tls']) ? $options['tls'] : array()
+                    \is_array($options['tls']) ? $options['tls'] : array()
                 );
             }
 
@@ -120,12 +120,12 @@ final class Connector implements ConnectorInterface
     public function connect($uri)
     {
         $scheme = 'tcp';
-        if (strpos($uri, '://') !== false) {
-            $scheme = (string)substr($uri, 0, strpos($uri, '://'));
+        if (\strpos($uri, '://') !== false) {
+            $scheme = (string)\substr($uri, 0, \strpos($uri, '://'));
         }
 
         if (!isset($this->connectors[$scheme])) {
-            return Promise\reject(new RuntimeException(
+            return Promise\reject(new \RuntimeException(
                 'No connector available for URI scheme "' . $scheme . '"'
             ));
         }

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -21,22 +21,22 @@ final class DnsConnector implements ConnectorInterface
 
     public function connect($uri)
     {
-        if (strpos($uri, '://') === false) {
-            $parts = parse_url('tcp://' . $uri);
+        if (\strpos($uri, '://') === false) {
+            $parts = \parse_url('tcp://' . $uri);
             unset($parts['scheme']);
         } else {
-            $parts = parse_url($uri);
+            $parts = \parse_url($uri);
         }
 
         if (!$parts || !isset($parts['host'])) {
-            return Promise\reject(new InvalidArgumentException('Given URI "' . $uri . '" is invalid'));
+            return Promise\reject(new \InvalidArgumentException('Given URI "' . $uri . '" is invalid'));
         }
 
-        $host = trim($parts['host'], '[]');
+        $host = \trim($parts['host'], '[]');
         $connector = $this->connector;
 
         // skip DNS lookup / URI manipulation if this URI already contains an IP
-        if (false !== filter_var($host, FILTER_VALIDATE_IP)) {
+        if (false !== \filter_var($host, \FILTER_VALIDATE_IP)) {
             return $connector->connect($uri);
         }
 
@@ -55,7 +55,7 @@ final class DnsConnector implements ConnectorInterface
                         $uri .= $parts['scheme'] . '://';
                     }
 
-                    if (strpos($ip, ':') !== false) {
+                    if (\strpos($ip, ':') !== false) {
                         // enclose IPv6 addresses in square brackets before appending port
                         $uri .= '[' . $ip . ']';
                     } else {
@@ -80,9 +80,9 @@ final class DnsConnector implements ConnectorInterface
                     // append original hostname as query if resolved via DNS and if
                     // destination URI does not contain "hostname" query param already
                     $args = array();
-                    parse_str(isset($parts['query']) ? $parts['query'] : '', $args);
+                    \parse_str(isset($parts['query']) ? $parts['query'] : '', $args);
                     if ($host !== $ip && !isset($args['hostname'])) {
-                        $uri .= (isset($parts['query']) ? '&' : '?') . 'hostname=' . rawurlencode($host);
+                        $uri .= (isset($parts['query']) ? '&' : '?') . 'hostname=' . \rawurlencode($host);
                     }
 
                     // append original fragment if known
@@ -92,14 +92,14 @@ final class DnsConnector implements ConnectorInterface
 
                     return $promise = $connector->connect($uri);
                 }, function ($e) use ($uri, $reject) {
-                    $reject(new RuntimeException('Connection to ' . $uri .' failed during DNS lookup: ' . $e->getMessage(), 0, $e));
+                    $reject(new \RuntimeException('Connection to ' . $uri .' failed during DNS lookup: ' . $e->getMessage(), 0, $e));
                 })->then($resolve, $reject);
             },
             function ($_, $reject) use (&$promise, &$resolved, $uri) {
                 // cancellation should reject connection attempt
                 // reject DNS resolution with custom reason, otherwise rely on connection cancellation below
                 if ($resolved === null) {
-                    $reject(new RuntimeException('Connection to ' . $uri . ' cancelled during DNS lookup'));
+                    $reject(new \RuntimeException('Connection to ' . $uri . ' cancelled during DNS lookup'));
                 }
 
                 // (try to) cancel pending DNS lookup / connection attempt

--- a/src/LimitingServer.php
+++ b/src/LimitingServer.php
@@ -156,8 +156,8 @@ class LimitingServer extends EventEmitter implements ServerInterface
     public function handleConnection(ConnectionInterface $connection)
     {
         // close connection if limit exceeded
-        if ($this->limit !== null && count($this->connections) >= $this->limit) {
-            $this->handleError(new OverflowException('Connection closed because server reached connection limit'));
+        if ($this->limit !== null && \count($this->connections) >= $this->limit) {
+            $this->handleError(new \OverflowException('Connection closed because server reached connection limit'));
             $connection->close();
             return;
         }
@@ -169,7 +169,7 @@ class LimitingServer extends EventEmitter implements ServerInterface
         });
 
         // pause accepting new connections if limit exceeded
-        if ($this->pauseOnLimit && !$this->autoPaused && count($this->connections) >= $this->limit) {
+        if ($this->pauseOnLimit && !$this->autoPaused && \count($this->connections) >= $this->limit) {
             $this->autoPaused = true;
 
             if (!$this->manuPaused) {
@@ -183,10 +183,10 @@ class LimitingServer extends EventEmitter implements ServerInterface
     /** @internal */
     public function handleDisconnection(ConnectionInterface $connection)
     {
-        unset($this->connections[array_search($connection, $this->connections)]);
+        unset($this->connections[\array_search($connection, $this->connections)]);
 
         // continue accepting new connection if below limit
-        if ($this->autoPaused && count($this->connections) < $this->limit) {
+        if ($this->autoPaused && \count($this->connections) < $this->limit) {
             $this->autoPaused = false;
 
             if (!$this->manuPaused) {
@@ -196,7 +196,7 @@ class LimitingServer extends EventEmitter implements ServerInterface
     }
 
     /** @internal */
-    public function handleError(Exception $error)
+    public function handleError(\Exception $error)
     {
         $this->emit('error', array($error));
     }

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -23,20 +23,20 @@ final class SecureConnector implements ConnectorInterface
 
     public function connect($uri)
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            return Promise\reject(new BadMethodCallException('Encryption not supported on your platform (HHVM < 3.8?)')); // @codeCoverageIgnore
+        if (!\function_exists('stream_socket_enable_crypto')) {
+            return Promise\reject(new \BadMethodCallException('Encryption not supported on your platform (HHVM < 3.8?)')); // @codeCoverageIgnore
         }
 
-        if (strpos($uri, '://') === false) {
+        if (\strpos($uri, '://') === false) {
             $uri = 'tls://' . $uri;
         }
 
-        $parts = parse_url($uri);
+        $parts = \parse_url($uri);
         if (!$parts || !isset($parts['scheme']) || $parts['scheme'] !== 'tls') {
-            return Promise\reject(new InvalidArgumentException('Given URI "' . $uri . '" is invalid'));
+            return Promise\reject(new \InvalidArgumentException('Given URI "' . $uri . '" is invalid'));
         }
 
-        $uri = str_replace('tls://', '', $uri);
+        $uri = \str_replace('tls://', '', $uri);
         $context = $this->context;
 
         $encryption = $this->streamEncryption;
@@ -47,12 +47,12 @@ final class SecureConnector implements ConnectorInterface
 
             if (!$connection instanceof Connection) {
                 $connection->close();
-                throw new UnexpectedValueException('Base connector does not use internal Connection class exposing stream resource');
+                throw new \UnexpectedValueException('Base connector does not use internal Connection class exposing stream resource');
             }
 
             // set required SSL/TLS context options
             foreach ($context as $name => $value) {
-                stream_context_set_option($connection->stream, 'ssl', $name, $value);
+                \stream_context_set_option($connection->stream, 'ssl', $name, $value);
             }
 
             // try to enable encryption

--- a/src/SecureServer.php
+++ b/src/SecureServer.php
@@ -117,8 +117,8 @@ final class SecureServer extends EventEmitter implements ServerInterface
      */
     public function __construct(ServerInterface $tcp, LoopInterface $loop, array $context)
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            throw new BadMethodCallException('Encryption not supported on your platform (HHVM < 3.8?)'); // @codeCoverageIgnore
+        if (!\function_exists('stream_socket_enable_crypto')) {
+            throw new \BadMethodCallException('Encryption not supported on your platform (HHVM < 3.8?)'); // @codeCoverageIgnore
         }
 
         // default to empty passphrase to suppress blocking passphrase prompt
@@ -146,7 +146,7 @@ final class SecureServer extends EventEmitter implements ServerInterface
             return null;
         }
 
-        return str_replace('tcp://' , 'tls://', $address);
+        return \str_replace('tcp://' , 'tls://', $address);
     }
 
     public function pause()
@@ -168,13 +168,13 @@ final class SecureServer extends EventEmitter implements ServerInterface
     public function handleConnection(ConnectionInterface $connection)
     {
         if (!$connection instanceof Connection) {
-            $this->emit('error', array(new UnexpectedValueException('Base server does not use internal Connection class exposing stream resource')));
+            $this->emit('error', array(new \UnexpectedValueException('Base server does not use internal Connection class exposing stream resource')));
             $connection->end();
             return;
         }
 
         foreach ($this->context as $name => $value) {
-            stream_context_set_option($connection->stream, 'ssl', $name, $value);
+            \stream_context_set_option($connection->stream, 'ssl', $name, $value);
         }
 
         $that = $this;

--- a/src/Server.php
+++ b/src/Server.php
@@ -25,9 +25,9 @@ final class Server extends EventEmitter implements ServerInterface
         );
 
         $scheme = 'tcp';
-        $pos = strpos($uri, '://');
+        $pos = \strpos($uri, '://');
         if ($pos !== false) {
-            $scheme = substr($uri, 0, $pos);
+            $scheme = \substr($uri, 0, $pos);
         }
 
         if ($scheme === 'unix') {

--- a/src/StreamEncryption.php
+++ b/src/StreamEncryption.php
@@ -32,28 +32,28 @@ class StreamEncryption
         // @link http://php.net/manual/en/migration56.openssl.php#migration56.openssl.crypto-method
         // @link https://3v4l.org/plbFn
         if ($server) {
-            $this->method = STREAM_CRYPTO_METHOD_TLS_SERVER;
+            $this->method = \STREAM_CRYPTO_METHOD_TLS_SERVER;
 
-            if (defined('STREAM_CRYPTO_METHOD_TLSv1_0_SERVER')) {
-                $this->method |= STREAM_CRYPTO_METHOD_TLSv1_0_SERVER;
+            if (\defined('STREAM_CRYPTO_METHOD_TLSv1_0_SERVER')) {
+                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_0_SERVER;
             }
-            if (defined('STREAM_CRYPTO_METHOD_TLSv1_1_SERVER')) {
-                $this->method |= STREAM_CRYPTO_METHOD_TLSv1_1_SERVER;
+            if (\defined('STREAM_CRYPTO_METHOD_TLSv1_1_SERVER')) {
+                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_1_SERVER;
             }
-            if (defined('STREAM_CRYPTO_METHOD_TLSv1_2_SERVER')) {
-                $this->method |= STREAM_CRYPTO_METHOD_TLSv1_2_SERVER;
+            if (\defined('STREAM_CRYPTO_METHOD_TLSv1_2_SERVER')) {
+                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_2_SERVER;
             }
         } else {
-            $this->method = STREAM_CRYPTO_METHOD_TLS_CLIENT;
+            $this->method = \STREAM_CRYPTO_METHOD_TLS_CLIENT;
 
-            if (defined('STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT')) {
-                $this->method |= STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
+            if (\defined('STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT')) {
+                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
             }
-            if (defined('STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT')) {
-                $this->method |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
+            if (\defined('STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT')) {
+                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
             }
-            if (defined('STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT')) {
-                $this->method |= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+            if (\defined('STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT')) {
+                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
             }
         }
     }
@@ -77,7 +77,7 @@ class StreamEncryption
 
         $deferred = new Deferred(function ($_, $reject) use ($toggle) {
             // cancelling this leaves this stream in an inconsistent state…
-            $reject(new RuntimeException('Cancelled toggling encryption ' . $toggle ? 'on' : 'off'));
+            $reject(new \RuntimeException('Cancelled toggling encryption ' . $toggle ? 'on' : 'off'));
         });
 
         // get actual stream socket from stream instance
@@ -143,13 +143,13 @@ class StreamEncryption
 
             if (\feof($socket) || $error === null) {
                 // EOF or failed without error => connection closed during handshake
-                $d->reject(new UnexpectedValueException(
+                $d->reject(new \UnexpectedValueException(
                     'Connection lost during TLS handshake',
                     \defined('SOCKET_ECONNRESET') ? \SOCKET_ECONNRESET : 0
                 ));
             } else {
                 // handshake failed with error message
-                $d->reject(new UnexpectedValueException(
+                $d->reject(new \UnexpectedValueException(
                     'Unable to complete TLS handshake: ' . $error
                 ));
             }

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -130,57 +130,57 @@ final class TcpServer extends EventEmitter implements ServerInterface
         }
 
         // assume default scheme if none has been given
-        if (strpos($uri, '://') === false) {
+        if (\strpos($uri, '://') === false) {
             $uri = 'tcp://' . $uri;
         }
 
         // parse_url() does not accept null ports (random port assignment) => manually remove
-        if (substr($uri, -2) === ':0') {
-            $parts = parse_url(substr($uri, 0, -2));
+        if (\substr($uri, -2) === ':0') {
+            $parts = \parse_url(\substr($uri, 0, -2));
             if ($parts) {
                 $parts['port'] = 0;
             }
         } else {
-            $parts = parse_url($uri);
+            $parts = \parse_url($uri);
         }
 
         // ensure URI contains TCP scheme, host and port
         if (!$parts || !isset($parts['scheme'], $parts['host'], $parts['port']) || $parts['scheme'] !== 'tcp') {
-            throw new InvalidArgumentException('Invalid URI "' . $uri . '" given');
+            throw new \InvalidArgumentException('Invalid URI "' . $uri . '" given');
         }
 
-        if (false === filter_var(trim($parts['host'], '[]'), FILTER_VALIDATE_IP)) {
-            throw new InvalidArgumentException('Given URI "' . $uri . '" does not contain a valid host IP');
+        if (false === \filter_var(\trim($parts['host'], '[]'), \FILTER_VALIDATE_IP)) {
+            throw new \InvalidArgumentException('Given URI "' . $uri . '" does not contain a valid host IP');
         }
 
-        $this->master = @stream_socket_server(
+        $this->master = @\stream_socket_server(
             $uri,
             $errno,
             $errstr,
-            STREAM_SERVER_BIND | STREAM_SERVER_LISTEN,
-            stream_context_create(array('socket' => $context))
+            \STREAM_SERVER_BIND | \STREAM_SERVER_LISTEN,
+            \stream_context_create(array('socket' => $context))
         );
         if (false === $this->master) {
-            throw new RuntimeException('Failed to listen on "' . $uri . '": ' . $errstr, $errno);
+            throw new \RuntimeException('Failed to listen on "' . $uri . '": ' . $errstr, $errno);
         }
-        stream_set_blocking($this->master, 0);
+        \stream_set_blocking($this->master, 0);
 
         $this->resume();
     }
 
     public function getAddress()
     {
-        if (!is_resource($this->master)) {
+        if (!\is_resource($this->master)) {
             return null;
         }
 
-        $address = stream_socket_get_name($this->master, false);
+        $address = \stream_socket_get_name($this->master, false);
 
         // check if this is an IPv6 address which includes multiple colons but no square brackets
-        $pos = strrpos($address, ':');
-        if ($pos !== false && strpos($address, ':') < $pos && substr($address, 0, 1) !== '[') {
-            $port = substr($address, $pos + 1);
-            $address = '[' . substr($address, 0, $pos) . ']:' . $port;
+        $pos = \strrpos($address, ':');
+        if ($pos !== false && \strpos($address, ':') < $pos && \substr($address, 0, 1) !== '[') {
+            $port = \substr($address, $pos + 1);
+            $address = '[' . \substr($address, 0, $pos) . ']:' . $port;
         }
 
         return 'tcp://' . $address;
@@ -198,15 +198,15 @@ final class TcpServer extends EventEmitter implements ServerInterface
 
     public function resume()
     {
-        if ($this->listening || !is_resource($this->master)) {
+        if ($this->listening || !\is_resource($this->master)) {
             return;
         }
 
         $that = $this;
         $this->loop->addReadStream($this->master, function ($master) use ($that) {
-            $newSocket = @stream_socket_accept($master);
+            $newSocket = @\stream_socket_accept($master);
             if (false === $newSocket) {
-                $that->emit('error', array(new RuntimeException('Error accepting new connection')));
+                $that->emit('error', array(new \RuntimeException('Error accepting new connection')));
 
                 return;
             }
@@ -217,12 +217,12 @@ final class TcpServer extends EventEmitter implements ServerInterface
 
     public function close()
     {
-        if (!is_resource($this->master)) {
+        if (!\is_resource($this->master)) {
             return;
         }
 
         $this->pause();
-        fclose($this->master);
+        \fclose($this->master);
         $this->removeAllListeners();
     }
 

--- a/src/UnixConnector.php
+++ b/src/UnixConnector.php
@@ -24,16 +24,16 @@ final class UnixConnector implements ConnectorInterface
 
     public function connect($path)
     {
-        if (strpos($path, '://') === false) {
+        if (\strpos($path, '://') === false) {
             $path = 'unix://' . $path;
-        } elseif (substr($path, 0, 7) !== 'unix://') {
-            return Promise\reject(new InvalidArgumentException('Given URI "' . $path . '" is invalid'));
+        } elseif (\substr($path, 0, 7) !== 'unix://') {
+            return Promise\reject(new \InvalidArgumentException('Given URI "' . $path . '" is invalid'));
         }
 
-        $resource = @stream_socket_client($path, $errno, $errstr, 1.0);
+        $resource = @\stream_socket_client($path, $errno, $errstr, 1.0);
 
         if (!$resource) {
-            return Promise\reject(new RuntimeException('Unable to connect to unix domain socket "' . $path . '": ' . $errstr, $errno));
+            return Promise\reject(new \RuntimeException('Unable to connect to unix domain socket "' . $path . '": ' . $errstr, $errno));
         }
 
         $connection = new Connection($resource, $this->loop);

--- a/src/UnixServer.php
+++ b/src/UnixServer.php
@@ -47,45 +47,45 @@ final class UnixServer extends EventEmitter implements ServerInterface
     {
         $this->loop = $loop;
 
-        if (strpos($path, '://') === false) {
+        if (\strpos($path, '://') === false) {
             $path = 'unix://' . $path;
-        } elseif (substr($path, 0, 7) !== 'unix://') {
-            throw new InvalidArgumentException('Given URI "' . $path . '" is invalid');
+        } elseif (\substr($path, 0, 7) !== 'unix://') {
+            throw new \InvalidArgumentException('Given URI "' . $path . '" is invalid');
         }
 
-        $this->master = @stream_socket_server(
+        $this->master = @\stream_socket_server(
             $path,
             $errno,
             $errstr,
-            STREAM_SERVER_BIND | STREAM_SERVER_LISTEN,
-            stream_context_create(array('socket' => $context))
+            \STREAM_SERVER_BIND | \STREAM_SERVER_LISTEN,
+            \stream_context_create(array('socket' => $context))
         );
         if (false === $this->master) {
             // PHP does not seem to report errno/errstr for Unix domain sockets (UDS) right now.
             // This only applies to UDS server sockets, see also https://3v4l.org/NAhpr.
             // Parse PHP warning message containing unknown error, HHVM reports proper info at least.
             if ($errno === 0 && $errstr === '') {
-                $error = error_get_last();
-                if (preg_match('/\(([^\)]+)\)|\[(\d+)\]: (.*)/', $error['message'], $match)) {
+                $error = \error_get_last();
+                if (\preg_match('/\(([^\)]+)\)|\[(\d+)\]: (.*)/', $error['message'], $match)) {
                     $errstr = isset($match[3]) ? $match['3'] : $match[1];
                     $errno = isset($match[2]) ? (int)$match[2] : 0;
                 }
             }
 
-            throw new RuntimeException('Failed to listen on Unix domain socket "' . $path . '": ' . $errstr, $errno);
+            throw new \RuntimeException('Failed to listen on Unix domain socket "' . $path . '": ' . $errstr, $errno);
         }
-        stream_set_blocking($this->master, 0);
+        \stream_set_blocking($this->master, 0);
 
         $this->resume();
     }
 
     public function getAddress()
     {
-        if (!is_resource($this->master)) {
+        if (!\is_resource($this->master)) {
             return null;
         }
 
-        return 'unix://' . stream_socket_get_name($this->master, false);
+        return 'unix://' . \stream_socket_get_name($this->master, false);
     }
 
     public function pause()
@@ -106,9 +106,9 @@ final class UnixServer extends EventEmitter implements ServerInterface
 
         $that = $this;
         $this->loop->addReadStream($this->master, function ($master) use ($that) {
-            $newSocket = @stream_socket_accept($master);
+            $newSocket = @\stream_socket_accept($master);
             if (false === $newSocket) {
-                $that->emit('error', array(new RuntimeException('Error accepting new connection')));
+                $that->emit('error', array(new \RuntimeException('Error accepting new connection')));
 
                 return;
             }
@@ -119,12 +119,12 @@ final class UnixServer extends EventEmitter implements ServerInterface
 
     public function close()
     {
-        if (!is_resource($this->master)) {
+        if (!\is_resource($this->master)) {
             return;
         }
 
         $this->pause();
-        fclose($this->master);
+        \fclose($this->master);
         $this->removeAllListeners();
     }
 


### PR DESCRIPTION
Just as previous PR's like https://github.com/reactphp/stream/pull/137 this prefixes all global functions and constants with a `\` to gain a small performance boost