### PR TITLE
Immediately try next connection when one attempt fails and fix possible race conditions (happy eyeballs)

### DIFF
--- a/src/HappyEyeBallsConnectionBuilder.php
+++ b/src/HappyEyeBallsConnectionBuilder.php
@@ -145,16 +145,20 @@ final class HappyEyeBallsConnectionBuilder
     {
         $ip = \array_shift($this->connectQueue);
 
+        // start connection attempt and remember array position to later unset again
+        $this->connectionPromises[] = $this->attemptConnection($ip);
+        \end($this->connectionPromises);
+        $index = \key($this->connectionPromises);
+
         $that = $this;
-        $that->connectionPromises[$ip] = $this->attemptConnection($ip);
-        $that->connectionPromises[$ip]->then(function ($connection) use ($that, $ip, $resolve) {
-            unset($that->connectionPromises[$ip]);
+        $that->connectionPromises[$index]->then(function ($connection) use ($that, $index, $resolve) {
+            unset($that->connectionPromises[$index]);
 
             $that->cleanUp();
 
             $resolve($connection);
-        }, function (\Exception $e) use ($that, $ip, $resolve, $reject) {
-            unset($that->connectionPromises[$ip]);
+        }, function (\Exception $e) use ($that, $index, $resolve, $reject) {
+            unset($that->connectionPromises[$index]);
 
             $that->failureCount++;
 

--- a/src/HappyEyeBallsConnectionBuilder.php
+++ b/src/HappyEyeBallsConnectionBuilder.php
@@ -146,7 +146,8 @@ final class HappyEyeBallsConnectionBuilder
         $ip = \array_shift($this->connectQueue);
 
         $that = $this;
-        $that->connectionPromises[$ip] = $this->attemptConnection($ip)->then(function ($connection) use ($that, $ip, $resolve) {
+        $that->connectionPromises[$ip] = $this->attemptConnection($ip);
+        $that->connectionPromises[$ip]->then(function ($connection) use ($that, $ip, $resolve) {
             unset($that->connectionPromises[$ip]);
 
             $that->cleanUp();
@@ -180,7 +181,7 @@ final class HappyEyeBallsConnectionBuilder
 
         // Allow next connection attempt in 100ms: https://tools.ietf.org/html/rfc8305#section-5
         // Only start timer when more IPs are queued or when DNS query is still pending (might add more IPs)
-        if (\count($this->connectQueue) > 0 || $this->resolved[Message::TYPE_A] === false || $this->resolved[Message::TYPE_AAAA] === false) {
+        if ($this->nextAttemptTimer === null && (\count($this->connectQueue) > 0 || $this->resolved[Message::TYPE_A] === false || $this->resolved[Message::TYPE_AAAA] === false)) {
             $this->nextAttemptTimer = $this->loop->addTimer(self::CONNECTION_ATTEMPT_DELAY, function () use ($that, $resolve, $reject) {
                 $that->nextAttemptTimer = null;
 

--- a/src/HappyEyeBallsConnectionBuilder.php
+++ b/src/HappyEyeBallsConnectionBuilder.php
@@ -251,6 +251,9 @@ final class HappyEyeBallsConnectionBuilder
      */
     public function cleanUp()
     {
+        // clear list of outstanding IPs to avoid creating new connections
+        $this->connectQueue = array();
+
         foreach ($this->connectionPromises as $connectionPromise) {
             if ($connectionPromise instanceof CancellablePromiseInterface) {
                 $connectionPromise->cancel();

--- a/tests/HappyEyeBallsConnectorTest.php
+++ b/tests/HappyEyeBallsConnectorTest.php
@@ -141,30 +141,6 @@ class HappyEyeBallsConnectorTest extends TestCase
     /**
      * @dataProvider provideIpvAddresses
      */
-    public function testIpv4ResolvesFirstSoButIPv6IsTheFirstToConnect(array $ipv6, array $ipv4)
-    {
-        $this->resolver->expects($this->at(0))->method('resolveAll')->with('google.com', Message::TYPE_AAAA)->will($this->returnValue(Promise\Timer\resolve(0.001, $this->loop)->then(function () use ($ipv6) {
-            return Promise\resolve($ipv6);
-        })));
-        $this->resolver->expects($this->at(1))->method('resolveAll')->with('google.com', Message::TYPE_A)->will($this->returnValue(Promise\resolve($ipv4)));
-        $i = 0;
-        while (count($ipv6) > 0 || count($ipv4) > 0) {
-            if (count($ipv6) > 0) {
-                $this->tcp->expects($this->at($i++))->method('connect')->with($this->equalTo('scheme://[' . array_shift($ipv6) . ']:80/?hostname=google.com'))->will($this->returnValue(Promise\resolve()));
-            }
-            if (count($ipv4) > 0) {
-                $this->tcp->expects($this->at($i++))->method('connect')->with($this->equalTo('scheme://' . array_shift($ipv4) . ':80/?hostname=google.com'))->will($this->returnValue(Promise\resolve()));
-            }
-        }
-
-        $this->connector->connect('scheme://google.com:80/?hostname=google.com');
-
-        $this->loop->run();
-    }
-
-    /**
-     * @dataProvider provideIpvAddresses
-     */
     public function testIpv6ResolvesFirstSoIsTheFirstToConnect(array $ipv6, array $ipv4)
     {
         $deferred = new Deferred();
@@ -198,29 +174,6 @@ class HappyEyeBallsConnectorTest extends TestCase
         $this->loop->addTimer(0.07, function () use ($deferred) {
             $deferred->reject(new \RuntimeException());
         });
-
-        $this->loop->run();
-    }
-
-    /**
-     * @dataProvider provideIpvAddresses
-     */
-    public function testAttemptsToConnectBothIpv6AndIpv4Addresses(array $ipv6, array $ipv4)
-    {
-        $this->resolver->expects($this->at(0))->method('resolveAll')->with('google.com', Message::TYPE_AAAA)->will($this->returnValue(Promise\resolve($ipv6)));
-        $this->resolver->expects($this->at(1))->method('resolveAll')->with('google.com', Message::TYPE_A)->will($this->returnValue(Promise\resolve($ipv4)));
-
-        $i = 0;
-        while (count($ipv6) > 0 || count($ipv4) > 0) {
-            if (count($ipv6) > 0) {
-                $this->tcp->expects($this->at($i++))->method('connect')->with($this->equalTo('scheme://[' . array_shift($ipv6) . ']:80/?hostname=google.com'))->will($this->returnValue(Promise\resolve()));
-            }
-            if (count($ipv4) > 0) {
-                $this->tcp->expects($this->at($i++))->method('connect')->with($this->equalTo('scheme://' . array_shift($ipv4) . ':80/?hostname=google.com'))->will($this->returnValue(Promise\resolve()));
-            }
-        }
-
-        $this->connector->connect('scheme://google.com:80/?hostname=google.com');
 
         $this->loop->run();
     }


### PR DESCRIPTION
This changeset ensures a new connection attempt will be started immediately when one connection attempt fails. This is quite common when connecting on IPv4-only systems where the first IPv6 connection will fail and the next connection attempt should not have to wait 100ms.

The 100ms delay between connection attempts now only triggers when the connection attempt is still pending. Afaict this is not in violation of RFC 8305 and seems to be in line with how other implementations handle this specific situation (https://daniel.haxx.se/blog/2020/03/16/curl-ootw-happy-eyeballs-timeout/, https://www.isc.org/blogs/2011-01-19-multi-homed-server-over-tcp/, https://github.com/curl/curl/issues/2281 and others).

This can easily be reproduced by connecting to `localhost:1` when nothing is listening on this port. Prior to this patch, this would take around ~160ms on my system, after applying this patch it takes around ~50ms. Likewise, connection setup is improved on IPv4-only systems (such as Docker in its default configuration) when the destination is reachable over both IPv6 and IPv4.

Additionally, this changeset fixes two subtle bugs when the connector rejects immediately and when DNS resolves with the same IP address multiple times.

Builds on top of #231, #230, #224 and #225