### PR TITLE
Socket address of closed socket should be null (support PHP 8)

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -138,12 +138,20 @@ class Connection extends EventEmitter implements ConnectionInterface
 
     public function getRemoteAddress()
     {
-        return $this->parseAddress(@\stream_socket_get_name($this->stream, true));
+        if (!\is_resource($this->stream)) {
+            return null;
+        }
+
+        return $this->parseAddress(\stream_socket_get_name($this->stream, true));
     }
 
     public function getLocalAddress()
     {
-        return $this->parseAddress(@\stream_socket_get_name($this->stream, false));
+        if (!\is_resource($this->stream)) {
+            return null;
+        }
+
+        return $this->parseAddress(\stream_socket_get_name($this->stream, false));
     }
 
     private function parseAddress($address)


### PR DESCRIPTION
The previous code works just fine on PHP 7 and older. PHP 8 adds
stricter type checks for closed socket resources, so the underlying
function now throws a `TypeError`. This can be avoided by first checking
if the socket resource is still valid (not closed). This works across
all PHP versions and also helps with avoiding some uneeded error
suppression operators.

This means this component now supports PHP 8 just fine :tada: 

```bash
~/workspace/reactphp-socket$ docker run -it --rm -v `pwd`:/data --workdir /data php:8.0.0beta1-cli php -d memory_limit=-1 vendor/bin/phpunit                                          
PHPUnit 9.3.7 by Sebastian Bergmann and contributors.                                                                                                                                          
                                                                                                                                                                                               
....................................S..........................  63 / 304 ( 20%)                                                                                                               
..........SSS.................................................. 126 / 304 ( 41%)                                                                                                               
............................................................... 189 / 304 ( 62%)                                                                                                               
..........................................................S.... 252 / 304 ( 82%)                                                                                                               
....................................................            304 / 304 (100%)                                                                                                               
                                                                                                                                                                                               
Time: 00:08.058, Memory: 628.00 MB                                                                                                                                                             
                                                                                                                                                                                               
OK, but incomplete, skipped, or risky tests!                                                                                                                                                   
Tests: 304, Assertions: 641, Skipped: 5.
```

This PR does not currently include PHP 8 in the Travis test matrix. PHP is scheduled to be released in November, I'll file a follow-up PR once it's available for installation on Travis.

Builds on top of #243 and #244