### PR TITLE
Implement STARTTLS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.2",
-        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -17,7 +17,7 @@ use React\Stream\WritableStreamInterface;
  * @see ConnectionInterface
  * @internal
  */
-class Connection extends EventEmitter implements ConnectionInterface
+class Connection extends EventEmitter implements ExtConnectionInterface
 {
     /**
      * Internal flag whether this is a Unix domain socket (UDS) connection
@@ -26,19 +26,8 @@ class Connection extends EventEmitter implements ConnectionInterface
      */
     public $unix = false;
 
-    /**
-     * Internal flag whether encryption has been enabled on this connection
-     *
-     * Mostly used by internal StreamEncryption so that connection returns
-     * `tls://` scheme for encrypted connections instead of `tcp://`.
-     *
-     * @internal
-     */
-    public $encryptionEnabled = false;
-
-    /** @internal */
-    public $stream;
-
+    private $encryptionEnabled = false;
+    private $stream;
     private $input;
 
     public function __construct($resource, LoopInterface $loop)
@@ -169,5 +158,15 @@ class Connection extends EventEmitter implements ConnectionInterface
         }
 
         return ($this->encryptionEnabled ? 'tls' : 'tcp') . '://' . $address;
+    }
+
+    public function getStream()
+    {
+        return $this->stream;
+    }
+
+    public function setTLSEnabledFlag($flag)
+    {
+        $this->encryptionEnabled = $flag;
     }
 }

--- a/src/ExtConnectionInterface.php
+++ b/src/ExtConnectionInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace React\Socket;
+
+/**
+ * This is an extended connection interface,
+ * which allows to expose the underlying stream
+ * in a non-BC way. This interface will be removed
+ * in the next major release and merge into `ConnectionInterface`.
+ *
+ * However it is not exposed for arbitrary reasons.
+ * Most notably it is exposed to enable TLS.
+ */
+interface ExtConnectionInterface extends ConnectionInterface
+{
+    /**
+     * Returns the underlying stream.
+     * @return resource
+     */
+    public function getStream();
+
+    /**
+     * Sets the internal flag to specify whether
+     * TLS was enabled or not.
+     *
+     * This is used to return `tls://` or `tcp://` as scheme.
+     * @param bool $flag
+     * @return void
+     */
+    public function setTLSEnabledFlag($flag);
+}

--- a/src/LimitingServer.php
+++ b/src/LimitingServer.php
@@ -3,8 +3,6 @@
 namespace React\Socket;
 
 use Evenement\EventEmitter;
-use Exception;
-use OverflowException;
 
 /**
  * The `LimitingServer` decorator wraps a given `ServerInterface` and is responsible

--- a/src/SecureConnectorInterface.php
+++ b/src/SecureConnectorInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace React\Socket;
+
+/**
+ * The `SecureConnectorInterface` is responsible for establishing secure connections.
+ * It defines methods to enable and disable TLS onto a given connection.
+ *
+ * As it extends the `ConnectorInterface`, it provides all
+ * other features of a Connector as well.
+ *
+ * @see ConnectorInterface
+ */
+interface SecureConnectorInterface extends ConnectorInterface
+{
+    /**
+     * Enables TLS on the given connection.
+     * @param ExtConnectionInterface $connection
+     * @return \React\Promise\PromiseInterface
+     */
+    public function enableTLS(ExtConnectionInterface $connection);
+
+    /**
+     * Disables TLS on the given connection.
+     *
+     * Current PHP versions [update me!] report
+     * a successful TLS downgrade handshake as failure. As such
+     * this method MAY return false even though the TLS downgrade
+     * handshake was successful, however we do not have a way
+     * to guarantee that the handshake was successful.
+     *
+     * @param ExtConnectionInterface $connection
+     * @return \React\Promise\PromiseInterface
+     */
+    public function disableTLS(ExtConnectionInterface $connection);
+}

--- a/src/StreamEncryption.php
+++ b/src/StreamEncryption.php
@@ -4,8 +4,6 @@ namespace React\Socket;
 
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
-use RuntimeException;
-use UnexpectedValueException;
 
 /**
  * This class is considered internal and its API should not be relied upon
@@ -44,17 +42,17 @@ class StreamEncryption
         }
     }
 
-    public function enable(Connection $stream)
+    public function enable(ExtConnectionInterface $stream)
     {
         return $this->toggle($stream, true);
     }
 
-    public function disable(Connection $stream)
+    public function disable(ExtConnectionInterface $stream)
     {
         return $this->toggle($stream, false);
     }
 
-    public function toggle(Connection $stream, $toggle)
+    public function toggle(ExtConnectionInterface $stream, $toggle)
     {
         // pause actual stream instance to continue operation on raw stream socket
         $stream->pause();
@@ -67,7 +65,7 @@ class StreamEncryption
         });
 
         // get actual stream socket from stream instance
-        $socket = $stream->stream;
+        $socket = $stream->getStream();
 
         // get crypto method from context options or use global setting from constructor
         $method = $this->method;
@@ -92,7 +90,7 @@ class StreamEncryption
         return $deferred->promise()->then(function () use ($stream, $socket, $loop, $toggle) {
             $loop->removeReadStream($socket);
 
-            $stream->encryptionEnabled = $toggle;
+            $stream->setTLSEnabledFlag($toggle);
             $stream->resume();
 
             return $stream;

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -4,8 +4,6 @@ namespace React\Socket;
 
 use React\EventLoop\LoopInterface;
 use React\Promise;
-use InvalidArgumentException;
-use RuntimeException;
 
 final class TcpConnector implements ConnectorInterface
 {

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -16,10 +16,10 @@ use RuntimeException;
  * ```
  *
  * Whenever a client connects, it will emit a `connection` event with a connection
- * instance implementing `ConnectionInterface`:
+ * instance implementing `ExtConnectionInterface`:
  *
  * ```php
- * $server->on('connection', function (React\Socket\ConnectionInterface $connection) {
+ * $server->on('connection', function (React\Socket\ExtConnectionInterface $connection) {
  *     echo 'Plaintext connection from ' . $connection->getRemoteAddress() . PHP_EOL;
  *     $connection->write('hello there!' . PHP_EOL);
  *     …

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -44,4 +44,24 @@ class ConnectionTest extends TestCase
         $this->assertTrue($onRemove);
         $this->assertFalse(is_resource($resource));
     }
+
+    public function testGetStream()
+    {
+        $stream = fopen('php://memory', 'r+');
+        $conn = new Connection($stream, $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock());
+        $this->assertSame($stream, $conn->getStream());
+    }
+
+    public function testSetTLSEnabledFlag()
+    {
+        $stream = fopen('php://memory', 'r+');
+        $conn = new Connection($stream, $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock());
+
+        $reflection = new \ReflectionProperty($conn, 'encryptionEnabled');
+        $reflection->setAccessible(true);
+
+        $this->assertFalse($reflection->getValue($conn));
+        $conn->setTLSEnabledFlag(true);
+        $this->assertTrue($reflection->getValue($conn));
+    }
 }

--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -70,9 +70,8 @@ class FunctionalSecureServerTest extends TestCase
         $client = Block\await($promise, $loop, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Socket\Connection', $client);
-        $this->assertTrue(isset($client->stream));
 
-        $meta = stream_get_meta_data($client->stream);
+        $meta = stream_get_meta_data($client->getStream());
         $this->assertTrue(isset($meta['crypto']['protocol']));
 
         if ($meta['crypto']['protocol'] === 'UNKNOWN') {
@@ -108,9 +107,8 @@ class FunctionalSecureServerTest extends TestCase
         $client = Block\await($promise, $loop, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Socket\Connection', $client);
-        $this->assertTrue(isset($client->stream));
 
-        $meta = stream_get_meta_data($client->stream);
+        $meta = stream_get_meta_data($client->getStream());
         $this->assertTrue(isset($meta['crypto']['protocol']));
         $this->assertEquals('TLSv1.2', $meta['crypto']['protocol']);
     }
@@ -138,9 +136,8 @@ class FunctionalSecureServerTest extends TestCase
         $client = Block\await($promise, $loop, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Socket\Connection', $client);
-        $this->assertTrue(isset($client->stream));
 
-        $meta = stream_get_meta_data($client->stream);
+        $meta = stream_get_meta_data($client->getStream());
         $this->assertTrue(isset($meta['crypto']['protocol']));
         $this->assertEquals('TLSv1.2', $meta['crypto']['protocol']);
     }

--- a/tests/FunctionalTcpServerTest.php
+++ b/tests/FunctionalTcpServerTest.php
@@ -2,11 +2,12 @@
 
 namespace React\Tests\Socket;
 
-use React\EventLoop\Factory;
-use React\Socket\TcpServer;
-use React\Socket\ConnectionInterface;
-use React\Socket\TcpConnector;
 use Clue\React\Block;
+use React\EventLoop\Factory;
+use React\Socket\ConnectionInterface;
+use React\Socket\ExtConnectionInterface;
+use React\Socket\TcpConnector;
+use React\Socket\TcpServer;
 
 class FunctionalTcpServerTest extends TestCase
 {
@@ -268,8 +269,8 @@ class FunctionalTcpServerTest extends TestCase
         ));
 
         $all = null;
-        $server->on('connection', function (ConnectionInterface $conn) use (&$all) {
-            $all = stream_context_get_options($conn->stream);
+        $server->on('connection', function (ExtConnectionInterface $conn) use (&$all) {
+            $all = stream_context_get_options($conn->getStream());
         });
 
         $connector = new TcpConnector($loop);

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -8,6 +8,7 @@ use React\Socket\TcpConnector;
 use React\Socket\UnixConnector;
 use Clue\React\Block;
 use React\Socket\ConnectionInterface;
+use React\Socket\ExtConnectionInterface;
 
 class ServerTest extends TestCase
 {
@@ -161,8 +162,8 @@ class ServerTest extends TestCase
         ));
 
         $all = null;
-        $server->on('connection', function (ConnectionInterface $conn) use (&$all) {
-            $all = stream_context_get_options($conn->stream);
+        $server->on('connection', function (ExtConnectionInterface $conn) use (&$all) {
+            $all = stream_context_get_options($conn->getStream());
         });
 
         $client = stream_socket_client($server->getAddress());

--- a/tests/UnixConnectorTest.php
+++ b/tests/UnixConnectorTest.php
@@ -5,6 +5,9 @@ namespace React\Tests\Socket;
 use React\Socket\ConnectionInterface;
 use React\Socket\UnixConnector;
 
+/**
+ * @requires OSFAMILY (?!win)
+ */
 class UnixConnectorTest extends TestCase
 {
     private $loop;

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -7,6 +7,9 @@ use React\EventLoop\Factory;
 use React\Socket\UnixServer;
 use React\Stream\DuplexResourceStream;
 
+/**
+ * @requires OSFAMILY (?!win)
+ */
 class UnixServerTest extends TestCase
 {
     private $loop;
@@ -19,10 +22,6 @@ class UnixServerTest extends TestCase
      */
     public function setUp()
     {
-        if (!in_array('unix', stream_get_transports())) {
-            $this->markTestSkipped('Unix domain sockets (UDS) not supported on your platform (Windows?)');
-        }
-
         $this->loop = Factory::create();
         $this->uds = $this->getRandomSocketUri();
         $this->server = new UnixServer($this->uds, $this->loop);


### PR DESCRIPTION
This PR implements STARTTLS and exposes the connection stream in a non-BC way through a getter method. The added "extended" interfaces should be merged into the "regular" interfaces with the next major version.

Maybe some more documentation is needed in case of the usage/requirement of the extended connection interface instead of the regular interface (e.g. `SecureConnector::connect`).

Closes #89.