### PR TITLE
Fix possible `accept()` race condition when multiple socket servers listen on same socket address

### DIFF
--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -204,7 +204,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
 
         $that = $this;
         $this->loop->addReadStream($this->master, function ($master) use ($that) {
-            $newSocket = @\stream_socket_accept($master);
+            $newSocket = @\stream_socket_accept($master, 0);
             if (false === $newSocket) {
                 $that->emit('error', array(new \RuntimeException('Error accepting new connection')));
 

--- a/src/UnixServer.php
+++ b/src/UnixServer.php
@@ -106,7 +106,7 @@ final class UnixServer extends EventEmitter implements ServerInterface
 
         $that = $this;
         $this->loop->addReadStream($this->master, function ($master) use ($that) {
-            $newSocket = @\stream_socket_accept($master);
+            $newSocket = @\stream_socket_accept($master, 0);
             if (false === $newSocket) {
                 $that->emit('error', array(new \RuntimeException('Error accepting new connection')));
 

--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -280,8 +280,12 @@ class TcpServerTest extends TestCase
 
         $this->assertNotNull($listener);
         $socket = stream_socket_server('tcp://127.0.0.1:0');
-        fclose($socket);
+
+        $time = microtime(true);
         $listener($socket);
+        $time = microtime(true) - $time;
+
+        $this->assertLessThan(1, $time);
     }
 
     public function testListenOnBusyPortThrows()

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -285,8 +285,12 @@ class UnixServerTest extends TestCase
 
         $this->assertNotNull($listener);
         $socket = stream_socket_server('tcp://127.0.0.1:0');
-        fclose($socket);
+
+        $time = microtime(true);
         $listener($socket);
+        $time = microtime(true) - $time;
+
+        $this->assertLessThan(1, $time);
     }
 
     public function testListenOnBusyPortThrows()


### PR DESCRIPTION
Multiple socket servers can listen on the same socket address (using
`SO_REUSEPORT` or shared file descriptors). Accordingly, when a new
connection is incoming, multiple event-loops could report the socket to
be readable and try to a `accept()` an incoming connection from the same
socket.

This wouldn't be an issue with the underlying `accept()` system call.
The first call would succeed and subsequent calls would report `EAGAIN`
or `EWOULDBLOCK` for the other servers given the socket resource is in
non-blocking mode.

However, PHP's `stream_socket_accept()` implementation first runs a
`poll()` on the socket resource before performing an `accept()`. This
means multiple instances listening on the same address could end up in a
race condition where some may be "stuck" in the pending `poll()`.
See https://github.com/php/php-src/blob/91fbd12d5736b3cc9fc6bc2545e877dd65be1f6c/main/network.c#L707

We work around this by specifiying a `0` timeout to ensure the `poll()`
doesn't block in this case. This allows all servers to either complete
successfully or report an error and continue processing right away.

Additionally, this also fixes two test failures for PHP 8. Instead of using an invalid (closed) socket server to test error reporting, we now use a socket that doesn't have a pending connection (refs #243). I'll file another PR address the last test failures on PHP 8, but this is currently blocked by #243.