### PR TITLE
Improve error reporting to include both IPv6 & IPv4 errors (happy eyeballs)

### DIFF
--- a/tests/HappyEyeBallsConnectorTest.php
+++ b/tests/HappyEyeBallsConnectorTest.php
@@ -291,29 +291,6 @@ class HappyEyeBallsConnectorTest extends TestCase
 
     /**
      * @expectedException RuntimeException
-     * @expectedExceptionMessage Connection to example.com:80 failed: Connection refused
-     * @dataProvider provideIpvAddresses
-     */
-    public function testRejectsWithTcpConnectorRejectionAfterDnsIsResolved(array $ipv6, array $ipv4)
-    {
-        $that = $this;
-        $promise = Promise\reject(new \RuntimeException('Connection refused'));
-        $this->resolver->expects($this->at(0))->method('resolveAll')->with($this->equalTo('example.com'), $this->anything())->willReturn(Promise\resolve($ipv6));
-        $this->resolver->expects($this->at(1))->method('resolveAll')->with($this->equalTo('example.com'), $this->anything())->willReturn(Promise\resolve($ipv4));
-        $this->tcp->expects($this->any())->method('connect')->with($this->stringContains(':80?hostname=example.com'))->willReturn($promise);
-
-        $promise = $this->connector->connect('example.com:80');
-        $this->loop->addTimer(0.1 * (count($ipv4) + count($ipv6)), function () use ($that, $promise) {
-            $promise->cancel();
-
-            $that->throwRejection($promise);
-        });
-
-        $this->loop->run();
-    }
-
-    /**
-     * @expectedException RuntimeException
      * @expectedExceptionMessage Connection to example.invalid:80 failed during DNS lookup: DNS error
      */
     public function testSkipConnectionIfDnsFails()


### PR DESCRIPTION
This changeset improves error reporting for failed connection attempts using happy eyeballs to always include the last error message for both IPv6 and IPv4 protocol families. The rationale for this is that both families commonly fail for very different reasons (broken IPv6 connectivity etc.). If both families report the same error, the message will only include a single message:

```php
Connection to foo.invalid failed during DNS lookup: DNS query for foo.invalid returned an error response (Server Failure)

Connection to asdasd.com failed: Last error for IPv4: Given URI "tcp://127.0.0.1?hostname=asdasd.com" is invalid. Previous error for IPv6: DNS query for asdasd.com did not return a valid answer (NOERROR / NODATA)
```

Builds on top of #232, #231, #230, #224 and #225
Refs #171 and others