### PR TITLE
Avoid uneeded fragmented TLS work around for PHP 7.3.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1372,6 +1372,15 @@ This library does not take responsibility over these context options, so it's
 up to consumers of this library to take care of setting appropriate context
 options as described above.
 
+PHP < 7.3.3 (and PHP < 7.2.15) suffers from a bug where feof() might
+block with 100% CPU usage on fragmented TLS records.
+We try to work around this by always consuming the complete receive
+buffer at once to avoid stale data in TLS buffers. This is known to
+work around high CPU usage for well-behaving peers, but this may
+cause very large data chunks for high throughput scenarios. The buggy
+behavior can still be triggered due to network I/O buffers or
+malicious peers on affected versions, upgrading is highly recommended.
+
 PHP < 7.1.4 (and PHP < 7.0.18) suffers from a bug when writing big
 chunks of data over TLS streams at once.
 We try to work around this by limiting the write chunk size to 8192


### PR DESCRIPTION
The work around was introduced in order to bring TLS 1.3 support to all
supported versions, but at the same time it may cause very large data
chunks for high throughput scenarios. The underlying bug has been fixed
in PHP 7.3.3 and PHP 7.2.15, so we can avoid this now uneeded work
around on said version.

Reproduction is not exactly trivial unfortunately. Prior to #186, older PHP version would simply consume 100% CPU usage when using an otherwise perfectly valid TLS 1.3 connection when the remote peer did not send any data (common for HTTPS). After applying #186 this bug has been avoided on all supported versions, including older PHP versions. However, at the same time it may cause very large data chunks for high throughput scenarios. In other words, when downloading large files over HTTPS, it would start emitting chunks of data that could be multiple megabytes large which has a significant performance hit. Now that the underlying bug in PHP has been fixed with PHP 7.3.3 and PHP 7.2.15, we do not need this work around from #186 anymore. As such, we now have proper TLS 1.3 support with reasonable data chunks on recent PHP versions and still have a work around for TLS 1.3 on older PHP versions.

Builds on top of #201 and #186
See https://bugs.php.net/bug.php?id=77390