### PR TITLE
Update `Connector` signature to take `$context` as first argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,12 +948,6 @@ also shares all of their features and implementation details.
 If you want to typehint in your higher-level protocol implementation, you SHOULD
 use the generic [`ConnectorInterface`](#connectorinterface) instead.
 
-This class takes an optional `LoopInterface|null $loop` parameter that can be used to
-pass the event loop instance to use for this object. You can use a `null` value
-here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
-This value SHOULD NOT be given unless you're sure you want to explicitly use a
-given event loop instance.
-
 As of `v1.4.0`, the `Connector` class defaults to using the
 [happy eyeballs algorithm](https://en.wikipedia.org/wiki/Happy_Eyeballs) to
 automatically connect over IPv4 or IPv6 when a hostname is given.
@@ -964,7 +958,7 @@ If you want to revert to the old behavior of only doing an IPv4 lookup and
 only attempt a single IPv4 connection, you can set up the `Connector` like this:
 
 ```php
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'happy_eyeballs' => false
 ));
 ```
@@ -978,7 +972,7 @@ If you explicitly want to use a custom DNS server (such as a local DNS relay or
 a company wide DNS server), you can set up the `Connector` like this:
 
 ```php
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'dns' => '127.0.1.1'
 ));
 
@@ -992,7 +986,7 @@ If you do not want to use a DNS resolver at all and want to connect to IP
 addresses only, you can also set up your `Connector` like this:
 
 ```php
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'dns' => false
 ));
 
@@ -1009,7 +1003,7 @@ can also set up your `Connector` like this:
 $dnsResolverFactory = new React\Dns\Resolver\Factory();
 $resolver = $dnsResolverFactory->createCached('127.0.1.1');
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'dns' => $resolver
 ));
 
@@ -1024,7 +1018,7 @@ respects your `default_socket_timeout` ini setting (which defaults to 60s).
 If you want a custom timeout value, you can simply pass this like this:
 
 ```php
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'timeout' => 10.0
 ));
 ```
@@ -1033,7 +1027,7 @@ Similarly, if you do not want to apply a timeout at all and let the operating
 system handle this, you can pass a boolean flag like this:
 
 ```php
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'timeout' => false
 ));
 ```
@@ -1044,7 +1038,7 @@ pass boolean flags like this:
 
 ```php
 // only allow secure TLS connections
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => false,
     'tls' => true,
     'unix' => false,
@@ -1063,7 +1057,7 @@ pass arrays of context options like this:
 
 ```php
 // allow insecure TLS connections
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => array(
         'bindto' => '192.168.0.1:0'
     ),
@@ -1084,7 +1078,7 @@ SSLv2/SSLv3. As of PHP 5.6+ you can also explicitly choose the TLS version you
 want to negotiate with the remote side:
 
 ```php
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tls' => array(
         'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT
     )
@@ -1110,7 +1104,7 @@ $tls = new React\Socket\SecureConnector($tcp);
 
 $unix = new React\Socket\UnixConnector();
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $tcp,
     'tls' => $tls,
     'unix' => $unix,
@@ -1136,6 +1130,24 @@ $connector->connect('google.com:80')->then(function (React\Socket\ConnectionInte
   explicitly pass a `tls://` connector like above instead.
   Internally, the `tcp://` and `tls://` connectors will always be wrapped by
   `TimeoutConnector`, unless you disable timeouts like in the above example.
+
+This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+pass the event loop instance to use for this object. You can use a `null` value
+here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+This value SHOULD NOT be given unless you're sure you want to explicitly use a
+given event loop instance.
+
+> Changelog v1.9.0: The constructur signature has been updated to take the
+> optional `$context` as the first parameter and the optional `$loop` as a second
+> argument. The previous signature has been deprecated and should not be used anymore.
+>
+> ```php
+> // constructor signature as of v1.9.0
+> $connector = new React\Socket\Connector(array $context = [], ?LoopInterface $loop = null);
+>
+> // legacy constructor signature before v1.9.0
+> $connector = new React\Socket\Connector(?LoopInterface $loop = null, array $context = []);
+> ```
 
 ### Advanced client usage
 

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -5,7 +5,6 @@ namespace React\Socket;
 use React\Dns\Config\Config as DnsConfig;
 use React\Dns\Resolver\Factory as DnsFactory;
 use React\Dns\Resolver\ResolverInterface;
-use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 
 /**
@@ -16,7 +15,7 @@ use React\EventLoop\LoopInterface;
  * as plaintext TCP/IP, secure TLS or local Unix connection streams.
  *
  * Under the hood, the `Connector` is implemented as a *higher-level facade*
- * or the lower-level connectors implemented in this package. This means it
+ * for the lower-level connectors implemented in this package. This means it
  * also shares all of their features and implementation details.
  * If you want to typehint in your higher-level protocol implementation, you SHOULD
  * use the generic [`ConnectorInterface`](#connectorinterface) instead.
@@ -27,11 +26,48 @@ final class Connector implements ConnectorInterface
 {
     private $connectors = array();
 
-    public function __construct(LoopInterface $loop = null, array $options = array())
+    /**
+     * Instantiate new `Connector`
+     *
+     * ```php
+     * $connector = new React\Socket\Connector();
+     * ```
+     *
+     * This class takes two optional arguments for more advanced usage:
+     *
+     * ```php
+     * // constructor signature as of v1.9.0
+     * $connector = new React\Socket\Connector(array $context = [], ?LoopInterface $loop = null);
+     *
+     * // legacy constructor signature before v1.9.0
+     * $connector = new React\Socket\Connector(?LoopInterface $loop = null, array $context = []);
+     * ```
+     *
+     * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+     * pass the event loop instance to use for this object. You can use a `null` value
+     * here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+     * This value SHOULD NOT be given unless you're sure you want to explicitly use a
+     * given event loop instance.
+     *
+     * @param array|LoopInterface|null $context
+     * @param null|LoopInterface|array $loop
+     * @throws \InvalidArgumentException for invalid arguments
+     */
+    public function __construct($context = array(), $loop = null)
     {
-        $loop = $loop ?: Loop::get();
+        // swap arguments for legacy constructor signature
+        if (($context instanceof LoopInterface || $context === null) && (\func_num_args() <= 1 || \is_array($loop))) {
+            $swap = $loop === null ? array(): $loop;
+            $loop = $context;
+            $context = $swap;
+        }
+
+        if (!\is_array($context) || ($loop !== null && !$loop instanceof LoopInterface)) {
+            throw new \InvalidArgumentException('Expected "array $context" and "?LoopInterface $loop" arguments');
+        }
+
         // apply default options if not explicitly given
-        $options += array(
+        $context += array(
             'tcp' => true,
             'tls' => true,
             'unix' => true,
@@ -41,25 +77,25 @@ final class Connector implements ConnectorInterface
             'happy_eyeballs' => true,
         );
 
-        if ($options['timeout'] === true) {
-            $options['timeout'] = (float)\ini_get("default_socket_timeout");
+        if ($context['timeout'] === true) {
+            $context['timeout'] = (float)\ini_get("default_socket_timeout");
         }
 
-        if ($options['tcp'] instanceof ConnectorInterface) {
-            $tcp = $options['tcp'];
+        if ($context['tcp'] instanceof ConnectorInterface) {
+            $tcp = $context['tcp'];
         } else {
             $tcp = new TcpConnector(
                 $loop,
-                \is_array($options['tcp']) ? $options['tcp'] : array()
+                \is_array($context['tcp']) ? $context['tcp'] : array()
             );
         }
 
-        if ($options['dns'] !== false) {
-            if ($options['dns'] instanceof ResolverInterface) {
-                $resolver = $options['dns'];
+        if ($context['dns'] !== false) {
+            if ($context['dns'] instanceof ResolverInterface) {
+                $resolver = $context['dns'];
             } else {
-                if ($options['dns'] !== true) {
-                    $config = $options['dns'];
+                if ($context['dns'] !== true) {
+                    $config = $context['dns'];
                 } else {
                     // try to load nameservers from system config or default to Google's public DNS
                     $config = DnsConfig::loadSystemConfigBlocking();
@@ -75,52 +111,52 @@ final class Connector implements ConnectorInterface
                 );
             }
 
-            if ($options['happy_eyeballs'] === true) {
+            if ($context['happy_eyeballs'] === true) {
                 $tcp = new HappyEyeBallsConnector($loop, $tcp, $resolver);
             } else {
                 $tcp = new DnsConnector($tcp, $resolver);
             }
         }
 
-        if ($options['tcp'] !== false) {
-            $options['tcp'] = $tcp;
+        if ($context['tcp'] !== false) {
+            $context['tcp'] = $tcp;
 
-            if ($options['timeout'] !== false) {
-                $options['tcp'] = new TimeoutConnector(
-                    $options['tcp'],
-                    $options['timeout'],
+            if ($context['timeout'] !== false) {
+                $context['tcp'] = new TimeoutConnector(
+                    $context['tcp'],
+                    $context['timeout'],
                     $loop
                 );
             }
 
-            $this->connectors['tcp'] = $options['tcp'];
+            $this->connectors['tcp'] = $context['tcp'];
         }
 
-        if ($options['tls'] !== false) {
-            if (!$options['tls'] instanceof ConnectorInterface) {
-                $options['tls'] = new SecureConnector(
+        if ($context['tls'] !== false) {
+            if (!$context['tls'] instanceof ConnectorInterface) {
+                $context['tls'] = new SecureConnector(
                     $tcp,
                     $loop,
-                    \is_array($options['tls']) ? $options['tls'] : array()
+                    \is_array($context['tls']) ? $context['tls'] : array()
                 );
             }
 
-            if ($options['timeout'] !== false) {
-                $options['tls'] = new TimeoutConnector(
-                    $options['tls'],
-                    $options['timeout'],
+            if ($context['timeout'] !== false) {
+                $context['tls'] = new TimeoutConnector(
+                    $context['tls'],
+                    $context['timeout'],
                     $loop
                 );
             }
 
-            $this->connectors['tls'] = $options['tls'];
+            $this->connectors['tls'] = $context['tls'];
         }
 
-        if ($options['unix'] !== false) {
-            if (!$options['unix'] instanceof ConnectorInterface) {
-                $options['unix'] = new UnixConnector($loop);
+        if ($context['unix'] !== false) {
+            if (!$context['unix'] instanceof ConnectorInterface) {
+                $context['unix'] = new UnixConnector($loop);
             }
-            $this->connectors['unix'] = $options['unix'];
+            $this->connectors['unix'] = $context['unix'];
         }
     }
 
@@ -140,4 +176,3 @@ final class Connector implements ConnectorInterface
         return $this->connectors[$scheme]->connect($uri);
     }
 }
-

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -22,6 +22,116 @@ class ConnectorTest extends TestCase
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
     }
 
+    public function testConstructWithLoopAssignsGivenLoop()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connector = new Connector(array(), $loop);
+
+        $ref = new \ReflectionProperty($connector, 'connectors');
+        $ref->setAccessible(true);
+        $connectors = $ref->getValue($connector);
+
+        $ref = new \ReflectionProperty($connectors['tcp'], 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($connectors['tcp']);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
+    public function testConstructWithContextAssignsGivenContext()
+    {
+        $tcp = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+
+        $connector = new Connector(array(
+            'tcp' => $tcp,
+            'dns' => false,
+            'timeout' => false
+        ));
+
+        $ref = new \ReflectionProperty($connector, 'connectors');
+        $ref->setAccessible(true);
+        $connectors = $ref->getValue($connector);
+
+        $this->assertSame($tcp, $connectors['tcp']);
+    }
+
+    public function testConstructWithLegacyContextSignatureAssignsGivenContext()
+    {
+        $tcp = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+
+        $connector = new Connector(null, array(
+            'tcp' => $tcp,
+            'dns' => false,
+            'timeout' => false
+        ));
+
+        $ref = new \ReflectionProperty($connector, 'connectors');
+        $ref->setAccessible(true);
+        $connectors = $ref->getValue($connector);
+
+        $this->assertSame($tcp, $connectors['tcp']);
+    }
+
+    public function testConstructWithLegacyLoopSignatureAssignsGivenLoop()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connector = new Connector($loop);
+
+        $ref = new \ReflectionProperty($connector, 'connectors');
+        $ref->setAccessible(true);
+        $connectors = $ref->getValue($connector);
+
+        $ref = new \ReflectionProperty($connectors['tcp'], 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($connectors['tcp']);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
+    public function testConstructWithInvalidContextThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        new Connector('foo');
+    }
+
+    public function testConstructWithInvalidLoopThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        new Connector(array(), 'foo');
+    }
+
+    public function testConstructWithContextTwiceThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        new Connector(array(), array());
+    }
+
+    public function testConstructWithLoopTwiceThrows()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $this->setExpectedException('InvalidArgumentException');
+        new Connector($loop, $loop);
+    }
+
+    public function testConstructWithNullContextAndLoopThrows()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $this->setExpectedException('InvalidArgumentException');
+        new Connector(null, $loop);
+    }
+
+    public function testConstructWithLoopAndNullContextThrows()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $this->setExpectedException('InvalidArgumentException');
+        new Connector($loop, null);
+    }
+
     public function testConnectorUsesTcpAsDefaultScheme()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -30,9 +140,9 @@ class ConnectorTest extends TestCase
         $tcp = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $tcp->expects($this->once())->method('connect')->with('127.0.0.1:80')->willReturn($promise);
 
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'tcp' => $tcp
-        ));
+        ), $loop);
 
         $connector->connect('127.0.0.1:80');
     }
@@ -45,10 +155,10 @@ class ConnectorTest extends TestCase
         $tcp = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $tcp->expects($this->once())->method('connect')->with('tcp://google.com:80')->willReturn($promise);
 
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'tcp' => $tcp,
             'dns' => false
-        ));
+        ), $loop);
 
         $connector->connect('tcp://google.com:80');
     }
@@ -56,7 +166,7 @@ class ConnectorTest extends TestCase
     public function testConnectorWithUnknownSchemeAlwaysFails()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-        $connector = new Connector($loop);
+        $connector = new Connector(array(), $loop);
 
         $promise = $connector->connect('unknown://google.com:80');
         $promise->then(null, $this->expectCallableOnce());
@@ -65,9 +175,9 @@ class ConnectorTest extends TestCase
     public function testConnectorWithDisabledTcpDefaultSchemeAlwaysFails()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'tcp' => false
-        ));
+        ), $loop);
 
         $promise = $connector->connect('google.com:80');
         $promise->then(null, $this->expectCallableOnce());
@@ -76,9 +186,9 @@ class ConnectorTest extends TestCase
     public function testConnectorWithDisabledTcpSchemeAlwaysFails()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'tcp' => false
-        ));
+        ), $loop);
 
         $promise = $connector->connect('tcp://google.com:80');
         $promise->then(null, $this->expectCallableOnce());
@@ -87,9 +197,9 @@ class ConnectorTest extends TestCase
     public function testConnectorWithDisabledTlsSchemeAlwaysFails()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'tls' => false
-        ));
+        ), $loop);
 
         $promise = $connector->connect('tls://google.com:443');
         $promise->then(null, $this->expectCallableOnce());
@@ -98,9 +208,9 @@ class ConnectorTest extends TestCase
     public function testConnectorWithDisabledUnixSchemeAlwaysFails()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'unix' => false
-        ));
+        ), $loop);
 
         $promise = $connector->connect('unix://demo.sock');
         $promise->then(null, $this->expectCallableOnce());
@@ -114,10 +224,10 @@ class ConnectorTest extends TestCase
         $resolver = $this->getMockBuilder('React\Dns\Resolver\ResolverInterface')->getMock();
         $resolver->expects($this->once())->method('resolve')->with('google.com')->willReturn($promise);
 
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'dns' => $resolver,
             'happy_eyeballs' => false,
-        ));
+        ), $loop);
 
         $connector->connect('google.com:80');
     }
@@ -134,11 +244,11 @@ class ConnectorTest extends TestCase
         $tcp = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $tcp->expects($this->once())->method('connect')->with('tcp://127.0.0.1:80?hostname=google.com')->willReturn($promise);
 
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'tcp' => $tcp,
             'dns' => $resolver,
             'happy_eyeballs' => false,
-        ));
+        ), $loop);
 
         $connector->connect('tcp://google.com:80');
     }

--- a/tests/FunctionalConnectorTest.php
+++ b/tests/FunctionalConnectorTest.php
@@ -24,7 +24,7 @@ class FunctionalConnectorTest extends TestCase
 
         $server = new TcpServer(9998, $loop);
 
-        $connector = new Connector($loop);
+        $connector = new Connector(array(), $loop);
 
         $connection = Block\await($connector->connect('localhost:9998'), $loop, self::TIMEOUT);
 
@@ -48,10 +48,10 @@ class FunctionalConnectorTest extends TestCase
 
         $socket = stream_socket_server('udp://127.0.0.1:0', $errno, $errstr, STREAM_SERVER_BIND);
 
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'dns' => 'udp://' . stream_socket_get_name($socket, false),
             'happy_eyeballs' => false
-        ));
+        ), $loop);
 
         // minimal DNS proxy stub which forwards DNS messages to actual DNS server
         $received = 0;
@@ -86,7 +86,7 @@ class FunctionalConnectorTest extends TestCase
 
         $loop = Factory::create();
 
-        $connector = new Connector($loop, array('happy_eyeballs' => true));
+        $connector = new Connector(array('happy_eyeballs' => true), $loop);
 
         $ip = Block\await($this->request('dual.tlund.se', $connector), $loop, self::TIMEOUT);
 
@@ -101,7 +101,7 @@ class FunctionalConnectorTest extends TestCase
     {
         $loop = Factory::create();
 
-        $connector = new Connector($loop, array('happy_eyeballs' => true));
+        $connector = new Connector(array('happy_eyeballs' => true), $loop);
 
         try {
             $ip = Block\await($this->request('ipv4.tlund.se', $connector), $loop, self::TIMEOUT);
@@ -122,7 +122,7 @@ class FunctionalConnectorTest extends TestCase
     {
         $loop = Factory::create();
 
-        $connector = new Connector($loop, array('happy_eyeballs' => true));
+        $connector = new Connector(array('happy_eyeballs' => true), $loop);
 
         try {
             $ip = Block\await($this->request('ipv6.tlund.se', $connector), $loop, self::TIMEOUT);
@@ -146,7 +146,7 @@ class FunctionalConnectorTest extends TestCase
         $server = new TcpServer(0, $loop);
         $uri = str_replace('tcp://', '', $server->getAddress());
 
-        $connector = new Connector($loop);
+        $connector = new Connector(array(), $loop);
         $promise = $connector->connect('tls://' . $uri);
 
         $deferred = new Deferred();

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -19,7 +19,7 @@ class IntegrationTest extends TestCase
     public function gettingStuffFromGoogleShouldWork()
     {
         $loop = Factory::create();
-        $connector = new Connector($loop);
+        $connector = new Connector(array(), $loop);
 
         $conn = Block\await($connector->connect('google.com:80'), $loop);
 
@@ -41,7 +41,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Factory::create();
-        $secureConnector = new Connector($loop);
+        $secureConnector = new Connector(array(), $loop);
 
         $conn = Block\await($secureConnector->connect('tls://google.com:443'), $loop);
 
@@ -85,7 +85,7 @@ class IntegrationTest extends TestCase
     public function gettingPlaintextStuffFromEncryptedGoogleShouldNotWork()
     {
         $loop = Factory::create();
-        $connector = new Connector($loop);
+        $connector = new Connector(array(), $loop);
 
         $conn = Block\await($connector->connect('google.com:443'), $loop);
 
@@ -110,9 +110,9 @@ class IntegrationTest extends TestCase
         $factory = new ResolverFactory();
         $dns = $factory->create('255.255.255.255', $loop);
 
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'dns' => $dns
-        ));
+        ), $loop);
 
         $this->setExpectedException('RuntimeException');
         Block\await($connector->connect('google.com:80'), $loop, self::TIMEOUT);
@@ -125,7 +125,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Factory::create();
-        $connector = new Connector($loop, array('timeout' => false));
+        $connector = new Connector(array('timeout' => false), $loop);
 
         gc_collect_cycles();
         gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
@@ -144,7 +144,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Factory::create();
-        $connector = new Connector($loop);
+        $connector = new Connector(array(), $loop);
 
         gc_collect_cycles();
         $promise = $connector->connect('8.8.8.8:80');
@@ -161,7 +161,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Factory::create();
-        $connector = new Connector($loop, array('timeout' => false));
+        $connector = new Connector(array('timeout' => false), $loop);
 
         gc_collect_cycles();
 
@@ -197,7 +197,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Factory::create();
-        $connector = new Connector($loop, array('timeout' => 0.001));
+        $connector = new Connector(array('timeout' => 0.001), $loop);
 
         gc_collect_cycles();
 
@@ -230,7 +230,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Factory::create();
-        $connector = new Connector($loop, array('timeout' => 0.000001));
+        $connector = new Connector(array('timeout' => 0.000001), $loop);
 
         gc_collect_cycles();
 
@@ -263,7 +263,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Factory::create();
-        $connector = new Connector($loop, array('timeout' => false));
+        $connector = new Connector(array('timeout' => false), $loop);
 
         gc_collect_cycles();
 
@@ -302,11 +302,11 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Factory::create();
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'tls' => array(
                 'verify_peer' => true
             )
-        ));
+        ), $loop);
 
         gc_collect_cycles();
 
@@ -342,7 +342,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Factory::create();
-        $connector = new Connector($loop, array('timeout' => false));
+        $connector = new Connector(array('timeout' => false), $loop);
 
         gc_collect_cycles();
         $promise = $connector->connect('google.com:80')->then(
@@ -360,9 +360,9 @@ class IntegrationTest extends TestCase
     {
         $loop = Factory::create();
 
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'timeout' => 0.001
-        ));
+        ), $loop);
 
         $this->setExpectedException('RuntimeException');
         Block\await($connector->connect('google.com:80'), $loop, self::TIMEOUT);
@@ -376,11 +376,11 @@ class IntegrationTest extends TestCase
 
         $loop = Factory::create();
 
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'tls' => array(
                 'verify_peer' => true
             )
-        ));
+        ), $loop);
 
         $this->setExpectedException('RuntimeException');
         Block\await($connector->connect('tls://self-signed.badssl.com:443'), $loop, self::TIMEOUT);
@@ -394,11 +394,11 @@ class IntegrationTest extends TestCase
 
         $loop = Factory::create();
 
-        $connector = new Connector($loop, array(
+        $connector = new Connector(array(
             'tls' => array(
                 'verify_peer' => false
             )
-        ));
+        ), $loop);
 
         $conn = Block\await($connector->connect('tls://self-signed.badssl.com:443'), $loop, self::TIMEOUT);
         $conn->close();


### PR DESCRIPTION
This changeset updates the `Connector` signature to take the `$context` as first argument.

```php
// unchanged
$connector = new React\Socket\Connector();

// deprecated
$connector = new React\Socket\Connector(null, $context);
$connector = new React\Socket\Connector($loop, $context);

// new
$connector = new React\Socket\Connector($context);
$connector = new React\Socket\Connector($context, $loop);
```

The new signature has been added to match the new `SocketServer` and consistently move the now commonly unneeded loop argument to the last argument. The previous signature has been deprecated and should not be used anymore. In its most basic form, both signatures are compatible. Existing code continues to work as-is.

Builds on top of #263, https://github.com/reactphp/http/pull/417 and #260