### PR TITLE
Update documentation to use full class names with namespaces

### DIFF
--- a/examples/01-echo-server.php
+++ b/examples/01-echo-server.php
@@ -30,9 +30,9 @@ $server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop, array(
     )
 ));
 
-$server->on('connection', function (ConnectionInterface $conn) {
-    echo '[' . $conn->getRemoteAddress() . ' connected]' . PHP_EOL;
-    $conn->pipe($conn);
+$server->on('connection', function (ConnectionInterface $connection) {
+    echo '[' . $connection->getRemoteAddress() . ' connected]' . PHP_EOL;
+    $connection->pipe($connection);
 });
 
 $server->on('error', 'printf');

--- a/examples/03-http-server.php
+++ b/examples/03-http-server.php
@@ -43,10 +43,10 @@ $server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop, array(
     )
 ));
 
-$server->on('connection', function (ConnectionInterface $conn) {
-    $conn->once('data', function () use ($conn) {
+$server->on('connection', function (ConnectionInterface $connection) {
+    $connection->once('data', function () use ($connection) {
         $body = "<html><h1>Hello world!</h1></html>\r\n";
-        $conn->end("HTTP/1.1 200 OK\r\nContent-Length: " . strlen($body) . "\r\nConnection: close\r\n\r\n" . $body);
+        $connection->end("HTTP/1.1 200 OK\r\nContent-Length: " . strlen($body) . "\r\nConnection: close\r\n\r\n" . $body);
     });
 });
 

--- a/examples/91-benchmark-server.php
+++ b/examples/91-benchmark-server.php
@@ -36,18 +36,18 @@ $server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop, array(
     )
 ));
 
-$server->on('connection', function (ConnectionInterface $conn) use ($loop) {
+$server->on('connection', function (ConnectionInterface $connection) use ($loop) {
     echo '[connected]' . PHP_EOL;
 
     // count the number of bytes received from this connection
     $bytes = 0;
-    $conn->on('data', function ($chunk) use (&$bytes) {
+    $connection->on('data', function ($chunk) use (&$bytes) {
         $bytes += strlen($chunk);
     });
 
     // report average throughput once client disconnects
     $t = microtime(true);
-    $conn->on('close', function () use ($conn, $t, &$bytes) {
+    $connection->on('close', function () use ($connection, $t, &$bytes) {
         $t = microtime(true) - $t;
         echo '[disconnected after receiving ' . $bytes . ' bytes in ' . round($t, 3) . 's => ' . round($bytes / $t / 1024 / 1024, 1) . ' MiB/s]' . PHP_EOL;
     });

--- a/src/ConnectorInterface.php
+++ b/src/ConnectorInterface.php
@@ -30,7 +30,7 @@ interface ConnectorInterface
      *
      * ```php
      * $connector->connect('google.com:443')->then(
-     *     function (ConnectionInterface $connection) {
+     *     function (React\Socket\ConnectionInterface $connection) {
      *         // connection successfully established
      *     },
      *     function (Exception $error) {

--- a/src/FixedUriConnector.php
+++ b/src/FixedUriConnector.php
@@ -10,9 +10,9 @@ namespace React\Socket;
  * instead of connecting to a default address assumed by an higher-level API:
  *
  * ```php
- * $connector = new FixedUriConnector(
+ * $connector = new React\Socket\FixedUriConnector(
  *     'unix:///var/run/docker.sock',
- *     new UnixConnector($loop)
+ *     new React\Socket\UnixConnector($loop)
  * );
  *
  * // destination will be ignored, actually connects to Unix domain socket

--- a/src/LimitingServer.php
+++ b/src/LimitingServer.php
@@ -21,8 +21,8 @@ use OverflowException;
  * open connections.
  *
  * ```php
- * $server = new LimitingServer($server, 100);
- * $server->on('connection', function (ConnectionInterface $connection) {
+ * $server = new React\Socket\LimitingServer($server, 100);
+ * $server->on('connection', function (React\Socket\ConnectionInterface $connection) {
  *     $connection->write('hello there!' . PHP_EOL);
  *     …
  * });
@@ -52,8 +52,8 @@ class LimitingServer extends EventEmitter implements ServerInterface
      * this and no `connection` event will be emitted.
      *
      * ```php
-     * $server = new LimitingServer($server, 100);
-     * $server->on('connection', function (ConnectionInterface $connection) {
+     * $server = new React\Socket\LimitingServer($server, 100);
+     * $server->on('connection', function (React\Socket\ConnectionInterface $connection) {
      *     $connection->write('hello there!' . PHP_EOL);
      *     …
      * });
@@ -81,8 +81,8 @@ class LimitingServer extends EventEmitter implements ServerInterface
      * an interactive chat).
      *
      * ```php
-     * $server = new LimitingServer($server, 100, true);
-     * $server->on('connection', function (ConnectionInterface $connection) {
+     * $server = new React\Socket\LimitingServer($server, 100, true);
+     * $server->on('connection', function (React\Socket\ConnectionInterface $connection) {
      *     $connection->write('hello there!' . PHP_EOL);
      *     …
      * });

--- a/src/SecureServer.php
+++ b/src/SecureServer.php
@@ -15,8 +15,8 @@ use UnexpectedValueException;
  * TCP/IP connections and then performs a TLS handshake for each connection.
  *
  * ```php
- * $server = new TcpServer(8000, $loop);
- * $server = new SecureServer($server, $loop, array(
+ * $server = new React\Socket\TcpServer(8000, $loop);
+ * $server = new React\Socket\SecureServer($server, $loop, array(
  *     // tls context options here…
  * ));
  * ```
@@ -25,7 +25,7 @@ use UnexpectedValueException;
  * with a connection instance implementing [`ConnectionInterface`](#connectioninterface):
  *
  * ```php
- * $server->on('connection', function (ConnectionInterface $connection) {
+ * $server->on('connection', function (React\Socket\ConnectionInterface $connection) {
  *     echo 'Secure connection from' . $connection->getRemoteAddress() . PHP_EOL;
  *
  *     $connection->write('hello there!' . PHP_EOL);
@@ -67,8 +67,8 @@ final class SecureServer extends EventEmitter implements ServerInterface
      * PEM encoded certificate file:
      *
      * ```php
-     * $server = new TcpServer(8000, $loop);
-     * $server = new SecureServer($server, $loop, array(
+     * $server = new React\Socket\TcpServer(8000, $loop);
+     * $server = new React\Socket\SecureServer($server, $loop, array(
      *     'local_cert' => 'server.pem'
      * ));
      * ```
@@ -82,8 +82,8 @@ final class SecureServer extends EventEmitter implements ServerInterface
      * like this:
      *
      * ```php
-     * $server = new TcpServer(8000, $loop);
-     * $server = new SecureServer($server, $loop, array(
+     * $server = new React\Socket\TcpServer(8000, $loop);
+     * $server = new React\Socket\SecureServer($server, $loop, array(
      *     'local_cert' => 'server.pem',
      *     'passphrase' => 'secret'
      * ));

--- a/src/ServerInterface.php
+++ b/src/ServerInterface.php
@@ -23,7 +23,7 @@ use Evenement\EventEmitterInterface;
  *     established, i.e. a new client connects to this server socket:
  *
  *     ```php
- *     $server->on('connection', function (ConnectionInterface $connection) {
+ *     $server->on('connection', function (React\Socket\ConnectionInterface $connection) {
  *         echo 'new connection' . PHP_EOL;
  *     });
  *     ```

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -12,14 +12,14 @@ use RuntimeException;
  * is responsible for accepting plaintext TCP/IP connections.
  *
  * ```php
- * $server = new TcpServer(8080, $loop);
+ * $server = new React\Socket\TcpServer(8080, $loop);
  * ```
  *
  * Whenever a client connects, it will emit a `connection` event with a connection
  * instance implementing `ConnectionInterface`:
  *
  * ```php
- * $server->on('connection', function (ConnectionInterface $connection) {
+ * $server->on('connection', function (React\Socket\ConnectionInterface $connection) {
  *     echo 'Plaintext connection from ' . $connection->getRemoteAddress() . PHP_EOL;
  *     $connection->write('hello there!' . PHP_EOL);
  *     …
@@ -45,7 +45,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * for more details.
      *
      * ```php
-     * $server = new TcpServer(8080, $loop);
+     * $server = new React\Socket\TcpServer(8080, $loop);
      * ```
      *
      * As above, the `$uri` parameter can consist of only a port, in which case the
@@ -55,7 +55,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * In order to use a random port assignment, you can use the port `0`:
      *
      * ```php
-     * $server = new TcpServer(0, $loop);
+     * $server = new React\Socket\TcpServer(0, $loop);
      * $address = $server->getAddress();
      * ```
      *
@@ -64,14 +64,14 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * preceded by the `tcp://` scheme:
      *
      * ```php
-     * $server = new TcpServer('192.168.0.1:8080', $loop);
+     * $server = new React\Socket\TcpServer('192.168.0.1:8080', $loop);
      * ```
      *
      * If you want to listen on an IPv6 address, you MUST enclose the host in square
      * brackets:
      *
      * ```php
-     * $server = new TcpServer('[::1]:8080', $loop);
+     * $server = new React\Socket\TcpServer('[::1]:8080', $loop);
      * ```
      *
      * If the given URI is invalid, does not contain a port, any other scheme or if it
@@ -79,7 +79,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
      *
      * ```php
      * // throws InvalidArgumentException due to missing port
-     * $server = new TcpServer('127.0.0.1', $loop);
+     * $server = new React\Socket\TcpServer('127.0.0.1', $loop);
      * ```
      *
      * If the given URI appears to be valid, but listening on it fails (such as if port
@@ -87,10 +87,10 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * throw a `RuntimeException`:
      *
      * ```php
-     * $first = new TcpServer(8080, $loop);
+     * $first = new React\Socket\TcpServer(8080, $loop);
      *
      * // throws RuntimeException because port is already in use
-     * $second = new TcpServer(8080, $loop);
+     * $second = new React\Socket\TcpServer(8080, $loop);
      * ```
      *
      * Note that these error conditions may vary depending on your system and/or
@@ -102,7 +102,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * for the underlying stream socket resource like this:
      *
      * ```php
-     * $server = new TcpServer('[::1]:8080', $loop, array(
+     * $server = new React\Socket\TcpServer('[::1]:8080', $loop, array(
      *     'backlog' => 200,
      *     'so_reuseport' => true,
      *     'ipv6_v6only' => true

--- a/src/UnixServer.php
+++ b/src/UnixServer.php
@@ -12,7 +12,7 @@ use RuntimeException;
  * is responsible for accepting plaintext connections on unix domain sockets.
  *
  * ```php
- * $server = new UnixServer('unix:///tmp/app.sock', $loop);
+ * $server = new React\Socket\UnixServer('unix:///tmp/app.sock', $loop);
  * ```
  *
  * See also the `ServerInterface` for more details.
@@ -34,7 +34,7 @@ final class UnixServer extends EventEmitter implements ServerInterface
      * for more details.
      *
      * ```php
-     * $server = new UnixServer('unix:///tmp/app.sock', $loop);
+     * $server = new React\Socket\UnixServer('unix:///tmp/app.sock', $loop);
      * ```
      *
      * @param string        $path


### PR DESCRIPTION
This simple PR updates the documentation to use full class names with namespace consistently. This was raised in #179 and this PR merely applies this to all occurrences in the docs.

Supersedes / closes #179, thank you @Big-Shark for the initial version