### PR TITLE
Work around failing test case detecting EOF on TLS 1.3 socket streams

### DIFF
--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -718,21 +718,4 @@ class FunctionalSecureServerTest extends TestCase
             });
         });
     }
-
-    private function supportsTls13()
-    {
-        // TLS 1.3 is supported as of OpenSSL 1.1.1 (https://www.openssl.org/blog/blog/2018/09/11/release111/)
-        // The OpenSSL library version can only be obtained by parsing output from phpinfo().
-        // OPENSSL_VERSION_TEXT refers to header version which does not necessarily match actual library version
-        // see php -i | grep OpenSSL
-        // OpenSSL Library Version => OpenSSL 1.1.1  11 Sep 2018
-        ob_start();
-        phpinfo(INFO_MODULES);
-        $info = ob_get_clean();
-
-        if (preg_match('/OpenSSL Library Version => OpenSSL (\S+)/', $info, $match)) {
-            return version_compare($match[1], '1.1.1', '>=');
-        }
-        return false;
-    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -98,4 +98,21 @@ class TestCase extends BaseTestCase
             parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
         }
     }
+
+    protected function supportsTls13()
+    {
+        // TLS 1.3 is supported as of OpenSSL 1.1.1 (https://www.openssl.org/blog/blog/2018/09/11/release111/)
+        // The OpenSSL library version can only be obtained by parsing output from phpinfo().
+        // OPENSSL_VERSION_TEXT refers to header version which does not necessarily match actual library version
+        // see php -i | grep OpenSSL
+        // OpenSSL Library Version => OpenSSL 1.1.1  11 Sep 2018
+        ob_start();
+        phpinfo(INFO_MODULES);
+        $info = ob_get_clean();
+
+        if (preg_match('/OpenSSL Library Version => OpenSSL ([\d\.]+)/', $info, $match)) {
+            return version_compare($match[1], '1.1.1', '>=');
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
This PR improves the test suite to avoid a possible race condition for
our TLS tests. It does not change anything about the actual behavior or
the expected output, but it helps making the expected output more
explicit and no longer subject to a possible race condition. This helps
avoiding possible false negatives if TLS 1.3 is supported and PHP
reports the EOF indicator before consuming all application data.

This builds on top of https://github.com/reactphp/socket/pull/185 and https://github.com/reactphp/socket/pull/186