### PR TITLE
Simplify Travis CI test matrix for Mac OS X setup and skip all TLS tests on legacy HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,12 @@ matrix:
     - php: 7.4
     - php: hhvm-3.18
       install: composer require phpunit/phpunit:^5 --dev --no-interaction # requires legacy phpunit
-    - os: osx
+    - name: Mac OS X
+      os: osx
       language: generic
-      php: 7.0 # just to look right on travis
-      env:
-        - PACKAGE: php70
+      before_install:
+        - curl -s http://getcomposer.org/installer | php
+        - mv composer.phar /usr/local/bin/composer
   allow_failures:
     - php: hhvm-3.18
     - os: osx
@@ -29,18 +30,6 @@ matrix:
 sudo: false
 
 install:
-  # OSX install inspired by https://github.com/kiler129/TravisCI-OSX-PHP
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then 
-      brew tap homebrew/homebrew-php 
-      echo "Installing PHP ..."
-      brew install "${PACKAGE}"
-      brew install "${PACKAGE}"-xdebug
-      brew link "${PACKAGE}"
-      echo "Installing composer ..."
-      curl -s http://getcomposer.org/installer | php
-      mv composer.phar /usr/local/bin/composer
-    fi
   - composer install --no-interaction
 
 script:

--- a/tests/FunctionalConnectorTest.php
+++ b/tests/FunctionalConnectorTest.php
@@ -22,17 +22,16 @@ class FunctionalConnectorTest extends TestCase
         $loop = Factory::create();
 
         $server = new TcpServer(9998, $loop);
-        $server->on('connection', $this->expectCallableOnce());
-        $server->on('connection', array($server, 'close'));
 
         $connector = new Connector($loop);
 
         $connection = Block\await($connector->connect('localhost:9998'), $loop, self::TIMEOUT);
 
+        $server->close();
+
         $this->assertInstanceOf('React\Socket\ConnectionInterface', $connection);
 
         $connection->close();
-        $server->close();
     }
 
     /**

--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -19,8 +19,8 @@ class FunctionalSecureServerTest extends TestCase
 
     public function setUp()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on legacy HHVM');
         }
     }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -36,8 +36,8 @@ class IntegrationTest extends TestCase
     /** @test */
     public function gettingEncryptedStuffFromGoogleShouldWork()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
         $loop = Factory::create();
@@ -55,8 +55,8 @@ class IntegrationTest extends TestCase
     /** @test */
     public function gettingEncryptedStuffFromGoogleShouldWorkIfHostIsResolvedFirst()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
         $loop = Factory::create();
@@ -363,8 +363,8 @@ class IntegrationTest extends TestCase
 
     public function testSelfSignedRejectsIfVerificationIsEnabled()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
         $loop = Factory::create();
@@ -381,8 +381,8 @@ class IntegrationTest extends TestCase
 
     public function testSelfSignedResolvesIfVerificationIsDisabled()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
         $loop = Factory::create();

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -14,8 +14,8 @@ class SecureConnectorTest extends TestCase
 
     public function setUp()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
         $this->loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();

--- a/tests/SecureIntegrationTest.php
+++ b/tests/SecureIntegrationTest.php
@@ -24,8 +24,8 @@ class SecureIntegrationTest extends TestCase
 
     public function setUp()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
         $this->loop = LoopFactory::create();

--- a/tests/SecureServerTest.php
+++ b/tests/SecureServerTest.php
@@ -10,8 +10,8 @@ class SecureServerTest extends TestCase
 {
     public function setUp()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on legacy HHVM');
         }
     }
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -51,6 +51,9 @@ class ServerTest extends TestCase
 
     public function testConstructorCreatesExpectedUnixServer()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on legacy HHVM');
+        }
         if (!in_array('unix', stream_get_transports())) {
             $this->markTestSkipped('Unix domain sockets (UDS) not supported on your platform (Windows?)');
         }
@@ -182,8 +185,8 @@ class ServerTest extends TestCase
 
     public function testDoesNotEmitSecureConnectionForNewPlaintextConnectionThatIsIdle()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
         $loop = Factory::create();

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -51,8 +51,6 @@ class TcpConnectorTest extends TestCase
         $loop = Factory::create();
 
         $server = new TcpServer(9999, $loop);
-        $server->on('connection', $this->expectCallableOnce());
-        $server->on('connection', array($server, 'close'));
 
         $connector = new TcpConnector($loop);
 
@@ -61,6 +59,7 @@ class TcpConnectorTest extends TestCase
         $this->assertInstanceOf('React\Socket\ConnectionInterface', $connection);
 
         $connection->close();
+        $server->close();
     }
 
     /** @test */
@@ -69,7 +68,6 @@ class TcpConnectorTest extends TestCase
         $loop = Factory::create();
 
         $server = new TcpServer(9999, $loop);
-        $server->on('connection', array($server, 'close'));
 
         $connector = new TcpConnector($loop);
 
@@ -79,6 +77,7 @@ class TcpConnectorTest extends TestCase
         $this->assertEquals('tcp://127.0.0.1:9999', $connection->getRemoteAddress());
 
         $connection->close();
+        $server->close();
     }
 
     /** @test */
@@ -87,7 +86,6 @@ class TcpConnectorTest extends TestCase
         $loop = Factory::create();
 
         $server = new TcpServer(9999, $loop);
-        $server->on('connection', array($server, 'close'));
 
         $connector = new TcpConnector($loop);
 
@@ -98,6 +96,7 @@ class TcpConnectorTest extends TestCase
         $this->assertNotEquals('tcp://127.0.0.1:9999', $connection->getLocalAddress());
 
         $connection->close();
+        $server->close();
     }
 
     /** @test */
@@ -106,13 +105,13 @@ class TcpConnectorTest extends TestCase
         $loop = Factory::create();
 
         $server = new TcpServer(9999, $loop);
-        $server->on('connection', array($server, 'close'));
 
         $connector = new TcpConnector($loop);
 
         $connection = Block\await($connector->connect('127.0.0.1:9999'), $loop, self::TIMEOUT);
         /* @var $connection ConnectionInterface */
 
+        $server->close();
         $connection->close();
 
         $this->assertNull($connection->getRemoteAddress());
@@ -165,9 +164,6 @@ class TcpConnectorTest extends TestCase
             $this->markTestSkipped('Unable to start IPv6 server socket (IPv6 not supported on this system?)');
         }
 
-        $server->on('connection', $this->expectCallableOnce());
-        $server->on('connection', array($server, 'close'));
-
         $connector = new TcpConnector($loop);
 
         $connection = Block\await($connector->connect('[::1]:9999'), $loop, self::TIMEOUT);
@@ -179,6 +175,7 @@ class TcpConnectorTest extends TestCase
         $this->assertNotEquals('tcp://[::1]:9999', $connection->getLocalAddress());
 
         $connection->close();
+        $server->close();
     }
 
     /** @test */


### PR DESCRIPTION
Builds on top of #223, https://github.com/reactphp/stream/pull/150 and others.