### PR TITLE
Internal improvement to avoid unhandled rejection for future Promise API

### DIFF
--- a/src/HappyEyeBallsConnectionBuilder.php
+++ b/src/HappyEyeBallsConnectionBuilder.php
@@ -84,8 +84,8 @@ final class HappyEyeBallsConnectionBuilder
 
             $that->resolverPromises[Message::TYPE_AAAA] = $that->resolve(Message::TYPE_AAAA, $reject)->then($lookupResolve(Message::TYPE_AAAA));
             $that->resolverPromises[Message::TYPE_A] = $that->resolve(Message::TYPE_A, $reject)->then(function (array $ips) use ($that, &$timer) {
-                // happy path: IPv6 has resolved already, continue with IPv4 addresses
-                if ($that->resolved[Message::TYPE_AAAA] === true) {
+                // happy path: IPv6 has resolved already (or could not resolve), continue with IPv4 addresses
+                if ($that->resolved[Message::TYPE_AAAA] === true || !$ips) {
                     return $ips;
                 }
 
@@ -117,8 +117,9 @@ final class HappyEyeBallsConnectionBuilder
      * @internal
      * @param int      $type   DNS query type
      * @param callable $reject
-     * @return \React\Promise\PromiseInterface<string[],\Exception> Returns a promise
-     *     that resolves list of IP addresses on success or rejects with an \Exception on error.
+     * @return \React\Promise\PromiseInterface<string[]> Returns a promise that
+     *     always resolves with a list of IP addresses on success or an empty
+     *     list on error.
      */
     public function resolve($type, $reject)
     {
@@ -145,7 +146,8 @@ final class HappyEyeBallsConnectionBuilder
                 $reject(new \RuntimeException($that->error()));
             }
 
-            throw $e;
+            // Exception already handled above, so don't throw an unhandled rejection here
+            return array();
         });
     }
 


### PR DESCRIPTION
This changeset applies some internal improvements to avoid unhandled rejection for future Promise API. This does not affect current behavior in any way (test cases are unaffected), but makes sure we do not use any unhandled promise rejections anymore. As discussed in https://github.com/reactphp/promise/issues/87 this could otherwise raise some error/warning in future.

Resolves / closes #248
Refs #214 