### PR TITLE
Improve error messages for failed connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ $connector = new React\Socket\Connector();
 $connector->connect('127.0.0.1:8080')->then(function (React\Socket\ConnectionInterface $connection) {
     $connection->pipe(new React\Stream\WritableResourceStream(STDOUT));
     $connection->write("Hello World!\n");
+}, function (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });
 ```
 
@@ -905,6 +907,8 @@ $connector = new React\Socket\Connector();
 $connector->connect($uri)->then(function (React\Socket\ConnectionInterface $connection) {
     $connection->write('...');
     $connection->end();
+}, function (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });
 ```
 

--- a/examples/11-http-client.php
+++ b/examples/11-http-client.php
@@ -29,4 +29,6 @@ $connector->connect($host. ':80')->then(function (ConnectionInterface $connectio
     });
 
     $connection->write("GET / HTTP/1.0\r\nHost: $host\r\n\r\n");
-}, 'printf');
+}, function (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
+});

--- a/examples/12-https-client.php
+++ b/examples/12-https-client.php
@@ -29,4 +29,6 @@ $connector->connect('tls://' . $host . ':443')->then(function (ConnectionInterfa
     });
 
     $connection->write("GET / HTTP/1.0\r\nHost: $host\r\n\r\n");
-}, 'printf');
+}, function (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
+});

--- a/examples/21-netcat-client.php
+++ b/examples/21-netcat-client.php
@@ -48,8 +48,8 @@ $connector->connect($argv[1])->then(function (ConnectionInterface $connection) u
     $connection->pipe($stdout);
 
     // report errors to STDERR
-    $connection->on('error', function ($error) use ($stderr) {
-        $stderr->write('Stream ERROR: ' . $error . PHP_EOL);
+    $connection->on('error', function (Exception $e) use ($stderr) {
+        $stderr->write('Stream error: ' . $e->getMessage() . PHP_EOL);
     });
 
     // report closing and stop reading from input
@@ -59,6 +59,6 @@ $connector->connect($argv[1])->then(function (ConnectionInterface $connection) u
     });
 
     $stderr->write('Connected' . PHP_EOL);
-}, function ($error) use ($stderr) {
-    $stderr->write('Connection ERROR: ' . $error . PHP_EOL);
+}, function (Exception $e) use ($stderr) {
+    $stderr->write('Connection error: ' . $e->getMessage() . PHP_EOL);
 });

--- a/examples/22-http-client.php
+++ b/examples/22-http-client.php
@@ -53,4 +53,6 @@ $connector->connect($target)->then(function (ConnectionInterface $connection) us
     $connection->pipe($stdout);
 
     $connection->write("GET $resource HTTP/1.0\r\nHost: $host\r\n\r\n");
-}, 'printf');
+}, function (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
+});

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -175,4 +175,61 @@ final class Connector implements ConnectorInterface
 
         return $this->connectors[$scheme]->connect($uri);
     }
+
+
+    /**
+     * [internal] Builds on URI from the given URI parts and ip address with original hostname as query
+     *
+     * @param array  $parts
+     * @param string $host
+     * @param string $ip
+     * @return string
+     * @internal
+     */
+    public static function uri(array $parts, $host, $ip)
+    {
+        $uri = '';
+
+        // prepend original scheme if known
+        if (isset($parts['scheme'])) {
+            $uri .= $parts['scheme'] . '://';
+        }
+
+        if (\strpos($ip, ':') !== false) {
+            // enclose IPv6 addresses in square brackets before appending port
+            $uri .= '[' . $ip . ']';
+        } else {
+            $uri .= $ip;
+        }
+
+        // append original port if known
+        if (isset($parts['port'])) {
+            $uri .= ':' . $parts['port'];
+        }
+
+        // append orignal path if known
+        if (isset($parts['path'])) {
+            $uri .= $parts['path'];
+        }
+
+        // append original query if known
+        if (isset($parts['query'])) {
+            $uri .= '?' . $parts['query'];
+        }
+
+        // append original hostname as query if resolved via DNS and if
+        // destination URI does not contain "hostname" query param already
+        $args = array();
+        \parse_str(isset($parts['query']) ? $parts['query'] : '', $args);
+        if ($host !== $ip && !isset($args['hostname'])) {
+            $uri .= (isset($parts['query']) ? '&' : '?') . 'hostname=' . \rawurlencode($host);
+        }
+
+        // append original fragment if known
+        if (isset($parts['fragment'])) {
+            $uri .= '#' . $parts['fragment'];
+        }
+
+        return $uri;
+    }
 }

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -19,15 +19,17 @@ final class DnsConnector implements ConnectorInterface
 
     public function connect($uri)
     {
+        $original = $uri;
         if (\strpos($uri, '://') === false) {
-            $parts = \parse_url('tcp://' . $uri);
+            $uri = 'tcp://' . $uri;
+            $parts = \parse_url($uri);
             unset($parts['scheme']);
         } else {
             $parts = \parse_url($uri);
         }
 
         if (!$parts || !isset($parts['host'])) {
-            return Promise\reject(new \InvalidArgumentException('Given URI "' . $uri . '" is invalid'));
+            return Promise\reject(new \InvalidArgumentException('Given URI "' . $original . '" is invalid'));
         }
 
         $host = \trim($parts['host'], '[]');
@@ -35,7 +37,7 @@ final class DnsConnector implements ConnectorInterface
 
         // skip DNS lookup / URI manipulation if this URI already contains an IP
         if (false !== \filter_var($host, \FILTER_VALIDATE_IP)) {
-            return $connector->connect($uri);
+            return $connector->connect($original);
         }
 
         $promise = $this->resolver->resolve($host);

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -46,47 +46,7 @@ final class DnsConnector implements ConnectorInterface
                 // resolve/reject with result of DNS lookup
                 $promise->then(function ($ip) use (&$promise, &$resolved, $connector, $host, $parts) {
                     $resolved = $ip;
-                    $uri = '';
-
-                    // prepend original scheme if known
-                    if (isset($parts['scheme'])) {
-                        $uri .= $parts['scheme'] . '://';
-                    }
-
-                    if (\strpos($ip, ':') !== false) {
-                        // enclose IPv6 addresses in square brackets before appending port
-                        $uri .= '[' . $ip . ']';
-                    } else {
-                        $uri .= $ip;
-                    }
-
-                    // append original port if known
-                    if (isset($parts['port'])) {
-                        $uri .= ':' . $parts['port'];
-                    }
-
-                    // append orignal path if known
-                    if (isset($parts['path'])) {
-                        $uri .= $parts['path'];
-                    }
-
-                    // append original query if known
-                    if (isset($parts['query'])) {
-                        $uri .= '?' . $parts['query'];
-                    }
-
-                    // append original hostname as query if resolved via DNS and if
-                    // destination URI does not contain "hostname" query param already
-                    $args = array();
-                    \parse_str(isset($parts['query']) ? $parts['query'] : '', $args);
-                    if ($host !== $ip && !isset($args['hostname'])) {
-                        $uri .= (isset($parts['query']) ? '&' : '?') . 'hostname=' . \rawurlencode($host);
-                    }
-
-                    // append original fragment if known
-                    if (isset($parts['fragment'])) {
-                        $uri .= '#' . $parts['fragment'];
-                    }
+                    $uri = Connector::uri($parts, $host, $ip);
 
                     return $promise = $connector->connect($uri);
                 }, function ($e) use ($uri, $reject) {

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -59,6 +59,26 @@ final class DnsConnector implements ConnectorInterface
                                 $e->getCode(),
                                 $e
                             );
+
+                            // avoid garbage references by replacing all closures in call stack.
+                            // what a lovely piece of code!
+                            $r = new \ReflectionProperty('Exception', 'trace');
+                            $r->setAccessible(true);
+                            $trace = $r->getValue($e);
+
+                            // Exception trace arguments are not available on some PHP 7.4 installs
+                            // @codeCoverageIgnoreStart
+                            foreach ($trace as &$one) {
+                                if (isset($one['args'])) {
+                                    foreach ($one['args'] as &$arg) {
+                                        if ($arg instanceof \Closure) {
+                                            $arg = 'Object(' . \get_class($arg) . ')';
+                                        }
+                                    }
+                                }
+                            }
+                            // @codeCoverageIgnoreEnd
+                            $r->setValue($e, $trace);
                         }
 
                         throw $e;

--- a/src/HappyEyeBallsConnectionBuilder.php
+++ b/src/HappyEyeBallsConnectionBuilder.php
@@ -175,11 +175,12 @@ final class HappyEyeBallsConnectionBuilder
 
             $that->failureCount++;
 
+            $message = \preg_replace('/^(Connection to [^ ]+)[&?]hostname=[^ &]+/', '$1', $e->getMessage());
             if (\strpos($ip, ':') === false) {
-                $that->lastError4 = $e->getMessage();
+                $that->lastError4 = $message;
                 $that->lastErrorFamily = 4;
             } else {
-                $that->lastError6 = $e->getMessage();
+                $that->lastError6 = $message;
                 $that->lastErrorFamily = 6;
             }
 

--- a/src/HappyEyeBallsConnectionBuilder.php
+++ b/src/HappyEyeBallsConnectionBuilder.php
@@ -222,47 +222,7 @@ final class HappyEyeBallsConnectionBuilder
      */
     public function attemptConnection($ip)
     {
-        $uri = '';
-
-        // prepend original scheme if known
-        if (isset($this->parts['scheme'])) {
-            $uri .= $this->parts['scheme'] . '://';
-        }
-
-        if (\strpos($ip, ':') !== false) {
-            // enclose IPv6 addresses in square brackets before appending port
-            $uri .= '[' . $ip . ']';
-        } else {
-            $uri .= $ip;
-        }
-
-        // append original port if known
-        if (isset($this->parts['port'])) {
-            $uri .= ':' . $this->parts['port'];
-        }
-
-        // append orignal path if known
-        if (isset($this->parts['path'])) {
-            $uri .= $this->parts['path'];
-        }
-
-        // append original query if known
-        if (isset($this->parts['query'])) {
-            $uri .= '?' . $this->parts['query'];
-        }
-
-        // append original hostname as query if resolved via DNS and if
-        // destination URI does not contain "hostname" query param already
-        $args = array();
-        \parse_str(isset($this->parts['query']) ? $this->parts['query'] : '', $args);
-        if ($this->host !== $ip && !isset($args['hostname'])) {
-            $uri .= (isset($this->parts['query']) ? '&' : '?') . 'hostname=' . \rawurlencode($this->host);
-        }
-
-        // append original fragment if known
-        if (isset($this->parts['fragment'])) {
-            $uri .= '#' . $this->parts['fragment'];
-        }
+        $uri = Connector::uri($this->parts, $this->host, $ip);
 
         return $this->connector->connect($uri);
     }

--- a/src/HappyEyeBallsConnector.php
+++ b/src/HappyEyeBallsConnector.php
@@ -31,23 +31,24 @@ final class HappyEyeBallsConnector implements ConnectorInterface
 
     public function connect($uri)
     {
-
+        $original = $uri;
         if (\strpos($uri, '://') === false) {
-            $parts = \parse_url('tcp://' . $uri);
+            $uri = 'tcp://' . $uri;
+            $parts = \parse_url($uri);
             unset($parts['scheme']);
         } else {
             $parts = \parse_url($uri);
         }
 
         if (!$parts || !isset($parts['host'])) {
-            return Promise\reject(new \InvalidArgumentException('Given URI "' . $uri . '" is invalid'));
+            return Promise\reject(new \InvalidArgumentException('Given URI "' . $original . '" is invalid'));
         }
 
         $host = \trim($parts['host'], '[]');
 
         // skip DNS lookup / URI manipulation if this URI already contains an IP
         if (false !== \filter_var($host, \FILTER_VALIDATE_IP)) {
-            return $this->connector->connect($uri);
+            return $this->connector->connect($original);
         }
 
         $builder = new HappyEyeBallsConnectionBuilder(

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -37,12 +37,12 @@ final class SecureConnector implements ConnectorInterface
             return Promise\reject(new \InvalidArgumentException('Given URI "' . $uri . '" is invalid'));
         }
 
-        $uri = \str_replace('tls://', '', $uri);
         $context = $this->context;
-
         $encryption = $this->streamEncryption;
         $connected = false;
-        $promise = $this->connector->connect($uri)->then(function (ConnectionInterface $connection) use ($context, $encryption, $uri, &$promise, &$connected) {
+        $promise = $this->connector->connect(
+            \str_replace('tls://', '', $uri)
+        )->then(function (ConnectionInterface $connection) use ($context, $encryption, $uri, &$promise, &$connected) {
             // (unencrypted) TCP/IP connection succeeded
             $connected = true;
 
@@ -66,6 +66,17 @@ final class SecureConnector implements ConnectorInterface
                     $error->getCode()
                 );
             });
+        }, function (\Exception $e) use ($uri) {
+            if ($e instanceof \RuntimeException) {
+                $message = \preg_replace('/^Connection to [^ ]+/', '', $e->getMessage());
+                $e = new \RuntimeException(
+                    'Connection to ' . $uri . $message,
+                    $e->getCode(),
+                    $e
+                );
+            }
+
+            throw $e;
         });
 
         return new \React\Promise\Promise(

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -81,29 +81,55 @@ class DnsConnectorTest extends TestCase
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
     }
 
-    public function testRejectsWithTcpConnectorRejectionIfGivenIp()
+    public function testConnectRejectsIfGivenIpAndTcpConnectorRejectsWithRuntimeException()
     {
-        $promise = Promise\reject(new \RuntimeException('Connection failed'));
+        $promise = Promise\reject(new \RuntimeException('Connection to tcp://1.2.3.4:80 failed: Connection failed', 42));
         $this->resolver->expects($this->never())->method('resolve');
-        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80'))->willReturn($promise);
+        $this->tcp->expects($this->once())->method('connect')->with('1.2.3.4:80')->willReturn($promise);
 
         $promise = $this->connector->connect('1.2.3.4:80');
         $promise->cancel();
 
-        $this->setExpectedException('RuntimeException', 'Connection failed');
+        $this->setExpectedException('RuntimeException', 'Connection to tcp://1.2.3.4:80 failed: Connection failed', 42);
         $this->throwRejection($promise);
     }
 
-    public function testRejectsWithTcpConnectorRejectionAfterDnsIsResolved()
+    public function testConnectRejectsIfGivenIpAndTcpConnectorRejectsWithInvalidArgumentException()
     {
-        $promise = Promise\reject(new \RuntimeException('Connection failed'));
-        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->willReturn(Promise\resolve('1.2.3.4'));
-        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80?hostname=example.com'))->willReturn($promise);
+        $promise = Promise\reject(new \InvalidArgumentException('Invalid', 42));
+        $this->resolver->expects($this->never())->method('resolve');
+        $this->tcp->expects($this->once())->method('connect')->with('1.2.3.4:80')->willReturn($promise);
+
+        $promise = $this->connector->connect('1.2.3.4:80');
+        $promise->cancel();
+
+        $this->setExpectedException('InvalidArgumentException', 'Invalid', 42);
+        $this->throwRejection($promise);
+    }
+
+    public function testConnectRejectsWithOriginalHostnameInMessageAfterResolvingIfTcpConnectorRejectsWithRuntimeException()
+    {
+        $promise = Promise\reject(new \RuntimeException('Connection to tcp://1.2.3.4:80?hostname=example.com failed: Connection failed', 42));
+        $this->resolver->expects($this->once())->method('resolve')->with('example.com')->willReturn(Promise\resolve('1.2.3.4'));
+        $this->tcp->expects($this->once())->method('connect')->with('1.2.3.4:80?hostname=example.com')->willReturn($promise);
 
         $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
 
-        $this->setExpectedException('RuntimeException', 'Connection failed');
+        $this->setExpectedException('RuntimeException', 'Connection to example.com:80 failed: Connection to tcp://1.2.3.4:80 failed: Connection failed', 42);
+        $this->throwRejection($promise);
+    }
+
+    public function testConnectRejectsWithOriginalExceptionAfterResolvingIfTcpConnectorRejectsWithInvalidArgumentException()
+    {
+        $promise = Promise\reject(new \InvalidArgumentException('Invalid', 42));
+        $this->resolver->expects($this->once())->method('resolve')->with('example.com')->willReturn(Promise\resolve('1.2.3.4'));
+        $this->tcp->expects($this->once())->method('connect')->with('1.2.3.4:80?hostname=example.com')->willReturn($promise);
+
+        $promise = $this->connector->connect('example.com:80');
+        $promise->cancel();
+
+        $this->setExpectedException('InvalidArgumentException', 'Invalid', 42);
         $this->throwRejection($promise);
     }
 

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -116,7 +116,7 @@ class DnsConnectorTest extends TestCase
         $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
 
-        $this->setExpectedException('RuntimeException', 'Connection to example.com:80 failed: Connection to tcp://1.2.3.4:80 failed: Connection failed', 42);
+        $this->setExpectedException('RuntimeException', 'Connection to tcp://example.com:80 failed: Connection to tcp://1.2.3.4:80 failed: Connection failed', 42);
         $this->throwRejection($promise);
     }
 
@@ -141,7 +141,7 @@ class DnsConnectorTest extends TestCase
 
         $promise = $this->connector->connect('example.invalid:80');
 
-        $this->setExpectedException('RuntimeException', 'Connection to example.invalid:80 failed during DNS lookup: DNS error');
+        $this->setExpectedException('RuntimeException', 'Connection to tcp://example.invalid:80 failed during DNS lookup: DNS error');
         $this->throwRejection($promise);
     }
 
@@ -167,7 +167,7 @@ class DnsConnectorTest extends TestCase
         $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
 
-        $this->setExpectedException('RuntimeException', 'Connection to example.com:80 cancelled during DNS lookup');
+        $this->setExpectedException('RuntimeException', 'Connection to tcp://example.com:80 cancelled during DNS lookup');
         $this->throwRejection($promise);
     }
 

--- a/tests/FunctionalConnectorTest.php
+++ b/tests/FunctionalConnectorTest.php
@@ -144,10 +144,10 @@ class FunctionalConnectorTest extends TestCase
         $loop = Factory::create();
 
         $server = new TcpServer(0, $loop);
-        $uri = str_replace('tcp://', '', $server->getAddress());
+        $uri = str_replace('tcp://', 'tls://', $server->getAddress());
 
         $connector = new Connector(array(), $loop);
-        $promise = $connector->connect('tls://' . $uri);
+        $promise = $connector->connect($uri);
 
         $deferred = new Deferred();
         $server->on('connection', function (ConnectionInterface $connection) use ($promise, $deferred, $loop) {

--- a/tests/HappyEyeBallsConnectorTest.php
+++ b/tests/HappyEyeBallsConnectorTest.php
@@ -256,7 +256,7 @@ class HappyEyeBallsConnectorTest extends TestCase
             $that->throwRejection($promise);
         });
 
-        $this->setExpectedException('RuntimeException', 'Connection to example.invalid:80 failed during DNS lookup: DNS error');
+        $this->setExpectedException('RuntimeException', 'Connection to tcp://example.invalid:80 failed during DNS lookup: DNS error');
         $this->loop->run();
     }
 
@@ -275,7 +275,7 @@ class HappyEyeBallsConnectorTest extends TestCase
             $that->throwRejection($promise);
         });
 
-        $this->setExpectedException('RuntimeException', 'Connection to example.com:80 cancelled during DNS lookup');
+        $this->setExpectedException('RuntimeException', 'Connection to tcp://example.com:80 cancelled during DNS lookup');
         $this->loop->run();
     }
 


### PR DESCRIPTION
This changeset improves error messages for failed connections. In particular, failed TCP/IP connections using the happy eyeballs connector (the default) or the old DNS connector will now report the hostname once at the beginning of the message and will not show its internal hostname parameter multiple times:

```diff
- Connection to tcp://localhost:80 failed: Last error for IPv4: Connection to tcp://127.0.0.1:80?hostname=localhost failed: Connection refused. Previous error for IPv6: Connection to tcp://[::1]:80?hostname=localhost failed: Connection refused
+ Connection to tcp://localhost:80 failed: Last error for IPv4: Connection to tcp://127.0.0.1:80 failed: Connection refused. Previous error for IPv6: Connection to tcp://[::1]:80 failed: Connection refused
```

Likewise, we now make sure to always consistently include the URI scheme used in the error message. For instance, failed TLS connections will now include the appropriate URI scheme for the start of the message and show the underlying URI scheme for underlying TCP/IP connection issues such as this:

```diff
- Connection to localhost:443 failed: Last error for IPv4: Connection to tcp://127.0.0.1:443?hostname=localhost failed: Connection refused. Previous error for IPv6: Connection to tcp://[::1]:443?hostname=localhost failed: Connection refused
+ Connection to tls://localhost:443 failed: Last error for IPv4: Connection to tcp://127.0.0.1:443 failed: Connection refused. Previous error for IPv6: Connection to tcp://[::1]:443 failed: Connection refused
```

Builds on top of #265, #266, #267 and others such as https://github.com/clue/reactphp-redis/pull/116, https://github.com/friends-of-reactphp/mysql/pull/141 and more