### PR TITLE
EOF check on invalid resource

### DIFF
--- a/src/StreamEncryption.php
+++ b/src/StreamEncryption.php
@@ -127,7 +127,7 @@ class StreamEncryption
             $d = $deferred;
             $deferred = null;
 
-            if (\feof($socket) || $error === null) {
+            if ($error === null || (\is_resource($socket) && \feof($socket))) {
                 // EOF or failed without error => connection closed during handshake
                 $d->reject(new \UnexpectedValueException(
                     'Connection lost during TLS handshake',


### PR DESCRIPTION
During the debugging of TLS support for a MySQL driver, I've encountered a SSL error which made the stream resource close and thus emit an error when we checked whether there's an EOF.

Error on `feof` was `supplied resource is not a valid stream resource` due to `stream_socket_enable_crypto` already failing with the error `An existing connection was forcibly closed by the remote host`.

This PR therefore only checks EOF if the resource is still valid.