### PR TITLE
Improve error reporting when DNS lookup fails (happy eyeballs)

### DIFF
--- a/tests/HappyEyeBallsConnectorTest.php
+++ b/tests/HappyEyeBallsConnectorTest.php
@@ -176,7 +176,7 @@ class HappyEyeBallsConnectorTest extends TestCase
         $this->connector->connect('scheme://google.com:80/?hostname=google.com');
 
         $this->loop->addTimer(0.07, function () use ($deferred) {
-            $deferred->reject();
+            $deferred->reject(new \RuntimeException());
         });
 
         $this->loop->run();
@@ -196,7 +196,7 @@ class HappyEyeBallsConnectorTest extends TestCase
         $this->connector->connect('scheme://google.com:80/?hostname=google.com');
 
         $this->loop->addTimer(0.07, function () use ($deferred) {
-            $deferred->reject();
+            $deferred->reject(new \RuntimeException());
         });
 
         $this->loop->run();


### PR DESCRIPTION
Improve error reporting when DNS lookup fails (happy eyeballs). The rejection message now always contains the underlying DNS error message with more details.

Also fixes a fatal error with legacy PHP 5 where it would fail with a
(catchable) fatal error when either DNS lookup fails. During test runs,
this would automatically be turned into an Exception and would
successfully reject the promise. Without an appropriate error handler, a
soft DNS error (such as when IPv6 is not available) would previously
terminate the program with a fatal error.

Builds on top of #224 and #225
Refs #171 and others