### PR TITLE
Improve TLS 1.3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1372,19 +1372,6 @@ This library does not take responsibility over these context options, so it's
 up to consumers of this library to take care of setting appropriate context
 options as described above.
 
-All versions of PHP prior to 5.6.8 suffered from a buffering issue where reading
-from a streaming TLS connection could be one `data` event behind.
-This library implements a work-around to try to flush the complete incoming
-data buffers on these legacy PHP versions, which has a penalty of around 10% of
-throughput on all connections.
-With this work-around, we have not been able to reproduce this issue anymore,
-but we have seen reports of people saying this could still affect some of the
-older PHP versions (`5.5.23`, `5.6.7`, and `5.6.8`).
-Note that this only affects *some* higher-level streaming protocols, such as
-IRC over TLS, but should not affect HTTP over TLS (HTTPS).
-Further investigation of this issue is needed.
-For more insights, this issue is also covered by our test suite.
-
 PHP < 7.1.4 (and PHP < 7.0.18) suffers from a bug when writing big
 chunks of data over TLS streams at once.
 We try to work around this by limiting the write chunk size to 8192

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/dns": "^0.4.13",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
-        "react/stream": "^1.0 || ^0.7.1",
+        "react/stream": "^1.1",
         "react/promise": "^2.6.0 || ^1.2.1",
         "react/promise-timer": "^1.4.0"
     },

--- a/src/StreamEncryption.php
+++ b/src/StreamEncryption.php
@@ -25,35 +25,21 @@ class StreamEncryption
         $this->server = $server;
 
         // support TLSv1.0+ by default and exclude legacy SSLv2/SSLv3.
-        // PHP 5.6+ supports bitmasks, legacy PHP only supports predefined
-        // constants, so apply accordingly below.
-        // Also, since PHP 5.6.7 up until before PHP 7.2.0 the main constant did
-        // only support TLSv1.0, so we explicitly apply all versions.
-        // @link http://php.net/manual/en/migration56.openssl.php#migration56.openssl.crypto-method
-        // @link https://3v4l.org/plbFn
+        // As of PHP 7.2+ the main crypto method constant includes all TLS versions.
+        // As of PHP 5.6+ the crypto method is a bitmask, so we explicitly include all TLS versions.
+        // For legacy PHP < 5.6 the crypto method is a single value only and this constant includes all TLS versions.
+        // @link https://3v4l.org/9PSST
         if ($server) {
             $this->method = \STREAM_CRYPTO_METHOD_TLS_SERVER;
 
-            if (\defined('STREAM_CRYPTO_METHOD_TLSv1_0_SERVER')) {
-                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_0_SERVER;
-            }
-            if (\defined('STREAM_CRYPTO_METHOD_TLSv1_1_SERVER')) {
-                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_1_SERVER;
-            }
-            if (\defined('STREAM_CRYPTO_METHOD_TLSv1_2_SERVER')) {
-                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_2_SERVER;
+            if (\PHP_VERSION_ID < 70200 && \PHP_VERSION_ID >= 50600) {
+                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_0_SERVER | \STREAM_CRYPTO_METHOD_TLSv1_1_SERVER | \STREAM_CRYPTO_METHOD_TLSv1_2_SERVER;
             }
         } else {
             $this->method = \STREAM_CRYPTO_METHOD_TLS_CLIENT;
 
-            if (\defined('STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT')) {
-                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
-            }
-            if (\defined('STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT')) {
-                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
-            }
-            if (\defined('STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT')) {
-                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+            if (\PHP_VERSION_ID < 70200 && \PHP_VERSION_ID >= 50600) {
+                $this->method |= \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT | \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT | \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
             }
         }
     }


### PR DESCRIPTION
TLS 1.3 is now an official standard as of August 2018 (https://tools.ietf.org/html/rfc8446) which is great news! :tada: See https://wiki.openssl.org/index.php/TLS1.3 if you want to learn more about why this is great news.

OpenSSL 1.1.1 supports TLS 1.3 (https://www.openssl.org/blog/blog/2017/05/04/tlsv1.3/). For example, this version ships with Ubuntu 18.10 (and newer) by default, meaning that recent installations support TLS 1.3 out of the box :shipit:

At the time of writing this, PHP does not know about TLS 1.3 at all. Interestingly, due to the way how PHP interfaces with OpenSSL, this means that TLS 1.3 is in fact enabled by default for all client and server connections when using a recent OpenSSL version (see also #184 for more details).

This PR improves TLS 1.3 support by working around the issues described in #184. In other words, prior to applying this patch, creating a TLS 1.3 connection could result in 100% CPU usage due to a bug in PHP. After applying this patch, this is worked around by consuming all stale data from the TLS receive buffers and as such support TLS 1.3 as well as older TLS versions. Accordingly, the test suite has been updated to add tests for all available TLS versions. The test suite confirms that existing behavior has not changed.

While PHP does not know about TLS 1.3 at the moment, there is however a pending PR that adds full TLS 1.3 support for a future PHP version (php/php-src#3700). This PR is designed in such a way as to be forwards compatible with when PHP receives official TLS 1.3 support and also when the underlying stream issue has been fixed (https://github.com/php/php-src/pull/3729). Again, the test suite covers these details to avoid any future regressions.

Builds on top of #185
Builds on top of reactphp/stream#139
Fixes #184