### PR TITLE
Improve error messages when accepting connections with errno/errstr

### DIFF
--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -213,7 +213,28 @@ final class TcpServer extends EventEmitter implements ServerInterface
         $this->loop->addReadStream($this->master, function ($master) use ($that) {
             $newSocket = @\stream_socket_accept($master, 0);
             if (false === $newSocket) {
-                $that->emit('error', array(new \RuntimeException('Error accepting new connection')));
+                // Match errstr from PHP's warning message.
+                // stream_socket_accept(): accept failed: Connection timed out
+                $error = \error_get_last();
+                $errstr = \preg_replace('#.*: #', '', $error['message']);
+
+                // Go through list of possible error constants to find matching errno.
+                // @codeCoverageIgnoreStart
+                $errno = 0;
+                if (\function_exists('socket_strerror')) {
+                    foreach (\get_defined_constants(false) as $name => $value) {
+                        if (\strpos($name, 'SOCKET_E') === 0 && \socket_strerror($value) === $errstr) {
+                            $errno = $value;
+                            break;
+                        }
+                    }
+                }
+                // @codeCoverageIgnoreEnd
+
+                $that->emit('error', array(new \RuntimeException(
+                    'Unable to accept new connection: ' . $errstr,
+                    $errno
+                )));
 
                 return;
             }

--- a/src/UnixServer.php
+++ b/src/UnixServer.php
@@ -113,10 +113,10 @@ final class UnixServer extends EventEmitter implements ServerInterface
 
         $that = $this;
         $this->loop->addReadStream($this->master, function ($master) use ($that) {
-            $newSocket = @\stream_socket_accept($master, 0);
-            if (false === $newSocket) {
-                $that->emit('error', array(new \RuntimeException('Error accepting new connection')));
-
+            try {
+                $newSocket = SocketServer::accept($master);
+            } catch (\RuntimeException $e) {
+                $that->emit('error', array($e));
                 return;
             }
             $that->handleConnection($newSocket);

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -292,7 +292,10 @@ class UnixServerTest extends TestCase
 
         $server = new UnixServer($this->getRandomSocketUri(), $loop);
 
-        $server->on('error', $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException')));
+        $exception = null;
+        $server->on('error', function ($e) use (&$exception) {
+            $exception = $e;
+        });
 
         $this->assertNotNull($listener);
         $socket = stream_socket_server('tcp://127.0.0.1:0');
@@ -302,6 +305,23 @@ class UnixServerTest extends TestCase
         $time = microtime(true) - $time;
 
         $this->assertLessThan(1, $time);
+
+        $this->assertInstanceOf('RuntimeException', $exception);
+        assert($exception instanceof \RuntimeException);
+        $this->assertStringStartsWith('Unable to accept new connection: ', $exception->getMessage());
+
+        return $exception;
+    }
+
+    /**
+     * @param \RuntimeException $e
+     * @requires extension sockets
+     * @depends testEmitsErrorWhenAcceptListenerFails
+     */
+    public function testEmitsTimeoutErrorWhenAcceptListenerFails(\RuntimeException $exception)
+    {
+        $this->assertEquals('Unable to accept new connection: ' . socket_strerror(SOCKET_ETIMEDOUT), $exception->getMessage());
+        $this->assertEquals(SOCKET_ETIMEDOUT, $exception->getCode());
     }
 
     public function testListenOnBusyPortThrows()


### PR DESCRIPTION
This changeset improves the error messages for failed incoming connections to include the appropriate errno/errstr. Reporting the errstr works on all supported platforms, the errno is only available when `ext-sockets` is available. Whereas it would previously report a generic "Error accepting new connection" error, it will now report the actual underlying error condition, such as this:

```diff
-Error accepting new connection
+Failed to accept new connection: Connection timed out
```

Builds on top of #266, #265, #171, https://github.com/reactphp/dns/pull/171, https://github.com/reactphp/dns/pull/172 and others
Together with #244 this is a prerequisite for #164 