### PR TITLE
Use round robin for happy eyeballs DNS responses (load balancing)

### DIFF
--- a/src/HappyEyeBallsConnectionBuilder.php
+++ b/src/HappyEyeBallsConnectionBuilder.php
@@ -316,6 +316,7 @@ final class HappyEyeBallsConnectionBuilder
      */
     public function mixIpsIntoConnectQueue(array $ips)
     {
+        \shuffle($ips);
         $this->ipsCount += \count($ips);
         $connectQueueStash = $this->connectQueue;
         $this->connectQueue = array();

--- a/tests/HappyEyeBallsConnectorTest.php
+++ b/tests/HappyEyeBallsConnectorTest.php
@@ -271,50 +271,6 @@ class HappyEyeBallsConnectorTest extends TestCase
     }
 
     /**
-     * @dataProvider provideIpvAddresses
-     */
-    public function testShouldConnectOverIpv4WhenIpv6LookupFails(array $ipv6, array $ipv4)
-    {
-        $this->resolver->expects($this->exactly(2))->method('resolveAll')->withConsecutive(
-            array($this->equalTo('example.com'), Message::TYPE_AAAA),
-            array($this->equalTo('example.com'), Message::TYPE_A)
-        )->willReturnOnConsecutiveCalls(
-            Promise\reject(new \Exception('failure')),
-            Promise\resolve($ipv4)
-        );
-        $this->tcp->expects($this->exactly(1))->method('connect')->with($this->equalTo('1.2.3.4:80?hostname=example.com'))->willReturn(Promise\resolve($this->connection));
-
-        $promise = $this->connector->connect('example.com:80');;
-        $resolvedConnection = Block\await($promise, $this->loop);
-
-        self::assertSame($this->connection, $resolvedConnection);
-    }
-
-    /**
-     * @dataProvider provideIpvAddresses
-     */
-    public function testShouldConnectOverIpv6WhenIpv4LookupFails(array $ipv6, array $ipv4)
-    {
-        if (count($ipv6) === 0) {
-            $ipv6[] = '1:2:3:4';
-        }
-
-        $this->resolver->expects($this->exactly(2))->method('resolveAll')->withConsecutive(
-            array($this->equalTo('example.com'), Message::TYPE_AAAA),
-            array($this->equalTo('example.com'), Message::TYPE_A)
-        )->willReturnOnConsecutiveCalls(
-            Promise\resolve($ipv6),
-            Promise\reject(new \Exception('failure'))
-        );
-        $this->tcp->expects($this->exactly(1))->method('connect')->with($this->equalTo('[1:2:3:4]:80?hostname=example.com'))->willReturn(Promise\resolve($this->connection));
-
-        $promise = $this->connector->connect('example.com:80');;
-        $resolvedConnection = Block\await($promise, $this->loop);
-
-        self::assertSame($this->connection, $resolvedConnection);
-    }
-
-    /**
      * @internal
      */
     public function throwRejection($promise)


### PR DESCRIPTION
The happy eyeballs algorithms tries to connect over both IPv6 and IPv4
at the same time. Accordingly, the hostname has to be resolved for both
address families which both may potentially contain any number of
records (load balancing).

This changeset randomizes the order of returned IP addresses per address
family. This means that if multiple records are returned, it will try to
connect to a random one from this list instead of always trying the
first. This allows the load to be distributed more evenly across all
returned IP addresses. This can be used as a very basic DNS load
balancing mechanism.

This is similar to what the old `DnsConnector` did (it always tried one random IP from the list of IPs). See also https://daniel.haxx.se/blog/2012/01/03/getaddrinfo-with-round-robin-dns-and-happy-eyeballs/ for some background information.