### PR TITLE
Make happy eyeballs algorithm (IPv6) the default, add new `happy_eyeballs` option to `Connector`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,7 +1061,7 @@ pass an instance implementing the `ConnectorInterface` like this:
 ```php
 $dnsResolverFactory = new React\Dns\Resolver\Factory();
 $resolver = $dnsResolverFactory->createCached('127.0.1.1', $loop);
-$tcp = new React\Socket\DnsConnector(new React\Socket\TcpConnector($loop), $resolver);
+$tcp = new React\Socket\HappyEyeBallsConnector($loop, new React\Socket\TcpConnector($loop), $resolver);
 
 $tls = new React\Socket\SecureConnector($tcp, $loop);
 
@@ -1093,6 +1093,17 @@ $connector->connect('google.com:80')->then(function (React\Socket\ConnectionInte
   explicitly pass a `tls://` connector like above instead.
   Internally, the `tcp://` and `tls://` connectors will always be wrapped by
   `TimeoutConnector`, unless you disable timeouts like in the above example.
+
+> Internally the `HappyEyeBallsConnector` has replaced the `DnsConnector` as default 
+  resolving connector. It is still available as `Connector` has a new option, namely 
+  `happy_eyeballs`, to control which of the two will be used. By default it's `true` 
+  and will use `HappyEyeBallsConnector`, when set to `false` `DnsConnector` is used. 
+  We only recommend doing so when there are any backwards compatible issues on older 
+  systems only supporting IPv4. The `HappyEyeBallsConnector` implements most of 
+  RFC6555 and RFC8305 and will use concurrency to connect to the remote host by
+  attempting to connect over both IPv4 and IPv6 with a priority for IPv6 when 
+  available. Which ever connection attempt succeeds first will be used, the rest 
+  connection attempts will be canceled.
 
 ### Advanced client usage
 

--- a/README.md
+++ b/README.md
@@ -927,6 +927,22 @@ also shares all of their features and implementation details.
 If you want to typehint in your higher-level protocol implementation, you SHOULD
 use the generic [`ConnectorInterface`](#connectorinterface) instead.
 
+As of `v1.4.0`, the `Connector` class defaults to using the
+[happy eyeballs algorithm](https://en.wikipedia.org/wiki/Happy_Eyeballs) to
+automatically connect over IPv4 or IPv6 when a hostname is given.
+This automatically attempts to connect using both IPv4 and IPv6 at the same time
+(preferring IPv6), thus avoiding the usual problems faced by users with imperfect
+IPv6 connections or setups.
+If you want to revert to the old behavior of only doing an IPv4 lookup and
+only attempt a single IPv4 connection, you can set up the `Connector` like this:
+
+```php
+$connector = new React\Socket\Connector($loop, array(
+    'happy_eyeballs' => false
+));
+```
+
+Similarly, you can also affect the default DNS behavior as follows.
 The `Connector` class will try to detect your system DNS settings (and uses
 Google's public DNS server `8.8.8.8` as a fallback if unable to determine your
 system settings) to resolve all public hostnames into underlying IP addresses by
@@ -977,7 +993,7 @@ $connector->connect('localhost:80')->then(function (React\Socket\ConnectionInter
 ```
 
 By default, the `tcp://` and `tls://` URI schemes will use timeout value that
-repects your `default_socket_timeout` ini setting (which defaults to 60s).
+respects your `default_socket_timeout` ini setting (which defaults to 60s).
 If you want a custom timeout value, you can simply pass this like this:
 
 ```php
@@ -1093,17 +1109,6 @@ $connector->connect('google.com:80')->then(function (React\Socket\ConnectionInte
   explicitly pass a `tls://` connector like above instead.
   Internally, the `tcp://` and `tls://` connectors will always be wrapped by
   `TimeoutConnector`, unless you disable timeouts like in the above example.
-
-> Internally the `HappyEyeBallsConnector` has replaced the `DnsConnector` as default 
-  resolving connector. It is still available as `Connector` has a new option, namely 
-  `happy_eyeballs`, to control which of the two will be used. By default it's `true` 
-  and will use `HappyEyeBallsConnector`, when set to `false` `DnsConnector` is used. 
-  We only recommend doing so when there are any backwards compatible issues on older 
-  systems only supporting IPv4. The `HappyEyeBallsConnector` implements most of 
-  RFC6555 and RFC8305 and will use concurrency to connect to the remote host by
-  attempting to connect over both IPv4 and IPv6 with a priority for IPv6 when 
-  available. Which ever connection attempt succeeds first will be used, the rest 
-  connection attempts will be canceled.
 
 ### Advanced client usage
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     },
     "require-dev": {
         "clue/block-react": "^1.2",
-        "phpunit/phpunit": "^7.5 || ^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^7.5 || ^6.4 || ^5.7 || ^4.8.35",
+        "react/promise-stream": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -36,6 +36,7 @@ final class Connector implements ConnectorInterface
 
             'dns' => true,
             'timeout' => true,
+            'happy_eyeballs' => \PHP_VERSION_ID < 70000 ? false : true,
         );
 
         if ($options['timeout'] === true) {
@@ -70,7 +71,11 @@ final class Connector implements ConnectorInterface
                 );
             }
 
-            $tcp = new DnsConnector($tcp, $resolver);
+            if ($options['happy_eyeballs'] === true) {
+                $tcp = new HappyEyeBallsConnector($loop, $tcp, $resolver);
+            } else {
+                $tcp = new DnsConnector($tcp, $resolver);
+            }
         }
 
         if ($options['tcp'] !== false) {

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -36,7 +36,7 @@ final class Connector implements ConnectorInterface
 
             'dns' => true,
             'timeout' => true,
-            'happy_eyeballs' => \PHP_VERSION_ID < 70000 ? false : true,
+            'happy_eyeballs' => true,
         );
 
         if ($options['timeout'] === true) {

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -100,7 +100,8 @@ class ConnectorTest extends TestCase
         $resolver->expects($this->once())->method('resolve')->with('google.com')->willReturn($promise);
 
         $connector = new Connector($loop, array(
-            'dns' => $resolver
+            'dns' => $resolver,
+            'happy_eyeballs' => false,
         ));
 
         $connector->connect('google.com:80');
@@ -120,7 +121,8 @@ class ConnectorTest extends TestCase
 
         $connector = new Connector($loop, array(
             'tcp' => $tcp,
-            'dns' => $resolver
+            'dns' => $resolver,
+            'happy_eyeballs' => false,
         ));
 
         $connector->connect('tcp://google.com:80');

--- a/tests/FunctionalConnectorTest.php
+++ b/tests/FunctionalConnectorTest.php
@@ -4,12 +4,17 @@ namespace React\Tests\Socket;
 
 use Clue\React\Block;
 use React\EventLoop\Factory;
+use React\Socket\ConnectionInterface;
 use React\Socket\Connector;
+use React\Socket\ConnectorInterface;
 use React\Socket\TcpServer;
 
 class FunctionalConnectorTest extends TestCase
 {
-    const TIMEOUT = 1.0;
+    const TIMEOUT = 30.0;
+
+    private $ipv4;
+    private $ipv6;
 
     /** @test */
     public function connectionToTcpServerShouldSucceedWithLocalhost()
@@ -28,5 +33,175 @@ class FunctionalConnectorTest extends TestCase
 
         $connection->close();
         $server->close();
+    }
+
+    /**
+     * @test
+     * @group internet
+     */
+    public function connectionToRemoteTCP4n6ServerShouldResultInOurIP()
+    {
+        $loop = Factory::create();
+
+        $connector = new Connector($loop, array('happy_eyeballs' => true));
+
+        $ip = Block\await($this->request('dual.tlund.se', $connector), $loop, self::TIMEOUT);
+
+        $this->assertSame($ip, filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6), $ip);
+    }
+
+    /**
+     * @test
+     * @group internet
+     */
+    public function connectionToRemoteTCP4ServerShouldResultInOurIP()
+    {
+        if ($this->ipv4() === false) {
+            // IPv4 not supported on this system
+            $this->assertFalse($this->ipv4());
+            return;
+        }
+
+        $loop = Factory::create();
+
+        $connector = new Connector($loop, array('happy_eyeballs' => true));
+
+        $ip = Block\await($this->request('ipv4.tlund.se', $connector), $loop, self::TIMEOUT);
+
+        $this->assertSame($ip, filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4), $ip);
+        $this->assertFalse(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6), $ip);
+    }
+
+    /**
+     * @test
+     * @group internet
+     */
+    public function connectionToRemoteTCP6ServerShouldResultInOurIP()
+    {
+        if ($this->ipv6() === false) {
+            // IPv6 not supported on this system
+            $this->assertFalse($this->ipv6());
+            return;
+        }
+
+        $loop = Factory::create();
+
+        $connector = new Connector($loop, array('happy_eyeballs' => true));
+
+        $ip = Block\await($this->request('ipv6.tlund.se', $connector), $loop, self::TIMEOUT);
+
+        $this->assertFalse(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4), $ip);
+        $this->assertSame($ip, filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6), $ip);
+    }
+
+    /**
+     * @test
+     * @group internet
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessageRegExp /Connection to ipv6.tlund.se:80 failed/
+     */
+    public function tryingToConnectToAnIPv6OnlyHostWithOutHappyEyeBallsShouldResultInFailure()
+    {
+        $loop = Factory::create();
+
+        $connector = new Connector($loop, array('happy_eyeballs' => false));
+
+        Block\await($this->request('ipv6.tlund.se', $connector), $loop, self::TIMEOUT);
+    }
+
+    /**
+     * @test
+     * @group internet
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessageRegExp /Connection to tcp:\/\/193.15.228.195:80 failed:/
+     */
+    public function connectingDirectlyToAnIPv4AddressShouldFailWhenIPv4IsntAvailable()
+    {
+        if ($this->ipv4() === true) {
+            // IPv4 supported on this system
+            throw new \RuntimeException('Connection to tcp://193.15.228.195:80 failed:');
+        }
+
+        $loop = Factory::create();
+
+        $connector = new Connector($loop);
+
+        $host = current(dns_get_record('ipv4.tlund.se', DNS_A));
+        $host = $host['ip'];
+        Block\await($this->request($host, $connector), $loop, self::TIMEOUT);
+    }
+
+    /**
+     * @test
+     * @group internet
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessageRegExp /Connection to tcp:\/\/\[2a00:801:f::195\]:80 failed:/
+     */
+    public function connectingDirectlyToAnIPv6AddressShouldFailWhenIPv6IsntAvailable()
+    {
+        if ($this->ipv6() === true) {
+            // IPv6 supported on this system
+            throw new \RuntimeException('Connection to tcp://[2a00:801:f::195]:80 failed:');
+        }
+
+        $loop = Factory::create();
+
+        $connector = new Connector($loop);
+
+        $host = current(dns_get_record('ipv6.tlund.se', DNS_AAAA));
+        $host = $host['ipv6'];
+        $host = '[' . $host . ']';
+        $ip = Block\await($this->request($host, $connector), $loop, self::TIMEOUT);
+
+        $this->assertFalse(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4), $ip);
+        $this->assertSame($ip, filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6), $ip);
+    }
+
+    /**
+     * @internal
+     */
+    public function parseIpFromPage($body)
+    {
+        $ex = explode('title="Look up on bgp.he.net">', $body);
+        $ex = explode('<', $ex[1]);
+
+        return $ex[0];
+    }
+
+    private function request($host, ConnectorInterface $connector)
+    {
+        $that = $this;
+        return $connector->connect($host . ':80')->then(function (ConnectionInterface $connection) use ($host) {
+            $connection->write("GET / HTTP/1.1\r\nHost: " . $host . "\r\n\r\n");
+
+            return \React\Promise\Stream\buffer($connection);
+        })->then(function ($response) use ($that) {
+            return $that->parseIpFromPage($response);
+        });
+    }
+
+    private function ipv4()
+    {
+        if ($this->ipv4 !== null) {
+            return $this->ipv4;
+        }
+
+        $this->ipv4 = !!@file_get_contents('http://ipv4.tlund.se/');
+
+        return $this->ipv4;
+    }
+
+    private function ipv6()
+    {
+        if ($this->ipv6 !== null) {
+            return $this->ipv6;
+        }
+
+        $this->ipv6 = !!@file_get_contents('http://ipv6.tlund.se/');
+
+        return $this->ipv6;
     }
 }

--- a/tests/FunctionalConnectorTest.php
+++ b/tests/FunctionalConnectorTest.php
@@ -57,9 +57,7 @@ class FunctionalConnectorTest extends TestCase
     public function connectionToRemoteTCP4ServerShouldResultInOurIP()
     {
         if ($this->ipv4() === false) {
-            // IPv4 not supported on this system
-            $this->assertFalse($this->ipv4());
-            return;
+            $this->markTestSkipped('IPv4 connection not supported on this system');
         }
 
         $loop = Factory::create();
@@ -79,9 +77,7 @@ class FunctionalConnectorTest extends TestCase
     public function connectionToRemoteTCP6ServerShouldResultInOurIP()
     {
         if ($this->ipv6() === false) {
-            // IPv6 not supported on this system
-            $this->assertFalse($this->ipv6());
-            return;
+            $this->markTestSkipped('IPv6 connection not supported on this system');
         }
 
         $loop = Factory::create();
@@ -89,72 +85,6 @@ class FunctionalConnectorTest extends TestCase
         $connector = new Connector($loop, array('happy_eyeballs' => true));
 
         $ip = Block\await($this->request('ipv6.tlund.se', $connector), $loop, self::TIMEOUT);
-
-        $this->assertFalse(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4), $ip);
-        $this->assertSame($ip, filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6), $ip);
-    }
-
-    /**
-     * @test
-     * @group internet
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessageRegExp /Connection to ipv6.tlund.se:80 failed/
-     */
-    public function tryingToConnectToAnIPv6OnlyHostWithOutHappyEyeBallsShouldResultInFailure()
-    {
-        $loop = Factory::create();
-
-        $connector = new Connector($loop, array('happy_eyeballs' => false));
-
-        Block\await($this->request('ipv6.tlund.se', $connector), $loop, self::TIMEOUT);
-    }
-
-    /**
-     * @test
-     * @group internet
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessageRegExp /Connection to tcp:\/\/193.15.228.195:80 failed:/
-     */
-    public function connectingDirectlyToAnIPv4AddressShouldFailWhenIPv4IsntAvailable()
-    {
-        if ($this->ipv4() === true) {
-            // IPv4 supported on this system
-            throw new \RuntimeException('Connection to tcp://193.15.228.195:80 failed:');
-        }
-
-        $loop = Factory::create();
-
-        $connector = new Connector($loop);
-
-        $host = current(dns_get_record('ipv4.tlund.se', DNS_A));
-        $host = $host['ip'];
-        Block\await($this->request($host, $connector), $loop, self::TIMEOUT);
-    }
-
-    /**
-     * @test
-     * @group internet
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessageRegExp /Connection to tcp:\/\/\[2a00:801:f::195\]:80 failed:/
-     */
-    public function connectingDirectlyToAnIPv6AddressShouldFailWhenIPv6IsntAvailable()
-    {
-        if ($this->ipv6() === true) {
-            // IPv6 supported on this system
-            throw new \RuntimeException('Connection to tcp://[2a00:801:f::195]:80 failed:');
-        }
-
-        $loop = Factory::create();
-
-        $connector = new Connector($loop);
-
-        $host = current(dns_get_record('ipv6.tlund.se', DNS_AAAA));
-        $host = $host['ipv6'];
-        $host = '[' . $host . ']';
-        $ip = Block\await($this->request($host, $connector), $loop, self::TIMEOUT);
 
         $this->assertFalse(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4), $ip);
         $this->assertSame($ip, filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6), $ip);

--- a/tests/HappyEyeBallsConnectionBuilderTest.php
+++ b/tests/HappyEyeBallsConnectionBuilderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace React\Tests\Socket;
+
+use React\Promise\Promise;
+use React\Socket\HappyEyeBallsConnectionBuilder;
+
+class HappyEyeBallsConnectionBuilderTest extends TestCase
+{
+    public function testAttemptConnectionWillConnectViaConnectorToGivenIpWithPortAndHostnameFromUriParts()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('tcp://10.1.1.1:80?hostname=reactphp.org')->willReturn(new Promise(function () { }));
+
+        $resolver = $this->getMockBuilder('React\Dns\Resolver\ResolverInterface')->getMock();
+        $resolver->expects($this->never())->method('resolveAll');
+
+        $uri = 'tcp://reactphp.org:80';
+        $host = 'reactphp.org';
+        $parts = parse_url($uri);
+
+        $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
+
+        $builder->attemptConnection('10.1.1.1');
+    }
+
+    public function testAttemptConnectionWillConnectViaConnectorToGivenIpv6WithAllUriParts()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('tcp://[::1]:80/path?test=yes&hostname=reactphp.org#start')->willReturn(new Promise(function () { }));
+
+        $resolver = $this->getMockBuilder('React\Dns\Resolver\ResolverInterface')->getMock();
+        $resolver->expects($this->never())->method('resolveAll');
+
+        $uri = 'tcp://reactphp.org:80/path?test=yes#start';
+        $host = 'reactphp.org';
+        $parts = parse_url($uri);
+
+        $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
+
+        $builder->attemptConnection('::1');
+    }
+}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -203,7 +203,7 @@ class IntegrationTest extends TestCase
             }
         );
 
-        // run loop for short period to ensure we detect connection timeout error
+        // run loop for short period to ensure we detect a connection timeout error
         Block\sleep(0.01, $loop);
         if ($wait) {
             Block\sleep(0.2, $loop);
@@ -236,7 +236,7 @@ class IntegrationTest extends TestCase
             }
         );
 
-        // run loop for short period to ensure we detect connection timeout error
+        // run loop for short period to ensure we detect a connection timeout error
         Block\sleep(0.01, $loop);
         if ($wait) {
             Block\sleep(0.2, $loop);
@@ -269,12 +269,15 @@ class IntegrationTest extends TestCase
             }
         );
 
-        // run loop for short period to ensure we detect DNS error
+        // run loop for short period to ensure we detect a DNS error
         Block\sleep(0.01, $loop);
         if ($wait) {
             Block\sleep(0.2, $loop);
             if ($wait) {
-                $this->fail('Connection attempt did not fail');
+                Block\sleep(2.0, $loop);
+                if ($wait) {
+                    $this->fail('Connection attempt did not fail');
+                }
             }
         }
         unset($promise);
@@ -309,12 +312,15 @@ class IntegrationTest extends TestCase
             }
         );
 
-        // run loop for short period to ensure we detect DNS error
+        // run loop for short period to ensure we detect a TLS error
         Block\sleep(0.1, $loop);
         if ($wait) {
             Block\sleep(0.4, $loop);
             if ($wait) {
-                $this->fail('Connection attempt did not fail');
+                Block\sleep(self::TIMEOUT - 0.5, $loop);
+                if ($wait) {
+                    $this->fail('Connection attempt did not fail');
+                }
             }
         }
         unset($promise);


### PR DESCRIPTION
The `Connector` class now defaults to using the
[happy eyeballs algorithm](https://en.wikipedia.org/wiki/Happy_Eyeballs) to
automatically connect over IPv4 or IPv6 when a hostname is given.
This automatically attempts to connect using both IPv4 and IPv6 at the same time
(preferring IPv6), thus avoiding the usual problems faced by users with imperfect
IPv6 connections or setups.
If you want to revert to the old behavior of only doing an IPv4 lookup and
only attempt a single IPv4 connection, you can set up the `Connector` like this:

```php
$connector = new React\Socket\Connector($loop, array(
    'happy_eyeballs' => false
));
```

Supersedes / closes #216, thanks @WyriHaximus for the original version. On top of this, I've resolved a garbage reference in legacy PHP by avoiding some unneeded promise wrapping and simplifying this logic slightly.