### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
         if: ${{ matrix.php >= 7.3 }}
@@ -46,6 +48,8 @@ jobs:
         with:
           php-version: 8.0
           coverage: xdebug
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
 
@@ -53,6 +57,7 @@ jobs:
     name: PHPUnit (HHVM)
     runs-on: ubuntu-18.04
     continue-on-error: true
+    if: false # temporarily skipped until https://github.com/azjezz/setup-hhvm/issues/3 is addressed
     steps:
       - uses: actions/checkout@v2
       - uses: azjezz/setup-hhvm@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
         if: ${{ matrix.php >= 7.3 }}
@@ -48,8 +46,6 @@ jobs:
         with:
           php-version: 8.0
           coverage: xdebug
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
 
@@ -57,7 +53,6 @@ jobs:
     name: PHPUnit (HHVM)
     runs-on: ubuntu-18.04
     continue-on-error: true
-    if: false # temporarily skipped until https://github.com/azjezz/setup-hhvm/issues/3 is addressed
     steps:
       - uses: actions/checkout@v2
       - uses: azjezz/setup-hhvm@v1

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
     "require": {
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/dns": "dev-default-loop#28e5df1 as 1.8.0",
-        "react/event-loop": "dev-master#78f7f43 as 1.2.0",
+        "react/dns": "^1.8",
+        "react/event-loop": "^1.2",
         "react/promise": "^2.6.0 || ^1.2.1",
         "react/promise-timer": "^1.4.0",
-        "react/stream": "dev-default-loop#e617d63 as 1.2.0"
+        "react/stream": "^1.2"
     },
     "require-dev": {
         "clue/block-react": "^1.2",
@@ -48,15 +48,5 @@
         "psr-4": {
             "React\\Tests\\Socket\\": "tests"
         }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/clue-labs/dns"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/clue-labs/stream"
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
     "require": {
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/dns": "^1.7",
-        "react/event-loop": "^1.0 || ^0.5",
+        "react/dns": "dev-default-loop#28e5df1 as 1.8.0",
+        "react/event-loop": "dev-master#78f7f43 as 1.2.0",
         "react/promise": "^2.6.0 || ^1.2.1",
         "react/promise-timer": "^1.4.0",
-        "react/stream": "^1.1"
+        "react/stream": "dev-default-loop#e617d63 as 1.2.0"
     },
     "require-dev": {
         "clue/block-react": "^1.2",
@@ -48,5 +48,15 @@
         "psr-4": {
             "React\\Tests\\Socket\\": "tests"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/clue-labs/dns"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/clue-labs/stream"
+        }
+    ]
 }

--- a/examples/01-echo-server.php
+++ b/examples/01-echo-server.php
@@ -16,15 +16,12 @@
 // $ php examples/01-echo-server.php unix:///tmp/server.sock
 // $ nc -U /tmp/server.sock
 
-use React\EventLoop\Factory;
 use React\Socket\Server;
 use React\Socket\ConnectionInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop, array(
+$server = new Server(isset($argv[1]) ? $argv[1] : 0, null, array(
     'tls' => array(
         'local_cert' => isset($argv[2]) ? $argv[2] : (__DIR__ . '/localhost.pem')
     )
@@ -38,5 +35,3 @@ $server->on('connection', function (ConnectionInterface $connection) {
 $server->on('error', 'printf');
 
 echo 'Listening on ' . $server->getAddress() . PHP_EOL;
-
-$loop->run();

--- a/examples/02-chat-server.php
+++ b/examples/02-chat-server.php
@@ -16,16 +16,13 @@
 // $ php examples/02-chat-server.php unix:///tmp/server.sock
 // $ nc -U /tmp/server.sock
 
-use React\EventLoop\Factory;
 use React\Socket\Server;
 use React\Socket\ConnectionInterface;
 use React\Socket\LimitingServer;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop, array(
+$server = new Server(isset($argv[1]) ? $argv[1] : 0, null, array(
     'tls' => array(
         'local_cert' => isset($argv[2]) ? $argv[2] : (__DIR__ . '/localhost.pem')
     )
@@ -55,5 +52,3 @@ $server->on('connection', function (ConnectionInterface $client) use ($server) {
 $server->on('error', 'printf');
 
 echo 'Listening on ' . $server->getAddress() . PHP_EOL;
-
-$loop->run();

--- a/examples/03-http-server.php
+++ b/examples/03-http-server.php
@@ -29,15 +29,12 @@
 // $ php examples/03-http-server.php unix:///tmp/server.sock
 // $ nc -U /tmp/server.sock
 
-use React\EventLoop\Factory;
 use React\Socket\Server;
 use React\Socket\ConnectionInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop, array(
+$server = new Server(isset($argv[1]) ? $argv[1] : 0, null, array(
     'tls' => array(
         'local_cert' => isset($argv[2]) ? $argv[2] : (__DIR__ . '/localhost.pem')
     )
@@ -53,5 +50,3 @@ $server->on('connection', function (ConnectionInterface $connection) {
 $server->on('error', 'printf');
 
 echo 'Listening on ' . strtr($server->getAddress(), array('tcp:' => 'http:', 'tls:' => 'https:')) . PHP_EOL;
-
-$loop->run();

--- a/examples/11-http-client.php
+++ b/examples/11-http-client.php
@@ -11,7 +11,6 @@
 // $ php examples/11-http-client.php
 // $ php examples/11-http-client.php reactphp.org
 
-use React\EventLoop\Factory;
 use React\Socket\Connector;
 use React\Socket\ConnectionInterface;
 
@@ -19,8 +18,7 @@ $host = isset($argv[1]) ? $argv[1] : 'www.google.com';
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-$connector = new Connector($loop);
+$connector = new Connector();
 
 $connector->connect($host. ':80')->then(function (ConnectionInterface $connection) use ($host) {
     $connection->on('data', function ($data) {
@@ -32,5 +30,3 @@ $connector->connect($host. ':80')->then(function (ConnectionInterface $connectio
 
     $connection->write("GET / HTTP/1.0\r\nHost: $host\r\n\r\n");
 }, 'printf');
-
-$loop->run();

--- a/examples/12-https-client.php
+++ b/examples/12-https-client.php
@@ -11,7 +11,6 @@
 // $ php examples/12-https-client.php
 // $ php examples/12-https-client.php reactphp.org
 
-use React\EventLoop\Factory;
 use React\Socket\Connector;
 use React\Socket\ConnectionInterface;
 
@@ -19,8 +18,7 @@ $host = isset($argv[1]) ? $argv[1] : 'www.google.com';
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-$connector = new Connector($loop);
+$connector = new Connector();
 
 $connector->connect('tls://' . $host . ':443')->then(function (ConnectionInterface $connection) use ($host) {
     $connection->on('data', function ($data) {
@@ -32,5 +30,3 @@ $connector->connect('tls://' . $host . ':443')->then(function (ConnectionInterfa
 
     $connection->write("GET / HTTP/1.0\r\nHost: $host\r\n\r\n");
 }, 'printf');
-
-$loop->run();

--- a/examples/21-netcat-client.php
+++ b/examples/21-netcat-client.php
@@ -8,7 +8,6 @@
 // $ php examples/21-netcat-client.php www.google.com:80
 // $ php examples/21-netcat-client.php tls://www.google.com:443
 
-use React\EventLoop\Factory;
 use React\Socket\Connector;
 use React\Socket\ConnectionInterface;
 use React\Stream\ReadableResourceStream;
@@ -31,13 +30,12 @@ if (!isset($argv[1])) {
     exit(1);
 }
 
-$loop = Factory::create();
-$connector = new Connector($loop);
+$connector = new Connector();
 
-$stdin = new ReadableResourceStream(STDIN, $loop);
+$stdin = new ReadableResourceStream(STDIN);
 $stdin->pause();
-$stdout = new WritableResourceStream(STDOUT, $loop);
-$stderr = new WritableResourceStream(STDERR, $loop);
+$stdout = new WritableResourceStream(STDOUT);
+$stderr = new WritableResourceStream(STDERR);
 
 $stderr->write('Connecting' . PHP_EOL);
 
@@ -64,5 +62,3 @@ $connector->connect($argv[1])->then(function (ConnectionInterface $connection) u
 }, function ($error) use ($stderr) {
     $stderr->write('Connection ERROR: ' . $error . PHP_EOL);
 });
-
-$loop->run();

--- a/examples/22-http-client.php
+++ b/examples/22-http-client.php
@@ -13,7 +13,6 @@
 // $ php examples/22-http-client.php
 // $ php examples/22-http-client.php https://reactphp.org/
 
-use React\EventLoop\Factory;
 use React\Socket\ConnectionInterface;
 use React\Socket\Connector;
 use React\Stream\WritableResourceStream;
@@ -32,8 +31,7 @@ if (!$parts || !isset($parts['scheme'], $parts['host'])) {
     exit(1);
 }
 
-$loop = Factory::create();
-$connector = new Connector($loop);
+$connector = new Connector();
 
 if (!isset($parts['port'])) {
     $parts['port'] = $parts['scheme'] === 'https' ? 443 : 80;
@@ -49,12 +47,10 @@ if (isset($parts['query'])) {
     $resource .= '?' . $parts['query'];
 }
 
-$stdout = new WritableResourceStream(STDOUT, $loop);
+$stdout = new WritableResourceStream(STDOUT);
 
 $connector->connect($target)->then(function (ConnectionInterface $connection) use ($resource, $host, $stdout) {
     $connection->pipe($stdout);
 
     $connection->write("GET $resource HTTP/1.0\r\nHost: $host\r\n\r\n");
 }, 'printf');
-
-$loop->run();

--- a/examples/91-benchmark-server.php
+++ b/examples/91-benchmark-server.php
@@ -22,21 +22,18 @@
 // $ nc -N -U /tmp/server.sock
 // $ dd if=/dev/zero bs=1M count=1000 | nc -N -U /tmp/server.sock
 
-use React\EventLoop\Factory;
 use React\Socket\Server;
 use React\Socket\ConnectionInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$server = new Server(isset($argv[1]) ? $argv[1] : 0, $loop, array(
+$server = new Server(isset($argv[1]) ? $argv[1] : 0, null, array(
     'tls' => array(
         'local_cert' => isset($argv[2]) ? $argv[2] : (__DIR__ . '/localhost.pem')
     )
 ));
 
-$server->on('connection', function (ConnectionInterface $connection) use ($loop) {
+$server->on('connection', function (ConnectionInterface $connection) {
     echo '[connected]' . PHP_EOL;
 
     // count the number of bytes received from this connection
@@ -56,5 +53,3 @@ $server->on('connection', function (ConnectionInterface $connection) use ($loop)
 $server->on('error', 'printf');
 
 echo 'Listening on ' . $server->getAddress() . PHP_EOL;
-
-$loop->run();

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -5,6 +5,7 @@ namespace React\Socket;
 use React\Dns\Config\Config as DnsConfig;
 use React\Dns\Resolver\Factory as DnsFactory;
 use React\Dns\Resolver\ResolverInterface;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 
 /**
@@ -26,8 +27,9 @@ final class Connector implements ConnectorInterface
 {
     private $connectors = array();
 
-    public function __construct(LoopInterface $loop, array $options = array())
+    public function __construct(LoopInterface $loop = null, array $options = array())
     {
+        $loop = $loop ?: Loop::get();
         // apply default options if not explicitly given
         $options += array(
             'tcp' => true,

--- a/src/FixedUriConnector.php
+++ b/src/FixedUriConnector.php
@@ -12,7 +12,7 @@ namespace React\Socket;
  * ```php
  * $connector = new React\Socket\FixedUriConnector(
  *     'unix:///var/run/docker.sock',
- *     new React\Socket\UnixConnector($loop)
+ *     new React\Socket\UnixConnector()
  * );
  *
  * // destination will be ignored, actually connects to Unix domain socket

--- a/src/HappyEyeBallsConnector.php
+++ b/src/HappyEyeBallsConnector.php
@@ -3,6 +3,7 @@
 namespace React\Socket;
 
 use React\Dns\Resolver\ResolverInterface;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise;
 
@@ -12,9 +13,18 @@ final class HappyEyeBallsConnector implements ConnectorInterface
     private $connector;
     private $resolver;
 
-    public function __construct(LoopInterface $loop, ConnectorInterface $connector, ResolverInterface $resolver)
+    public function __construct(LoopInterface $loop = null, ConnectorInterface $connector = null, ResolverInterface $resolver = null)
     {
-        $this->loop = $loop;
+        // $connector and $resolver arguments are actually required, marked
+        // optional for technical reasons only. Nullable $loop without default
+        // requires PHP 7.1, null default is also supported in legacy PHP
+        // versions, but required parameters are not allowed after arguments
+        // with null default. Mark all parameters optional and check accordingly.
+        if ($connector === null || $resolver === null) {
+            throw new \InvalidArgumentException('Missing required $connector or $resolver argument');
+        }
+
+        $this->loop = $loop ?: Loop::get();
         $this->connector = $connector;
         $this->resolver = $resolver;
     }
@@ -34,7 +44,7 @@ final class HappyEyeBallsConnector implements ConnectorInterface
         }
 
         $host = \trim($parts['host'], '[]');
-        
+
         // skip DNS lookup / URI manipulation if this URI already contains an IP
         if (false !== \filter_var($host, \FILTER_VALIDATE_IP)) {
             return $this->connector->connect($uri);

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -2,6 +2,7 @@
 
 namespace React\Socket;
 
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise;
 use BadMethodCallException;
@@ -14,10 +15,10 @@ final class SecureConnector implements ConnectorInterface
     private $streamEncryption;
     private $context;
 
-    public function __construct(ConnectorInterface $connector, LoopInterface $loop, array $context = array())
+    public function __construct(ConnectorInterface $connector, LoopInterface $loop = null, array $context = array())
     {
         $this->connector = $connector;
-        $this->streamEncryption = new StreamEncryption($loop, false);
+        $this->streamEncryption = new StreamEncryption($loop ?: Loop::get(), false);
         $this->context = $context;
     }
 

--- a/src/SecureServer.php
+++ b/src/SecureServer.php
@@ -3,6 +3,7 @@
 namespace React\Socket;
 
 use Evenement\EventEmitter;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use BadMethodCallException;
 use UnexpectedValueException;
@@ -15,8 +16,8 @@ use UnexpectedValueException;
  * TCP/IP connections and then performs a TLS handshake for each connection.
  *
  * ```php
- * $server = new React\Socket\TcpServer(8000, $loop);
- * $server = new React\Socket\SecureServer($server, $loop, array(
+ * $server = new React\Socket\TcpServer(8000);
+ * $server = new React\Socket\SecureServer($server, null, array(
  *     // tls context options here…
  * ));
  * ```
@@ -67,8 +68,8 @@ final class SecureServer extends EventEmitter implements ServerInterface
      * PEM encoded certificate file:
      *
      * ```php
-     * $server = new React\Socket\TcpServer(8000, $loop);
-     * $server = new React\Socket\SecureServer($server, $loop, array(
+     * $server = new React\Socket\TcpServer(8000);
+     * $server = new React\Socket\SecureServer($server, null, array(
      *     'local_cert' => 'server.pem'
      * ));
      * ```
@@ -82,8 +83,8 @@ final class SecureServer extends EventEmitter implements ServerInterface
      * like this:
      *
      * ```php
-     * $server = new React\Socket\TcpServer(8000, $loop);
-     * $server = new React\Socket\SecureServer($server, $loop, array(
+     * $server = new React\Socket\TcpServer(8000);
+     * $server = new React\Socket\SecureServer($server, null, array(
      *     'local_cert' => 'server.pem',
      *     'passphrase' => 'secret'
      * ));
@@ -93,6 +94,12 @@ final class SecureServer extends EventEmitter implements ServerInterface
      * their defaults and effects of changing these may vary depending on your system
      * and/or PHP version.
      * Passing unknown context options has no effect.
+     *
+     * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+     * pass the event loop instance to use for this object. You can use a `null` value
+     * here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+     * This value SHOULD NOT be given unless you're sure you want to explicitly use a
+     * given event loop instance.
      *
      * Advanced usage: Despite allowing any `ServerInterface` as first parameter,
      * you SHOULD pass a `TcpServer` instance as first parameter, unless you
@@ -109,13 +116,13 @@ final class SecureServer extends EventEmitter implements ServerInterface
      * then close the underlying connection.
      *
      * @param ServerInterface|TcpServer $tcp
-     * @param LoopInterface $loop
+     * @param ?LoopInterface $loop
      * @param array $context
      * @throws BadMethodCallException for legacy HHVM < 3.8 due to lack of support
      * @see TcpServer
      * @link https://www.php.net/manual/en/context.ssl.php for TLS context options
      */
-    public function __construct(ServerInterface $tcp, LoopInterface $loop, array $context)
+    public function __construct(ServerInterface $tcp, LoopInterface $loop = null, array $context = array())
     {
         if (!\function_exists('stream_socket_enable_crypto')) {
             throw new \BadMethodCallException('Encryption not supported on your platform (HHVM < 3.8?)'); // @codeCoverageIgnore
@@ -127,7 +134,7 @@ final class SecureServer extends EventEmitter implements ServerInterface
         );
 
         $this->tcp = $tcp;
-        $this->encryption = new StreamEncryption($loop);
+        $this->encryption = new StreamEncryption($loop ?: Loop::get());
         $this->context = $context;
 
         $that = $this;

--- a/src/Server.php
+++ b/src/Server.php
@@ -3,6 +3,7 @@
 namespace React\Socket;
 
 use Evenement\EventEmitter;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use Exception;
 
@@ -10,8 +11,10 @@ final class Server extends EventEmitter implements ServerInterface
 {
     private $server;
 
-    public function __construct($uri, LoopInterface $loop, array $context = array())
+    public function __construct($uri, LoopInterface $loop = null, array $context = array())
     {
+        $loop = $loop ?: Loop::get();
+
         // sanitize TCP context options if not properly wrapped
         if ($context && (!isset($context['tcp']) && !isset($context['tls']) && !isset($context['unix']))) {
             $context = array('tcp' => $context);

--- a/src/ServerInterface.php
+++ b/src/ServerInterface.php
@@ -124,7 +124,7 @@ interface ServerInterface extends EventEmitterInterface
      * ```php
      * $server->pause();
      *
-     * $loop->addTimer(1.0, function () use ($server) {
+     * Loop::addTimer(1.0, function () use ($server) {
      *     $server->resume();
      * });
      * ```

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -2,6 +2,7 @@
 
 namespace React\Socket;
 
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise;
 use InvalidArgumentException;
@@ -12,9 +13,9 @@ final class TcpConnector implements ConnectorInterface
     private $loop;
     private $context;
 
-    public function __construct(LoopInterface $loop, array $context = array())
+    public function __construct(LoopInterface $loop = null, array $context = array())
     {
-        $this->loop = $loop;
+        $this->loop = $loop ?: Loop::get();
         $this->context = $context;
     }
 

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -3,6 +3,7 @@
 namespace React\Socket;
 
 use Evenement\EventEmitter;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use InvalidArgumentException;
 use RuntimeException;
@@ -12,7 +13,7 @@ use RuntimeException;
  * is responsible for accepting plaintext TCP/IP connections.
  *
  * ```php
- * $server = new React\Socket\TcpServer(8080, $loop);
+ * $server = new React\Socket\TcpServer(8080);
  * ```
  *
  * Whenever a client connects, it will emit a `connection` event with a connection
@@ -45,7 +46,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * for more details.
      *
      * ```php
-     * $server = new React\Socket\TcpServer(8080, $loop);
+     * $server = new React\Socket\TcpServer(8080);
      * ```
      *
      * As above, the `$uri` parameter can consist of only a port, in which case the
@@ -55,7 +56,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * In order to use a random port assignment, you can use the port `0`:
      *
      * ```php
-     * $server = new React\Socket\TcpServer(0, $loop);
+     * $server = new React\Socket\TcpServer(0);
      * $address = $server->getAddress();
      * ```
      *
@@ -64,14 +65,14 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * preceded by the `tcp://` scheme:
      *
      * ```php
-     * $server = new React\Socket\TcpServer('192.168.0.1:8080', $loop);
+     * $server = new React\Socket\TcpServer('192.168.0.1:8080');
      * ```
      *
      * If you want to listen on an IPv6 address, you MUST enclose the host in square
      * brackets:
      *
      * ```php
-     * $server = new React\Socket\TcpServer('[::1]:8080', $loop);
+     * $server = new React\Socket\TcpServer('[::1]:8080');
      * ```
      *
      * If the given URI is invalid, does not contain a port, any other scheme or if it
@@ -79,7 +80,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
      *
      * ```php
      * // throws InvalidArgumentException due to missing port
-     * $server = new React\Socket\TcpServer('127.0.0.1', $loop);
+     * $server = new React\Socket\TcpServer('127.0.0.1');
      * ```
      *
      * If the given URI appears to be valid, but listening on it fails (such as if port
@@ -87,10 +88,10 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * throw a `RuntimeException`:
      *
      * ```php
-     * $first = new React\Socket\TcpServer(8080, $loop);
+     * $first = new React\Socket\TcpServer(8080);
      *
      * // throws RuntimeException because port is already in use
-     * $second = new React\Socket\TcpServer(8080, $loop);
+     * $second = new React\Socket\TcpServer(8080);
      * ```
      *
      * Note that these error conditions may vary depending on your system and/or
@@ -98,11 +99,17 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * See the exception message and code for more details about the actual error
      * condition.
      *
+     * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+     * pass the event loop instance to use for this object. You can use a `null` value
+     * here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+     * This value SHOULD NOT be given unless you're sure you want to explicitly use a
+     * given event loop instance.
+     *
      * Optionally, you can specify [socket context options](https://www.php.net/manual/en/context.socket.php)
      * for the underlying stream socket resource like this:
      *
      * ```php
-     * $server = new React\Socket\TcpServer('[::1]:8080', $loop, array(
+     * $server = new React\Socket\TcpServer('[::1]:8080', null, array(
      *     'backlog' => 200,
      *     'so_reuseport' => true,
      *     'ipv6_v6only' => true
@@ -115,15 +122,15 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * Passing unknown context options has no effect.
      * The `backlog` context option defaults to `511` unless given explicitly.
      *
-     * @param string|int    $uri
-     * @param LoopInterface $loop
-     * @param array         $context
+     * @param string|int     $uri
+     * @param ?LoopInterface $loop
+     * @param array          $context
      * @throws InvalidArgumentException if the listening address is invalid
      * @throws RuntimeException if listening on this address fails (already in use etc.)
      */
-    public function __construct($uri, LoopInterface $loop, array $context = array())
+    public function __construct($uri, LoopInterface $loop = null, array $context = array())
     {
-        $this->loop = $loop;
+        $this->loop = $loop ?: Loop::get();
 
         // a single port has been given => assume localhost
         if ((string)(int)$uri === (string)$uri) {

--- a/src/TimeoutConnector.php
+++ b/src/TimeoutConnector.php
@@ -2,6 +2,7 @@
 
 namespace React\Socket;
 
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Timer;
 use React\Promise\Timer\TimeoutException;
@@ -12,11 +13,11 @@ final class TimeoutConnector implements ConnectorInterface
     private $timeout;
     private $loop;
 
-    public function __construct(ConnectorInterface $connector, $timeout, LoopInterface $loop)
+    public function __construct(ConnectorInterface $connector, $timeout, LoopInterface $loop = null)
     {
         $this->connector = $connector;
         $this->timeout = $timeout;
-        $this->loop = $loop;
+        $this->loop = $loop ?: Loop::get();
     }
 
     public function connect($uri)

--- a/src/UnixConnector.php
+++ b/src/UnixConnector.php
@@ -2,6 +2,7 @@
 
 namespace React\Socket;
 
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise;
 use InvalidArgumentException;
@@ -17,9 +18,9 @@ final class UnixConnector implements ConnectorInterface
 {
     private $loop;
 
-    public function __construct(LoopInterface $loop)
+    public function __construct(LoopInterface $loop = null)
     {
-        $this->loop = $loop;
+        $this->loop = $loop ?: Loop::get();
     }
 
     public function connect($path)

--- a/src/UnixServer.php
+++ b/src/UnixServer.php
@@ -3,6 +3,7 @@
 namespace React\Socket;
 
 use Evenement\EventEmitter;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use InvalidArgumentException;
 use RuntimeException;
@@ -12,7 +13,7 @@ use RuntimeException;
  * is responsible for accepting plaintext connections on unix domain sockets.
  *
  * ```php
- * $server = new React\Socket\UnixServer('unix:///tmp/app.sock', $loop);
+ * $server = new React\Socket\UnixServer('unix:///tmp/app.sock');
  * ```
  *
  * See also the `ServerInterface` for more details.
@@ -34,18 +35,24 @@ final class UnixServer extends EventEmitter implements ServerInterface
      * for more details.
      *
      * ```php
-     * $server = new React\Socket\UnixServer('unix:///tmp/app.sock', $loop);
+     * $server = new React\Socket\UnixServer('unix:///tmp/app.sock');
      * ```
      *
-     * @param string        $path
-     * @param LoopInterface $loop
-     * @param array         $context
+     * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+     * pass the event loop instance to use for this object. You can use a `null` value
+     * here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+     * This value SHOULD NOT be given unless you're sure you want to explicitly use a
+     * given event loop instance.
+     *
+     * @param string         $path
+     * @param ?LoopInterface $loop
+     * @param array          $context
      * @throws InvalidArgumentException if the listening address is invalid
      * @throws RuntimeException if listening on this address fails (already in use etc.)
      */
-    public function __construct($path, LoopInterface $loop, array $context = array())
+    public function __construct($path, LoopInterface $loop = null, array $context = array())
     {
-        $this->loop = $loop;
+        $this->loop = $loop ?: Loop::get();
 
         if (\strpos($path, '://') === false) {
             $path = 'unix://' . $path;

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -7,6 +7,21 @@ use React\Promise\Promise;
 
 class ConnectorTest extends TestCase
 {
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $connector = new Connector();
+
+        $ref = new \ReflectionProperty($connector, 'connectors');
+        $ref->setAccessible(true);
+        $connectors = $ref->getValue($connector);
+
+        $ref = new \ReflectionProperty($connectors['tcp'], 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($connectors['tcp']);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testConnectorUsesTcpAsDefaultScheme()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();

--- a/tests/HappyEyeBallsConnectorTest.php
+++ b/tests/HappyEyeBallsConnectorTest.php
@@ -30,6 +30,29 @@ class HappyEyeBallsConnectorTest extends TestCase
         $this->connector = new HappyEyeBallsConnector($this->loop, $this->tcp, $this->resolver);
     }
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $connector = new HappyEyeBallsConnector(null, $this->tcp, $this->resolver);
+
+        $ref = new \ReflectionProperty($connector, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($connector);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
+    public function testConstructWithoutRequiredConnectorThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        new HappyEyeBallsConnector(null, null, $this->resolver);
+    }
+
+    public function testConstructWithoutRequiredResolverThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        new HappyEyeBallsConnector(null, $this->tcp);
+    }
+
     public function testHappyFlow()
     {
         $first = new Deferred();

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -26,6 +26,21 @@ class SecureConnectorTest extends TestCase
         $this->connector = new SecureConnector($this->tcp, $this->loop);
     }
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $connector = new SecureConnector($this->tcp);
+
+        $ref = new \ReflectionProperty($connector, 'streamEncryption');
+        $ref->setAccessible(true);
+        $streamEncryption = $ref->getValue($connector);
+
+        $ref = new \ReflectionProperty($streamEncryption, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($streamEncryption);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testConnectionWillWaitForTcpConnection()
     {
         $pending = new Promise\Promise(function () { });

--- a/tests/SecureServerTest.php
+++ b/tests/SecureServerTest.php
@@ -18,6 +18,23 @@ class SecureServerTest extends TestCase
         }
     }
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $tcp = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();
+
+        $server = new SecureServer($tcp);
+
+        $ref = new \ReflectionProperty($server, 'encryption');
+        $ref->setAccessible(true);
+        $encryption = $ref->getValue($server);
+
+        $ref = new \ReflectionProperty($encryption, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($encryption);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testGetAddressWillBePassedThroughToTcpServer()
     {
         $tcp = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -14,6 +14,21 @@ class ServerTest extends TestCase
 {
     const TIMEOUT = 0.1;
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $server = new Server(0);
+
+        $ref = new \ReflectionProperty($server, 'server');
+        $ref->setAccessible(true);
+        $tcp = $ref->getValue($server);
+
+        $ref = new \ReflectionProperty($tcp, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($tcp);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testCreateServerWithZeroPortAssignsRandomPort()
     {
         $loop = Factory::create();

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -13,6 +13,17 @@ class TcpConnectorTest extends TestCase
 {
     const TIMEOUT = 5.0;
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $connector = new TcpConnector();
+
+        $ref = new \ReflectionProperty($connector, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($connector);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     /** @test */
     public function connectionToEmptyPortShouldFail()
     {

--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -34,6 +34,17 @@ class TcpServerTest extends TestCase
         $this->port = parse_url($this->server->getAddress(), PHP_URL_PORT);
     }
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $server = new TcpServer(0);
+
+        $ref = new \ReflectionProperty($server, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($server);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     /**
      * @covers React\Socket\TcpServer::handleConnection
      */

--- a/tests/TimeoutConnectorTest.php
+++ b/tests/TimeoutConnectorTest.php
@@ -10,6 +10,19 @@ use React\Promise\Deferred;
 
 class TimeoutConnectorTest extends TestCase
 {
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $base = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+
+        $connector = new TimeoutConnector($base, 0.01);
+
+        $ref = new \ReflectionProperty($connector, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($connector);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testRejectsWithTimeoutReasonOnTimeout()
     {
         $promise = new Promise\Promise(function () { });

--- a/tests/UnixConnectorTest.php
+++ b/tests/UnixConnectorTest.php
@@ -19,6 +19,17 @@ class UnixConnectorTest extends TestCase
         $this->connector = new UnixConnector($this->loop);
     }
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $connector = new UnixConnector();
+
+        $ref = new \ReflectionProperty($connector, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($connector);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testInvalid()
     {
         $promise = $this->connector->connect('google.com:80');

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -29,6 +29,17 @@ class UnixServerTest extends TestCase
         $this->server = new UnixServer($this->uds, $this->loop);
     }
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $server = new UnixServer($this->getRandomSocketUri());
+
+        $ref = new \ReflectionProperty($server, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($server);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     /**
      * @covers React\Socket\UnixServer::handleConnection
      */


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$socket = new React\Socket\Server('127.0.0.1:8080', $loop);
$connector = new React\Socket\Connector($loop);

// new (using default loop)
$socket = new React\Socket\Server('127.0.0.1:8080');
$connector = new React\Socket\Connector();
```

Builds on top of https://github.com/reactphp/event-loop/pull/226, https://github.com/reactphp/event-loop/pull/229, https://github.com/reactphp/event-loop/pull/232, https://github.com/reactphp/stream/pull/159 and https://github.com/reactphp/dns/pull/182