### PR TITLE
Skip unsupported tests for HHVM

### DIFF
--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -315,6 +315,10 @@ class TcpServerTest extends TestCase
      */
     public function testEmitsTimeoutErrorWhenAcceptListenerFails(\RuntimeException $exception)
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('not supported on HHVM');
+        }
+
         $this->assertEquals('Unable to accept new connection: ' . socket_strerror(SOCKET_ETIMEDOUT), $exception->getMessage());
         $this->assertEquals(SOCKET_ETIMEDOUT, $exception->getCode());
     }

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -320,6 +320,10 @@ class UnixServerTest extends TestCase
      */
     public function testEmitsTimeoutErrorWhenAcceptListenerFails(\RuntimeException $exception)
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('not supported on HHVM');
+        }
+
         $this->assertEquals('Unable to accept new connection: ' . socket_strerror(SOCKET_ETIMEDOUT), $exception->getMessage());
         $this->assertEquals(SOCKET_ETIMEDOUT, $exception->getCode());
     }


### PR DESCRIPTION
The improved error messages in #267 by @clue are not supported under HHVM.