### PR TITLE
Change default socket backlog size to 511

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ $server = new React\Socket\Server('[::1]:8080', $loop, array(
   their defaults and effects of changing these may vary depending on your system
   and/or PHP version.
   Passing unknown context options has no effect.
+  The `backlog` context option defaults to `511` unless given explicitly.
   For BC reasons, you can also pass the TCP socket context options as a simple
   array without wrapping this in another array under the `tcp` key.
 
@@ -577,6 +578,7 @@ $server = new React\Socket\TcpServer('[::1]:8080', $loop, array(
 their defaults and effects of changing these may vary depending on your system
 and/or PHP version.
 Passing unknown context options has no effect.
+The `backlog` context option defaults to `511` unless given explicitly.
 
 Whenever a client connects, it will emit a `connection` event with a connection
 instance implementing [`ConnectionInterface`](#connectioninterface):

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -113,6 +113,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * their defaults and effects of changing these may vary depending on your system
      * and/or PHP version.
      * Passing unknown context options has no effect.
+     * The `backlog` context option defaults to `511` unless given explicitly.
      *
      * @param string|int    $uri
      * @param LoopInterface $loop
@@ -158,7 +159,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
             $errno,
             $errstr,
             \STREAM_SERVER_BIND | \STREAM_SERVER_LISTEN,
-            \stream_context_create(array('socket' => $context))
+            \stream_context_create(array('socket' => $context + array('backlog' => 511)))
         );
         if (false === $this->master) {
             throw new \RuntimeException('Failed to listen on "' . $uri . '": ' . $errstr, $errno);

--- a/tests/FunctionalTcpServerTest.php
+++ b/tests/FunctionalTcpServerTest.php
@@ -285,6 +285,38 @@ class FunctionalTcpServerTest extends TestCase
         $this->assertEquals($server->getAddress(), $local);
     }
 
+    public function testServerPassesContextOptionsToSocket()
+    {
+        $loop = Factory::create();
+
+        $server = new TcpServer(0, $loop, array(
+            'backlog' => 4
+        ));
+
+        $ref = new \ReflectionProperty($server, 'master');
+        $ref->setAccessible(true);
+        $socket = $ref->getValue($server);
+
+        $context = stream_context_get_options($socket);
+
+        $this->assertEquals(array('socket' => array('backlog' => 4)), $context);
+    }
+
+    public function testServerPassesDefaultBacklogSizeViaContextOptionsToSocket()
+    {
+        $loop = Factory::create();
+
+        $server = new TcpServer(0, $loop);
+
+        $ref = new \ReflectionProperty($server, 'master');
+        $ref->setAccessible(true);
+        $socket = $ref->getValue($server);
+
+        $context = stream_context_get_options($socket);
+
+        $this->assertEquals(array('socket' => array('backlog' => 511)), $context);
+    }
+
     public function testEmitsConnectionWithInheritedContextOptions()
     {
         if (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.13', '<')) {


### PR DESCRIPTION
The `backlog` parameter used to default to just 32 as of PHP 5.3.3 and
used to be hard coded to 4 in earlier PHP versions.

The new default of 511 was evaluated to be a reasonable value for
event-driven applications that can cope with many concurrent connections
on a variety of platforms. In particular, this solves common ECONNRESET
(connection reset by peer) errors when running benchmarks with higher
concurrency. For more specific requirements, the `backlog` parameter can
be given explicitly to override this default.

See https://github.com/php/php-src/commit/5b277c4da0d9fb8bfb59186b61a884aaafffb861
Refs https://github.com/reactphp/http/issues/354 and others