### PR TITLE
Update PHPUnit configuration schema for PHPUnit 9.3 and replace deprecated at() Mocks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
@@ -38,10 +38,9 @@ matrix:
     - os: osx
     - os: windows
 
-sudo: false
-
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.2",
-        "phpunit/phpunit": "^9.0 || ^5.7 || ^4.8.35",
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
         "react/promise-stream": "^1.2"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="React Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="React Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/HappyEyeBallsConnectionBuilderTest.php
+++ b/tests/HappyEyeBallsConnectionBuilderTest.php
@@ -290,6 +290,47 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $deferred->reject(new \RuntimeException());
     }
 
+    public function testConnectWillStartConnectingWithAlternatingIPv6AndIPv4WhenResolverReturnsMultipleIPAdresses()
+    {
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addTimer')->with(0.1, $this->anything())->willReturn($timer);
+        $loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        $deferred = new Deferred();
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->exactly(4))->method('connect')->withConsecutive(
+            array('tcp://[::1]:80?hostname=reactphp.org'),
+            array('tcp://127.0.0.1:80?hostname=reactphp.org'),
+            array('tcp://[::2]:80?hostname=reactphp.org'),
+            array('tcp://127.0.0.2:80?hostname=reactphp.org')
+        )->willReturnOnConsecutiveCalls(
+            $deferred->promise(),
+            $deferred->promise(),
+            $deferred->promise(),
+            new Promise(function () { })
+        );
+
+        $resolver = $this->getMockBuilder('React\Dns\Resolver\ResolverInterface')->getMock();
+        $resolver->expects($this->exactly(2))->method('resolveAll')->withConsecutive(
+            array('reactphp.org', Message::TYPE_AAAA),
+            array('reactphp.org', Message::TYPE_A)
+        )->willReturnOnConsecutiveCalls(
+            \React\Promise\resolve(array('::1', '::2')),
+            \React\Promise\resolve(array('127.0.0.1', '127.0.0.2'))
+        );
+
+        $uri = 'tcp://reactphp.org:80';
+        $host = 'reactphp.org';
+        $parts = parse_url($uri);
+
+        $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
+
+        $builder->connect();
+
+        $deferred->reject(new \RuntimeException());
+    }
+
     public function testConnectWillStartConnectingWithAttemptTimerWhenOnlyIpv6ResolvesAndWillStartNextConnectionAttemptWithoutAttemptTimerImmediatelyWhenFirstConnectionAttemptFails()
     {
         $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
I also had to update  some tests, because the `at()` matcher deprecated in PHPUnit 9.3 and will be removed in PHPUnit 10.

The code needs some minor changes to run with PHP 8, I will look into this in an upcoming pull request.

For further details concerning this pull request look into [graphp/graphviz #46](https://github.com/graphp/graphviz/pull/46).
This pull request builds on top of [reactphp/socket #239](https://github.com/reactphp/socket/pull/239).