### PR TITLE
Avoid failing test by using invalid DNS resolver IP instead of hostname

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -99,12 +99,12 @@ class IntegrationTest extends TestCase
         $this->assertNotRegExp('#^HTTP/1\.0#', $response);
     }
 
-    public function testConnectingFailsIfDnsUsesInvalidResolver()
+    public function testConnectingFailsIfConnectorUsesInvalidDnsResolverAddress()
     {
         $loop = Factory::create();
 
         $factory = new ResolverFactory();
-        $dns = $factory->create('demo.invalid', $loop);
+        $dns = $factory->create('255.255.255.255', $loop);
 
         $connector = new Connector($loop, array(
             'dns' => $dns


### PR DESCRIPTION
This simple changeset avoids a failing test by now using an invalid DNS resolver IP instead of an invalid hostname.

Refs https://github.com/reactphp/dns/pull/146