### PR TITLE
Accept DNS `ResolverInterface` and fix failing test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,8 +958,8 @@ $connector->connect('127.0.0.1:80')->then(function (React\Socket\ConnectionInter
 });
 ```
 
-Advanced: If you need a custom DNS `Resolver` instance, you can also set up
-your `Connector` like this:
+Advanced: If you need a custom DNS `React\Dns\Resolver\ResolverInterface` instance, you
+can also set up your `Connector` like this:
 
 ```php
 $dnsResolverFactory = new React\Dns\Resolver\Factory();
@@ -1193,8 +1193,8 @@ $promise->cancel();
 Calling `cancel()` on a pending promise will cancel the underlying DNS lookup
 and/or the underlying TCP/IP connection and reject the resulting promise.
 
-> Advanced usage: Internally, the `DnsConnector` relies on a `Resolver` to
-look up the IP address for the given hostname.
+> Advanced usage: Internally, the `DnsConnector` relies on a `React\Dns\Resolver\ResolverInterface`
+to look up the IP address for the given hostname.
 It will then replace the hostname in the destination URI with this IP and
 append a `hostname` query parameter and pass this updated URI to the underlying
 connector.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/dns": "^1.0 || ^0.4.13",
+        "react/dns": "^1.1",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
         "react/promise": "^2.6.0 || ^1.2.1",
         "react/promise-timer": "^1.4.0",

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -2,12 +2,10 @@
 
 namespace React\Socket;
 
-use React\Dns\Config\Config;
-use React\Dns\Resolver\Factory;
-use React\Dns\Resolver\Resolver;
+use React\Dns\Config\Config as DnsConfig;
+use React\Dns\Resolver\Factory as DnsFactory;
+use React\Dns\Resolver\ResolverInterface;
 use React\EventLoop\LoopInterface;
-use React\Promise;
-use RuntimeException;
 
 /**
  * The `Connector` class is the main class in this package that implements the
@@ -54,18 +52,18 @@ final class Connector implements ConnectorInterface
         }
 
         if ($options['dns'] !== false) {
-            if ($options['dns'] instanceof Resolver) {
+            if ($options['dns'] instanceof ResolverInterface) {
                 $resolver = $options['dns'];
             } else {
                 if ($options['dns'] !== true) {
                     $server = $options['dns'];
                 } else {
                     // try to load nameservers from system config or default to Google's public DNS
-                    $config = Config::loadSystemConfigBlocking();
+                    $config = DnsConfig::loadSystemConfigBlocking();
                     $server = $config->nameservers ? \reset($config->nameservers) : '8.8.8.8';
                 }
 
-                $factory = new Factory();
+                $factory = new DnsFactory();
                 $resolver = $factory->create(
                     $server,
                     $loop
@@ -125,7 +123,7 @@ final class Connector implements ConnectorInterface
         }
 
         if (!isset($this->connectors[$scheme])) {
-            return Promise\reject(new \RuntimeException(
+            return \React\Promise\reject(new \RuntimeException(
                 'No connector available for URI scheme "' . $scheme . '"'
             ));
         }

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -2,18 +2,16 @@
 
 namespace React\Socket;
 
-use React\Dns\Resolver\Resolver;
+use React\Dns\Resolver\ResolverInterface;
 use React\Promise;
 use React\Promise\CancellablePromiseInterface;
-use InvalidArgumentException;
-use RuntimeException;
 
 final class DnsConnector implements ConnectorInterface
 {
     private $connector;
     private $resolver;
 
-    public function __construct(ConnectorInterface $connector, Resolver $resolver)
+    public function __construct(ConnectorInterface $connector, ResolverInterface $resolver)
     {
         $this->connector = $connector;
         $this->resolver = $resolver;

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -96,7 +96,7 @@ class ConnectorTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
         $promise = new Promise(function () { });
-        $resolver = $this->getMockBuilder('React\Dns\Resolver\Resolver')->disableOriginalConstructor()->getMock();
+        $resolver = $this->getMockBuilder('React\Dns\Resolver\ResolverInterface')->getMock();
         $resolver->expects($this->once())->method('resolve')->with('google.com')->willReturn($promise);
 
         $connector = new Connector($loop, array(
@@ -111,7 +111,7 @@ class ConnectorTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
         $promise = new Promise(function ($resolve) { $resolve('127.0.0.1'); });
-        $resolver = $this->getMockBuilder('React\Dns\Resolver\Resolver')->disableOriginalConstructor()->getMock();
+        $resolver = $this->getMockBuilder('React\Dns\Resolver\ResolverInterface')->getMock();
         $resolver->expects($this->once())->method('resolve')->with('google.com')->willReturn($promise);
 
         $promise = new Promise(function () { });

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -15,7 +15,7 @@ class DnsConnectorTest extends TestCase
     public function setUp()
     {
         $this->tcp = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-        $this->resolver = $this->getMockBuilder('React\Dns\Resolver\Resolver')->disableOriginalConstructor()->getMock();
+        $this->resolver = $this->getMockBuilder('React\Dns\Resolver\ResolverInterface')->getMock();
 
         $this->connector = new DnsConnector($this->tcp, $this->resolver);
     }


### PR DESCRIPTION
As of https://github.com/reactphp/dns/pull/134, all DNS classes are marked as `final`, including the `Resolver` class which is most commonly used in consuming packages. This changeset adjusts our connectors to accept the `ResolverInterface` interface as the common interface into this class and also adjust tests to use this interface for mocking. This is not a BC break because the interface is strictly compatible with the original `Resolver` behavior.

Resolves https://github.com/reactphp/socket/issues/207
Builds on top of https://github.com/reactphp/dns/pull/139 and https://github.com/reactphp/dns/pull/134