### PR TITLE
Support falling back to multiple DNS servers from DNS config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/dns": "dev-master#ae37876 as 1.7.0",
+        "react/dns": "^1.7",
         "react/event-loop": "^1.0 || ^0.5",
         "react/promise": "^2.6.0 || ^1.2.1",
         "react/promise-timer": "^1.4.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/dns": "^1.1",
+        "react/dns": "dev-master#ae37876 as 1.7.0",
         "react/event-loop": "^1.0 || ^0.5",
         "react/promise": "^2.6.0 || ^1.2.1",
         "react/promise-timer": "^1.4.0",

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -57,16 +57,18 @@ final class Connector implements ConnectorInterface
                 $resolver = $options['dns'];
             } else {
                 if ($options['dns'] !== true) {
-                    $server = $options['dns'];
+                    $config = $options['dns'];
                 } else {
                     // try to load nameservers from system config or default to Google's public DNS
                     $config = DnsConfig::loadSystemConfigBlocking();
-                    $server = $config->nameservers ? \reset($config->nameservers) : '8.8.8.8';
+                    if (!$config->nameservers) {
+                        $config->nameservers[] = '8.8.8.8';
+                    }
                 }
 
                 $factory = new DnsFactory();
                 $resolver = $factory->createCached(
-                    $server,
+                    $config,
                     $loop
                 );
             }

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -62,7 +62,7 @@ final class Connector implements ConnectorInterface
                     // try to load nameservers from system config or default to Google's public DNS
                     $config = DnsConfig::loadSystemConfigBlocking();
                     if (!$config->nameservers) {
-                        $config->nameservers[] = '8.8.8.8';
+                        $config->nameservers[] = '8.8.8.8'; // @codeCoverageIgnore
                     }
                 }
 


### PR DESCRIPTION
This changeset adds support for falling back to multiple DNS servers from DNS config. In other words, if you have multiple DNS servers configured (rare) and connectivity to the primary DNS server is broken (even rarer), it will now fall back to your other DNS servers.

This is done by simply passing the complete list of DNS servers down to the DNS component that is responsible for setting up the DNS executor stack. Accordingly, this builds on top of https://github.com/reactphp/dns/pull/179 and https://github.com/reactphp/dns/pull/180.