### PR TITLE
Fix closing connection when cancelling during TLS handshake

### DIFF
--- a/src/StreamEncryption.php
+++ b/src/StreamEncryption.php
@@ -57,7 +57,9 @@ class StreamEncryption
         // TODO: add write() event to make sure we're not sending any excessive data
 
         // cancelling this leaves this stream in an inconsistent state…
-        $deferred = new Deferred();
+        $deferred = new Deferred(function () {
+            throw new \RuntimeException();
+        });
 
         // get actual stream socket from stream instance
         $socket = $stream->stream;


### PR DESCRIPTION
This changeset fixes closing the pending connection attempt when the connection is cancelled during the TLS handshake. This is a minor oversight from the previous cleanup in https://github.com/reactphp/socket/commit/15426bdcb905511915ec2784448e32f08375d45b#diff-fa535a0ca5a2f2df7b368c67e3bfd18dL66. This is now covered by some higher level integration tests to ensure correct system behavior.