### PR TITLE
Default to using DNS cache (with max 256 entries) for Connector

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -65,7 +65,7 @@ final class Connector implements ConnectorInterface
                 }
 
                 $factory = new DnsFactory();
-                $resolver = $factory->create(
+                $resolver = $factory->createCached(
                     $server,
                     $loop
                 );


### PR DESCRIPTION
Resolves / closes #115
Builds on top of https://github.com/reactphp/dns/pull/127 and https://github.com/reactphp/cache/pull/26