### PR TITLE
Minor code style fix for stream_set_blocking() parameter type

### DIFF
--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -163,7 +163,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
         if (false === $this->master) {
             throw new \RuntimeException('Failed to listen on "' . $uri . '": ' . $errstr, $errno);
         }
-        \stream_set_blocking($this->master, 0);
+        \stream_set_blocking($this->master, false);
 
         $this->resume();
     }


### PR DESCRIPTION
To be strict, the second parameter of this function is a `bool` instead of an `int`.