### PR TITLE
Improve test suite to exclude TLS 1.3 tests on PHP 7.3

### DIFF
--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -50,8 +50,11 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testClientUsesTls13ByDefaultWhenSupportedByOpenSSL()
     {
-        if (PHP_VERSION_ID < 70000 || !$this->supportsTls13()) {
-            $this->markTestSkipped('Test requires PHP 7+ for crypto meta data and OpenSSL 1.1.1+ for TLS 1.3');
+        if (PHP_VERSION_ID < 70000 || (PHP_VERSION_ID >= 70300 && PHP_VERSION_ID < 70400) || !$this->supportsTls13()) {
+            // @link https://github.com/php/php-src/pull/3909 explicitly adds TLS 1.3 on PHP 7.4
+            // @link https://github.com/php/php-src/pull/3317 implicitly limits to TLS 1.2 on PHP 7.3
+            // all older PHP versions support TLS 1.3 (provided OpenSSL supports it), but only PHP 7 allows checking the version
+            $this->markTestSkipped('Test requires PHP 7+ for crypto meta data (but excludes PHP 7.3 because it implicitly limits to TLS 1.2) and OpenSSL 1.1.1+ for TLS 1.3');
         }
 
         $loop = Factory::create();


### PR DESCRIPTION
Explicit TLS 1.3 support will be available in PHP 7.4: https://github.com/php/php-src/pull/3909

Older PHP versions implicitly support TLS 1.3 provided that the
underlying OpenSSL version supports TLS 1.3. However, for PHP 7.3 some
(not so) recent changes implicitly disable TLS 1.3, so we skip TLS 1.3 tests on
affected PHP versions: https://github.com/php/php-src/pull/3317

Builds on top of #186, #201 and #202
Noticed this due to a build error while working on https://github.com/reactphp/reactphp/pull/432