### PR TITLE
Improve error messages for failed connections to include errno

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ $socket->on('error', function (Exception $e) {
 Note that this is not a fatal error event, i.e. the server keeps listening for
 new connections even after this event.
 
-
 #### getAddress()
 
 The `getAddress(): ?string` method can be used to

--- a/examples/01-echo-server.php
+++ b/examples/01-echo-server.php
@@ -19,6 +19,7 @@
 // You can also use systemd socket activation and listen on an inherited file descriptor:
 //
 // $ systemd-socket-activate -l 8000 php examples/01-echo-server.php php://fd/3
+// $ telnet localhost 8000
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -31,8 +32,14 @@ $socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '127.0.0.1:
 $socket->on('connection', function (React\Socket\ConnectionInterface $connection) {
     echo '[' . $connection->getRemoteAddress() . ' connected]' . PHP_EOL;
     $connection->pipe($connection);
+
+    $connection->on('close', function () use ($connection) {
+        echo '[' . $connection->getRemoteAddress() . ' disconnected]' . PHP_EOL;
+    });
 });
 
-$socket->on('error', 'printf');
+$socket->on('error', function (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
+});
 
 echo 'Listening on ' . $socket->getAddress() . PHP_EOL;

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -169,7 +169,8 @@ final class Connector implements ConnectorInterface
 
         if (!isset($this->connectors[$scheme])) {
             return \React\Promise\reject(new \RuntimeException(
-                'No connector available for URI scheme "' . $scheme . '"'
+                'No connector available for URI scheme "' . $scheme . '"',
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
             ));
         }
 

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -169,7 +169,7 @@ final class Connector implements ConnectorInterface
 
         if (!isset($this->connectors[$scheme])) {
             return \React\Promise\reject(new \RuntimeException(
-                'No connector available for URI scheme "' . $scheme . '"',
+                'No connector available for URI scheme "' . $scheme . '" (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
             ));
         }

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -91,7 +91,10 @@ final class DnsConnector implements ConnectorInterface
                 // cancellation should reject connection attempt
                 // reject DNS resolution with custom reason, otherwise rely on connection cancellation below
                 if ($resolved === null) {
-                    $reject(new \RuntimeException('Connection to ' . $uri . ' cancelled during DNS lookup'));
+                    $reject(new \RuntimeException(
+                        'Connection to ' . $uri . ' cancelled during DNS lookup',
+                        \defined('SOCKET_ECONNABORTED') ? \SOCKET_ECONNABORTED : 103
+                    ));
                 }
 
                 // (try to) cancel pending DNS lookup / connection attempt

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -29,7 +29,10 @@ final class DnsConnector implements ConnectorInterface
         }
 
         if (!$parts || !isset($parts['host'])) {
-            return Promise\reject(new \InvalidArgumentException('Given URI "' . $original . '" is invalid'));
+            return Promise\reject(new \InvalidArgumentException(
+                'Given URI "' . $original . '" is invalid',
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+            ));
         }
 
         $host = \trim($parts['host'], '[]');

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -30,7 +30,7 @@ final class DnsConnector implements ConnectorInterface
 
         if (!$parts || !isset($parts['host'])) {
             return Promise\reject(new \InvalidArgumentException(
-                'Given URI "' . $original . '" is invalid',
+                'Given URI "' . $original . '" is invalid (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
             ));
         }
@@ -95,7 +95,7 @@ final class DnsConnector implements ConnectorInterface
                 // reject DNS resolution with custom reason, otherwise rely on connection cancellation below
                 if ($resolved === null) {
                     $reject(new \RuntimeException(
-                        'Connection to ' . $uri . ' cancelled during DNS lookup',
+                        'Connection to ' . $uri . ' cancelled during DNS lookup (ECONNABORTED)',
                         \defined('SOCKET_ECONNABORTED') ? \SOCKET_ECONNABORTED : 103
                     ));
                 }

--- a/src/FdServer.php
+++ b/src/FdServer.php
@@ -81,7 +81,10 @@ final class FdServer extends EventEmitter implements ServerInterface
             $fd = (int) $m[1];
         }
         if (!\is_int($fd) || $fd < 0 || $fd >= \PHP_INT_MAX) {
-            throw new \InvalidArgumentException('Invalid FD number given');
+            throw new \InvalidArgumentException(
+                'Invalid FD number given',
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+            );
         }
 
         $this->loop = $loop ?: Loop::get();
@@ -95,7 +98,10 @@ final class FdServer extends EventEmitter implements ServerInterface
             $errno = isset($m[1]) ? (int) $m[1] : 0;
             $errstr = isset($m[2]) ? $m[2] : $error['message'];
 
-            throw new \RuntimeException('Failed to listen on FD ' . $fd . ': ' . $errstr, $errno);
+            throw new \RuntimeException(
+                'Failed to listen on FD ' . $fd . ': ' . $errstr,
+                $errno
+            );
         }
 
         $meta = \stream_get_meta_data($this->master);
@@ -105,7 +111,10 @@ final class FdServer extends EventEmitter implements ServerInterface
             $errno = \defined('SOCKET_ENOTSOCK') ? \SOCKET_ENOTSOCK : 88;
             $errstr = \function_exists('socket_strerror') ? \socket_strerror($errno) : 'Not a socket';
 
-            throw new \RuntimeException('Failed to listen on FD ' . $fd . ': ' . $errstr, $errno);
+            throw new \RuntimeException(
+                'Failed to listen on FD ' . $fd . ': ' . $errstr,
+                $errno
+            );
         }
 
         // Socket should not have a peer address if this is a listening socket.
@@ -116,7 +125,10 @@ final class FdServer extends EventEmitter implements ServerInterface
             $errno = \defined('SOCKET_EISCONN') ? \SOCKET_EISCONN : 106;
             $errstr = \function_exists('socket_strerror') ? \socket_strerror($errno) : 'Socket is connected';
 
-            throw new \RuntimeException('Failed to listen on FD ' . $fd . ': ' . $errstr, $errno);
+            throw new \RuntimeException(
+                'Failed to listen on FD ' . $fd . ': ' . $errstr,
+                $errno
+            );
         }
 
         // Assume this is a Unix domain socket (UDS) when its listening address doesn't parse as a valid URL with a port.

--- a/src/FdServer.php
+++ b/src/FdServer.php
@@ -82,7 +82,7 @@ final class FdServer extends EventEmitter implements ServerInterface
         }
         if (!\is_int($fd) || $fd < 0 || $fd >= \PHP_INT_MAX) {
             throw new \InvalidArgumentException(
-                'Invalid FD number given',
+                'Invalid FD number given (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
             );
         }
@@ -99,7 +99,7 @@ final class FdServer extends EventEmitter implements ServerInterface
             $errstr = isset($m[2]) ? $m[2] : $error['message'];
 
             throw new \RuntimeException(
-                'Failed to listen on FD ' . $fd . ': ' . $errstr,
+                'Failed to listen on FD ' . $fd . ': ' . $errstr . SocketServer::errconst($errno),
                 $errno
             );
         }
@@ -112,7 +112,7 @@ final class FdServer extends EventEmitter implements ServerInterface
             $errstr = \function_exists('socket_strerror') ? \socket_strerror($errno) : 'Not a socket';
 
             throw new \RuntimeException(
-                'Failed to listen on FD ' . $fd . ': ' . $errstr,
+                'Failed to listen on FD ' . $fd . ': ' . $errstr . ' (ENOTSOCK)',
                 $errno
             );
         }
@@ -126,7 +126,7 @@ final class FdServer extends EventEmitter implements ServerInterface
             $errstr = \function_exists('socket_strerror') ? \socket_strerror($errno) : 'Socket is connected';
 
             throw new \RuntimeException(
-                'Failed to listen on FD ' . $fd . ': ' . $errstr,
+                'Failed to listen on FD ' . $fd . ': ' . $errstr . ' (EISCONN)',
                 $errno
             );
         }

--- a/src/HappyEyeBallsConnectionBuilder.php
+++ b/src/HappyEyeBallsConnectionBuilder.php
@@ -104,7 +104,7 @@ final class HappyEyeBallsConnectionBuilder
             })->then($lookupResolve(Message::TYPE_A));
         }, function ($_, $reject) use ($that, &$timer) {
             $reject(new \RuntimeException(
-                'Connection to ' . $that->uri . ' cancelled' . (!$that->connectionPromises ? ' during DNS lookup' : ''),
+                'Connection to ' . $that->uri . ' cancelled' . (!$that->connectionPromises ? ' during DNS lookup' : '') . ' (ECONNABORTED)',
                 \defined('SOCKET_ECONNABORTED') ? \SOCKET_ECONNABORTED : 103
             ));
             $_ = $reject = null;

--- a/src/HappyEyeBallsConnectionBuilder.php
+++ b/src/HappyEyeBallsConnectionBuilder.php
@@ -103,7 +103,10 @@ final class HappyEyeBallsConnectionBuilder
                 return $deferred->promise();
             })->then($lookupResolve(Message::TYPE_A));
         }, function ($_, $reject) use ($that, &$timer) {
-            $reject(new \RuntimeException('Connection to ' . $that->uri . ' cancelled' . (!$that->connectionPromises ? ' during DNS lookup' : '')));
+            $reject(new \RuntimeException(
+                'Connection to ' . $that->uri . ' cancelled' . (!$that->connectionPromises ? ' during DNS lookup' : ''),
+                \defined('SOCKET_ECONNABORTED') ? \SOCKET_ECONNABORTED : 103
+            ));
             $_ = $reject = null;
 
             $that->cleanUp();

--- a/src/HappyEyeBallsConnectionBuilder.php
+++ b/src/HappyEyeBallsConnectionBuilder.php
@@ -143,7 +143,11 @@ final class HappyEyeBallsConnectionBuilder
             }
 
             if ($that->hasBeenResolved() && $that->ipsCount === 0) {
-                $reject(new \RuntimeException($that->error()));
+                $reject(new \RuntimeException(
+                    $that->error(),
+                    0,
+                    $e
+                ));
             }
 
             // Exception already handled above, so don't throw an unhandled rejection here
@@ -201,7 +205,11 @@ final class HappyEyeBallsConnectionBuilder
             if ($that->ipsCount === $that->failureCount) {
                 $that->cleanUp();
 
-                $reject(new \RuntimeException($that->error()));
+                $reject(new \RuntimeException(
+                    $that->error(),
+                    $e->getCode(),
+                    $e
+                ));
             }
         });
 

--- a/src/HappyEyeBallsConnector.php
+++ b/src/HappyEyeBallsConnector.php
@@ -41,7 +41,10 @@ final class HappyEyeBallsConnector implements ConnectorInterface
         }
 
         if (!$parts || !isset($parts['host'])) {
-            return Promise\reject(new \InvalidArgumentException('Given URI "' . $original . '" is invalid'));
+            return Promise\reject(new \InvalidArgumentException(
+                'Given URI "' . $original . '" is invalid',
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+            ));
         }
 
         $host = \trim($parts['host'], '[]');

--- a/src/HappyEyeBallsConnector.php
+++ b/src/HappyEyeBallsConnector.php
@@ -42,7 +42,7 @@ final class HappyEyeBallsConnector implements ConnectorInterface
 
         if (!$parts || !isset($parts['host'])) {
             return Promise\reject(new \InvalidArgumentException(
-                'Given URI "' . $original . '" is invalid',
+                'Given URI "' . $original . '" is invalid (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
             ));
         }

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -34,7 +34,10 @@ final class SecureConnector implements ConnectorInterface
 
         $parts = \parse_url($uri);
         if (!$parts || !isset($parts['scheme']) || $parts['scheme'] !== 'tls') {
-            return Promise\reject(new \InvalidArgumentException('Given URI "' . $uri . '" is invalid'));
+            return Promise\reject(new \InvalidArgumentException(
+                'Given URI "' . $uri . '" is invalid',
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+            ));
         }
 
         $context = $this->context;

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -35,7 +35,7 @@ final class SecureConnector implements ConnectorInterface
         $parts = \parse_url($uri);
         if (!$parts || !isset($parts['scheme']) || $parts['scheme'] !== 'tls') {
             return Promise\reject(new \InvalidArgumentException(
-                'Given URI "' . $uri . '" is invalid',
+                'Given URI "' . $uri . '" is invalid (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
             ));
         }
@@ -109,7 +109,7 @@ final class SecureConnector implements ConnectorInterface
             function ($_, $reject) use (&$promise, $uri, &$connected) {
                 if ($connected) {
                     $reject(new \RuntimeException(
-                        'Connection to ' . $uri . ' cancelled during TLS handshake',
+                        'Connection to ' . $uri . ' cancelled during TLS handshake (ECONNABORTED)',
                         \defined('SOCKET_ECONNABORTED') ? \SOCKET_ECONNABORTED : 103
                     ));
                 }

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -105,7 +105,10 @@ final class SecureConnector implements ConnectorInterface
             },
             function ($_, $reject) use (&$promise, $uri, &$connected) {
                 if ($connected) {
-                    $reject(new \RuntimeException('Connection to ' . $uri . ' cancelled during TLS handshake'));
+                    $reject(new \RuntimeException(
+                        'Connection to ' . $uri . ' cancelled during TLS handshake',
+                        \defined('SOCKET_ECONNABORTED') ? \SOCKET_ECONNABORTED : 103
+                    ));
                 }
 
                 $promise->cancel();

--- a/src/SocketServer.php
+++ b/src/SocketServer.php
@@ -52,7 +52,10 @@ final class SocketServer extends EventEmitter implements ServerInterface
             $server = new FdServer($uri, $loop);
         } else {
             if (preg_match('#^(?:\w+://)?\d+$#', $uri)) {
-                throw new \InvalidArgumentException('Invalid URI given');
+                throw new \InvalidArgumentException(
+                    'Invalid URI given',
+                    \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                );
             }
 
             $server = new TcpServer(str_replace('tls://', '', $uri), $loop, $context['tcp']);

--- a/src/StreamEncryption.php
+++ b/src/StreamEncryption.php
@@ -125,13 +125,13 @@ class StreamEncryption
             if (\feof($socket) || $error === null) {
                 // EOF or failed without error => connection closed during handshake
                 $d->reject(new \UnexpectedValueException(
-                    'Connection lost during TLS handshake',
+                    'Connection lost during TLS handshake (ECONNRESET)',
                     \defined('SOCKET_ECONNRESET') ? \SOCKET_ECONNRESET : 104
                 ));
             } else {
                 // handshake failed with error message
                 $d->reject(new \UnexpectedValueException(
-                    'Unable to complete TLS handshake: ' . $error
+                    $error
                 ));
             }
         } else {

--- a/src/StreamEncryption.php
+++ b/src/StreamEncryption.php
@@ -126,7 +126,7 @@ class StreamEncryption
                 // EOF or failed without error => connection closed during handshake
                 $d->reject(new \UnexpectedValueException(
                     'Connection lost during TLS handshake',
-                    \defined('SOCKET_ECONNRESET') ? \SOCKET_ECONNRESET : 0
+                    \defined('SOCKET_ECONNRESET') ? \SOCKET_ECONNRESET : 104
                 ));
             } else {
                 // handshake failed with error message

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -28,7 +28,7 @@ final class TcpConnector implements ConnectorInterface
         $parts = \parse_url($uri);
         if (!$parts || !isset($parts['scheme'], $parts['host'], $parts['port']) || $parts['scheme'] !== 'tcp') {
             return Promise\reject(new \InvalidArgumentException(
-                'Given URI "' . $uri . '" is invalid',
+                'Given URI "' . $uri . '" is invalid (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
             ));
         }
@@ -36,7 +36,7 @@ final class TcpConnector implements ConnectorInterface
         $ip = \trim($parts['host'], '[]');
         if (false === \filter_var($ip, \FILTER_VALIDATE_IP)) {
             return Promise\reject(new \InvalidArgumentException(
-                'Given URI "' . $uri . '" does not contain a valid host IP',
+                'Given URI "' . $uri . '" does not contain a valid host IP (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
             ));
         }
@@ -91,7 +91,7 @@ final class TcpConnector implements ConnectorInterface
 
         if (false === $stream) {
             return Promise\reject(new \RuntimeException(
-                \sprintf("Connection to %s failed: %s", $uri, $errstr),
+                'Connection to ' . $uri . ' failed: ' . $errstr . SocketServer::errconst($errno),
                 $errno
             ));
         }
@@ -132,7 +132,7 @@ final class TcpConnector implements ConnectorInterface
 
                     \fclose($stream);
                     $reject(new \RuntimeException(
-                        'Connection to ' . $uri . ' failed: ' . $errstr,
+                        'Connection to ' . $uri . ' failed: ' . $errstr . SocketServer::errconst($errno),
                         $errno
                     ));
                 } else {
@@ -151,7 +151,7 @@ final class TcpConnector implements ConnectorInterface
             // @codeCoverageIgnoreEnd
 
             throw new \RuntimeException(
-                'Connection to ' . $uri . ' cancelled during TCP/IP handshake',
+                'Connection to ' . $uri . ' cancelled during TCP/IP handshake (ECONNABORTED)',
                 \defined('SOCKET_ECONNABORTED') ? \SOCKET_ECONNABORTED : 103
             );
         });

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -141,7 +141,10 @@ final class TcpConnector implements ConnectorInterface
             }
             // @codeCoverageIgnoreEnd
 
-            throw new \RuntimeException('Connection to ' . $uri . ' cancelled during TCP/IP handshake');
+            throw new \RuntimeException(
+                'Connection to ' . $uri . ' cancelled during TCP/IP handshake',
+                \defined('SOCKET_ECONNABORTED') ? \SOCKET_ECONNABORTED : 103
+            );
         });
     }
 }

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -27,12 +27,18 @@ final class TcpConnector implements ConnectorInterface
 
         $parts = \parse_url($uri);
         if (!$parts || !isset($parts['scheme'], $parts['host'], $parts['port']) || $parts['scheme'] !== 'tcp') {
-            return Promise\reject(new \InvalidArgumentException('Given URI "' . $uri . '" is invalid'));
+            return Promise\reject(new \InvalidArgumentException(
+                'Given URI "' . $uri . '" is invalid',
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+            ));
         }
 
         $ip = \trim($parts['host'], '[]');
         if (false === \filter_var($ip, \FILTER_VALIDATE_IP)) {
-            return Promise\reject(new \InvalidArgumentException('Given URI "' . $ip . '" does not contain a valid host IP'));
+            return Promise\reject(new \InvalidArgumentException(
+                'Given URI "' . $uri . '" does not contain a valid host IP',
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+            ));
         }
 
         // use context given in constructor
@@ -125,7 +131,10 @@ final class TcpConnector implements ConnectorInterface
                     // @codeCoverageIgnoreEnd
 
                     \fclose($stream);
-                    $reject(new \RuntimeException('Connection to ' . $uri . ' failed: ' . $errstr, $errno));
+                    $reject(new \RuntimeException(
+                        'Connection to ' . $uri . ' failed: ' . $errstr,
+                        $errno
+                    ));
                 } else {
                     $resolve(new Connection($stream, $loop));
                 }

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -175,6 +175,12 @@ final class TcpServer extends EventEmitter implements ServerInterface
             \stream_context_create(array('socket' => $context + array('backlog' => 511)))
         );
         if (false === $this->master) {
+            if ($errno === 0) {
+                // PHP does not seem to report errno, so match errno from errstr
+                // @link https://3v4l.org/3qOBl
+                $errno = SocketServer::errno($errstr);
+            }
+
             throw new \RuntimeException(
                 'Failed to listen on "' . $uri . '": ' . $errstr . SocketServer::errconst($errno),
                 $errno

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -155,14 +155,14 @@ final class TcpServer extends EventEmitter implements ServerInterface
         // ensure URI contains TCP scheme, host and port
         if (!$parts || !isset($parts['scheme'], $parts['host'], $parts['port']) || $parts['scheme'] !== 'tcp') {
             throw new \InvalidArgumentException(
-                'Invalid URI "' . $uri . '" given',
+                'Invalid URI "' . $uri . '" given (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
             );
         }
 
         if (false === \filter_var(\trim($parts['host'], '[]'), \FILTER_VALIDATE_IP)) {
             throw new \InvalidArgumentException(
-                'Given URI "' . $uri . '" does not contain a valid host IP',
+                'Given URI "' . $uri . '" does not contain a valid host IP (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
             );
         }
@@ -176,7 +176,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
         );
         if (false === $this->master) {
             throw new \RuntimeException(
-                'Failed to listen on "' . $uri . '": ' . $errstr,
+                'Failed to listen on "' . $uri . '": ' . $errstr . SocketServer::errconst($errno),
                 $errno
             );
         }

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -154,11 +154,17 @@ final class TcpServer extends EventEmitter implements ServerInterface
 
         // ensure URI contains TCP scheme, host and port
         if (!$parts || !isset($parts['scheme'], $parts['host'], $parts['port']) || $parts['scheme'] !== 'tcp') {
-            throw new \InvalidArgumentException('Invalid URI "' . $uri . '" given');
+            throw new \InvalidArgumentException(
+                'Invalid URI "' . $uri . '" given',
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+            );
         }
 
         if (false === \filter_var(\trim($parts['host'], '[]'), \FILTER_VALIDATE_IP)) {
-            throw new \InvalidArgumentException('Given URI "' . $uri . '" does not contain a valid host IP');
+            throw new \InvalidArgumentException(
+                'Given URI "' . $uri . '" does not contain a valid host IP',
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+            );
         }
 
         $this->master = @\stream_socket_server(
@@ -169,7 +175,10 @@ final class TcpServer extends EventEmitter implements ServerInterface
             \stream_context_create(array('socket' => $context + array('backlog' => 511)))
         );
         if (false === $this->master) {
-            throw new \RuntimeException('Failed to listen on "' . $uri . '": ' . $errstr, $errno);
+            throw new \RuntimeException(
+                'Failed to listen on "' . $uri . '": ' . $errstr,
+                $errno
+            );
         }
         \stream_set_blocking($this->master, false);
 

--- a/src/TimeoutConnector.php
+++ b/src/TimeoutConnector.php
@@ -40,7 +40,7 @@ final class TimeoutConnector implements ConnectorInterface
         return function (\Exception $e) use ($uri) {
             if ($e instanceof TimeoutException) {
                 throw new \RuntimeException(
-                    'Connection to ' . $uri . ' timed out after ' . $e->getTimeout() . ' seconds',
+                    'Connection to ' . $uri . ' timed out after ' . $e->getTimeout() . ' seconds (ETIMEDOUT)',
                     \defined('SOCKET_ETIMEDOUT') ? \SOCKET_ETIMEDOUT : 110
                 );
             }

--- a/src/TimeoutConnector.php
+++ b/src/TimeoutConnector.php
@@ -41,7 +41,7 @@ final class TimeoutConnector implements ConnectorInterface
             if ($e instanceof TimeoutException) {
                 throw new \RuntimeException(
                     'Connection to ' . $uri . ' timed out after ' . $e->getTimeout() . ' seconds',
-                    \defined('SOCKET_ETIMEDOUT') ? \SOCKET_ETIMEDOUT : 0
+                    \defined('SOCKET_ETIMEDOUT') ? \SOCKET_ETIMEDOUT : 110
                 );
             }
 

--- a/src/UnixConnector.php
+++ b/src/UnixConnector.php
@@ -29,7 +29,7 @@ final class UnixConnector implements ConnectorInterface
             $path = 'unix://' . $path;
         } elseif (\substr($path, 0, 7) !== 'unix://') {
             return Promise\reject(new \InvalidArgumentException(
-                'Given URI "' . $path . '" is invalid',
+                'Given URI "' . $path . '" is invalid (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
             ));
         }
@@ -38,7 +38,7 @@ final class UnixConnector implements ConnectorInterface
 
         if (!$resource) {
             return Promise\reject(new \RuntimeException(
-                'Unable to connect to unix domain socket "' . $path . '": ' . $errstr,
+                'Unable to connect to unix domain socket "' . $path . '": ' . $errstr . SocketServer::errconst($errno),
                 $errno
             ));
         }

--- a/src/UnixConnector.php
+++ b/src/UnixConnector.php
@@ -28,13 +28,19 @@ final class UnixConnector implements ConnectorInterface
         if (\strpos($path, '://') === false) {
             $path = 'unix://' . $path;
         } elseif (\substr($path, 0, 7) !== 'unix://') {
-            return Promise\reject(new \InvalidArgumentException('Given URI "' . $path . '" is invalid'));
+            return Promise\reject(new \InvalidArgumentException(
+                'Given URI "' . $path . '" is invalid',
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+            ));
         }
 
         $resource = @\stream_socket_client($path, $errno, $errstr, 1.0);
 
         if (!$resource) {
-            return Promise\reject(new \RuntimeException('Unable to connect to unix domain socket "' . $path . '": ' . $errstr, $errno));
+            return Promise\reject(new \RuntimeException(
+                'Unable to connect to unix domain socket "' . $path . '": ' . $errstr,
+                $errno
+            ));
         }
 
         $connection = new Connection($resource, $this->loop);

--- a/src/UnixServer.php
+++ b/src/UnixServer.php
@@ -58,7 +58,7 @@ final class UnixServer extends EventEmitter implements ServerInterface
             $path = 'unix://' . $path;
         } elseif (\substr($path, 0, 7) !== 'unix://') {
             throw new \InvalidArgumentException(
-                'Given URI "' . $path . '" is invalid',
+                'Given URI "' . $path . '" is invalid (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
             );
         }
@@ -83,7 +83,7 @@ final class UnixServer extends EventEmitter implements ServerInterface
             }
 
             throw new \RuntimeException(
-                'Failed to listen on Unix domain socket "' . $path . '": ' . $errstr,
+                'Failed to listen on Unix domain socket "' . $path . '": ' . $errstr . SocketServer::errconst($errno),
                 $errno
             );
         }

--- a/src/UnixServer.php
+++ b/src/UnixServer.php
@@ -57,7 +57,10 @@ final class UnixServer extends EventEmitter implements ServerInterface
         if (\strpos($path, '://') === false) {
             $path = 'unix://' . $path;
         } elseif (\substr($path, 0, 7) !== 'unix://') {
-            throw new \InvalidArgumentException('Given URI "' . $path . '" is invalid');
+            throw new \InvalidArgumentException(
+                'Given URI "' . $path . '" is invalid',
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+            );
         }
 
         $this->master = @\stream_socket_server(
@@ -79,7 +82,10 @@ final class UnixServer extends EventEmitter implements ServerInterface
                 }
             }
 
-            throw new \RuntimeException('Failed to listen on Unix domain socket "' . $path . '": ' . $errstr, $errno);
+            throw new \RuntimeException(
+                'Failed to listen on Unix domain socket "' . $path . '": ' . $errstr,
+                $errno
+            );
         }
         \stream_set_blocking($this->master, 0);
 

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -172,7 +172,7 @@ class ConnectorTest extends TestCase
 
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
-            'No connector available for URI scheme "unknown"',
+            'No connector available for URI scheme "unknown" (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         ));
     }
@@ -188,7 +188,7 @@ class ConnectorTest extends TestCase
 
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
-            'No connector available for URI scheme "tcp"',
+            'No connector available for URI scheme "tcp" (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         ));
     }
@@ -204,7 +204,7 @@ class ConnectorTest extends TestCase
 
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
-            'No connector available for URI scheme "tcp"',
+            'No connector available for URI scheme "tcp" (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         ));
     }
@@ -220,7 +220,7 @@ class ConnectorTest extends TestCase
 
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
-            'No connector available for URI scheme "tls"',
+            'No connector available for URI scheme "tls" (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         ));
     }
@@ -236,7 +236,7 @@ class ConnectorTest extends TestCase
 
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
-            'No connector available for URI scheme "unix"',
+            'No connector available for URI scheme "unix" (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         ));
     }

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -169,7 +169,12 @@ class ConnectorTest extends TestCase
         $connector = new Connector(array(), $loop);
 
         $promise = $connector->connect('unknown://google.com:80');
-        $promise->then(null, $this->expectCallableOnce());
+
+        $promise->then(null, $this->expectCallableOnceWithException(
+            'RuntimeException',
+            'No connector available for URI scheme "unknown"',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        ));
     }
 
     public function testConnectorWithDisabledTcpDefaultSchemeAlwaysFails()
@@ -180,7 +185,12 @@ class ConnectorTest extends TestCase
         ), $loop);
 
         $promise = $connector->connect('google.com:80');
-        $promise->then(null, $this->expectCallableOnce());
+
+        $promise->then(null, $this->expectCallableOnceWithException(
+            'RuntimeException',
+            'No connector available for URI scheme "tcp"',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        ));
     }
 
     public function testConnectorWithDisabledTcpSchemeAlwaysFails()
@@ -191,7 +201,12 @@ class ConnectorTest extends TestCase
         ), $loop);
 
         $promise = $connector->connect('tcp://google.com:80');
-        $promise->then(null, $this->expectCallableOnce());
+
+        $promise->then(null, $this->expectCallableOnceWithException(
+            'RuntimeException',
+            'No connector available for URI scheme "tcp"',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        ));
     }
 
     public function testConnectorWithDisabledTlsSchemeAlwaysFails()
@@ -202,7 +217,12 @@ class ConnectorTest extends TestCase
         ), $loop);
 
         $promise = $connector->connect('tls://google.com:443');
-        $promise->then(null, $this->expectCallableOnce());
+
+        $promise->then(null, $this->expectCallableOnceWithException(
+            'RuntimeException',
+            'No connector available for URI scheme "tls"',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        ));
     }
 
     public function testConnectorWithDisabledUnixSchemeAlwaysFails()
@@ -213,7 +233,12 @@ class ConnectorTest extends TestCase
         ), $loop);
 
         $promise = $connector->connect('unix://demo.sock');
-        $promise->then(null, $this->expectCallableOnce());
+
+        $promise->then(null, $this->expectCallableOnceWithException(
+            'RuntimeException',
+            'No connector available for URI scheme "unix"',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        ));
     }
 
     public function testConnectorUsesGivenResolverInstance()

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -78,7 +78,11 @@ class DnsConnectorTest extends TestCase
 
         $promise = $this->connector->connect('////');
 
-        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+        $promise->then(null, $this->expectCallableOnceWithException(
+            'InvalidArgumentException',
+            'Given URI "////" is invalid',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        ));
     }
 
     public function testConnectRejectsIfGivenIpAndTcpConnectorRejectsWithRuntimeException()

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -80,7 +80,7 @@ class DnsConnectorTest extends TestCase
 
         $promise->then(null, $this->expectCallableOnceWithException(
             'InvalidArgumentException',
-            'Given URI "////" is invalid',
+            'Given URI "////" is invalid (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         ));
     }
@@ -173,7 +173,7 @@ class DnsConnectorTest extends TestCase
 
         $this->setExpectedException(
             'RuntimeException',
-            'Connection to tcp://example.com:80 cancelled during DNS lookup',
+            'Connection to tcp://example.com:80 cancelled during DNS lookup (ECONNABORTED)',
             defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
         );
         $this->throwRejection($promise);

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -167,7 +167,11 @@ class DnsConnectorTest extends TestCase
         $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
 
-        $this->setExpectedException('RuntimeException', 'Connection to tcp://example.com:80 cancelled during DNS lookup');
+        $this->setExpectedException(
+            'RuntimeException',
+            'Connection to tcp://example.com:80 cancelled during DNS lookup',
+            defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
+        );
         $this->throwRejection($promise);
     }
 
@@ -196,7 +200,10 @@ class DnsConnectorTest extends TestCase
         $first = new Deferred();
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->willReturn($first->promise());
         $pending = new Promise\Promise(function () { }, function () {
-            throw new \RuntimeException('Connection cancelled');
+            throw new \RuntimeException(
+                'Connection cancelled',
+                defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
+            );
         });
         $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80?hostname=example.com'))->willReturn($pending);
 
@@ -205,7 +212,11 @@ class DnsConnectorTest extends TestCase
 
         $promise->cancel();
 
-        $this->setExpectedException('RuntimeException', 'Connection cancelled');
+        $this->setExpectedException(
+            'RuntimeException',
+            'Connection cancelled',
+            defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
+        );
         $this->throwRejection($promise);
     }
 

--- a/tests/FdServerTest.php
+++ b/tests/FdServerTest.php
@@ -32,7 +32,7 @@ class FdServerTest extends TestCase
 
         $this->setExpectedException(
             'InvalidArgumentException',
-            'Invalid FD number given',
+            'Invalid FD number given (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         );
         new FdServer(-1, $loop);
@@ -45,7 +45,7 @@ class FdServerTest extends TestCase
 
         $this->setExpectedException(
             'InvalidArgumentException',
-            'Invalid FD number given',
+            'Invalid FD number given (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         );
         new FdServer('tcp://127.0.0.1:8080', $loop);
@@ -64,7 +64,7 @@ class FdServerTest extends TestCase
 
         $this->setExpectedException(
             'RuntimeException',
-            'Failed to listen on FD ' . $fd . ': ' . (function_exists('socket_strerror') ? socket_strerror(SOCKET_EBADF) : 'Bad file descriptor'),
+            'Failed to listen on FD ' . $fd . ': ' . (function_exists('socket_strerror') ? socket_strerror(SOCKET_EBADF) . ' (EBADF)' : 'Bad file descriptor'),
             defined('SOCKET_EBADF') ? SOCKET_EBADF : 9
         );
         new FdServer($fd, $loop);
@@ -85,7 +85,7 @@ class FdServerTest extends TestCase
 
         $this->setExpectedException(
             'RuntimeException',
-            'Failed to listen on FD ' . $fd . ': ' . (function_exists('socket_strerror') ? socket_strerror(SOCKET_ENOTSOCK) : 'Not a socket'),
+            'Failed to listen on FD ' . $fd . ': ' . (function_exists('socket_strerror') ? socket_strerror(SOCKET_ENOTSOCK) : 'Not a socket') . ' (ENOTSOCK)',
             defined('SOCKET_ENOTSOCK') ? SOCKET_ENOTSOCK : 88
         );
         new FdServer($fd, $loop);
@@ -108,7 +108,7 @@ class FdServerTest extends TestCase
 
         $this->setExpectedException(
             'RuntimeException',
-            'Failed to listen on FD ' . $fd . ': ' . (function_exists('socket_strerror') ? socket_strerror(SOCKET_EISCONN) : 'Socket is connected'),
+            'Failed to listen on FD ' . $fd . ': ' . (function_exists('socket_strerror') ? socket_strerror(SOCKET_EISCONN) : 'Socket is connected') . ' (EISCONN)',
             defined('SOCKET_EISCONN') ? SOCKET_EISCONN : 106
         );
         new FdServer($fd, $loop);
@@ -361,7 +361,7 @@ class FdServerTest extends TestCase
      */
     public function testEmitsTimeoutErrorWhenAcceptListenerFails(\RuntimeException $exception)
     {
-        $this->assertEquals('Unable to accept new connection: ' . socket_strerror(SOCKET_ETIMEDOUT), $exception->getMessage());
+        $this->assertEquals('Unable to accept new connection: ' . socket_strerror(SOCKET_ETIMEDOUT) . ' (ETIMEDOUT)', $exception->getMessage());
         $this->assertEquals(SOCKET_ETIMEDOUT, $exception->getCode());
     }
 

--- a/tests/FdServerTest.php
+++ b/tests/FdServerTest.php
@@ -30,7 +30,11 @@ class FdServerTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->never())->method('addReadStream');
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Invalid FD number given',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        );
         new FdServer(-1, $loop);
     }
 
@@ -39,7 +43,11 @@ class FdServerTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $loop->expects($this->never())->method('addReadStream');
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Invalid FD number given',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        );
         new FdServer('tcp://127.0.0.1:8080', $loop);
     }
 

--- a/tests/FunctionalConnectorTest.php
+++ b/tests/FunctionalConnectorTest.php
@@ -168,7 +168,7 @@ class FunctionalConnectorTest extends TestCase
             $this->fail();
         } catch (\Exception $e) {
             $this->assertInstanceOf('RuntimeException', $e);
-            $this->assertEquals('Connection to ' . $uri . ' cancelled during TLS handshake', $e->getMessage());
+            $this->assertEquals('Connection to ' . $uri . ' cancelled during TLS handshake (ECONNABORTED)', $e->getMessage());
         }
     }
 

--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -664,11 +664,11 @@ class FunctionalSecureServerTest extends TestCase
 
         $error = Block\await($errorEvent, $loop, self::TIMEOUT);
 
-        // Connection from tcp://127.0.0.1:39528 failed during TLS handshake: Connection lost during TLS handshak
+        // Connection from tcp://127.0.0.1:39528 failed during TLS handshake: Connection lost during TLS handshake
         $this->assertInstanceOf('RuntimeException', $error);
         $this->assertStringStartsWith('Connection from tcp://', $error->getMessage());
         $this->assertStringEndsWith('failed during TLS handshake: Connection lost during TLS handshake', $error->getMessage());
-        $this->assertEquals(defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 0, $error->getCode());
+        $this->assertEquals(defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 104, $error->getCode());
         $this->assertNull($error->getPrevious());
     }
 
@@ -692,11 +692,11 @@ class FunctionalSecureServerTest extends TestCase
 
         $error = Block\await($errorEvent, $loop, self::TIMEOUT);
 
-        // Connection from tcp://127.0.0.1:39528 failed during TLS handshake: Connection lost during TLS handshak
+        // Connection from tcp://127.0.0.1:39528 failed during TLS handshake: Connection lost during TLS handshake
         $this->assertInstanceOf('RuntimeException', $error);
         $this->assertStringStartsWith('Connection from tcp://', $error->getMessage());
         $this->assertStringEndsWith('failed during TLS handshake: Connection lost during TLS handshake', $error->getMessage());
-        $this->assertEquals(defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 0, $error->getCode());
+        $this->assertEquals(defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 104, $error->getCode());
         $this->assertNull($error->getPrevious());
     }
 

--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -664,10 +664,10 @@ class FunctionalSecureServerTest extends TestCase
 
         $error = Block\await($errorEvent, $loop, self::TIMEOUT);
 
-        // Connection from tcp://127.0.0.1:39528 failed during TLS handshake: Connection lost during TLS handshake
+        // Connection from tcp://127.0.0.1:39528 failed during TLS handshake: Connection lost during TLS handshake (ECONNRESET)
         $this->assertInstanceOf('RuntimeException', $error);
         $this->assertStringStartsWith('Connection from tcp://', $error->getMessage());
-        $this->assertStringEndsWith('failed during TLS handshake: Connection lost during TLS handshake', $error->getMessage());
+        $this->assertStringEndsWith('failed during TLS handshake: Connection lost during TLS handshake (ECONNRESET)', $error->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 104, $error->getCode());
         $this->assertNull($error->getPrevious());
     }
@@ -692,10 +692,10 @@ class FunctionalSecureServerTest extends TestCase
 
         $error = Block\await($errorEvent, $loop, self::TIMEOUT);
 
-        // Connection from tcp://127.0.0.1:39528 failed during TLS handshake: Connection lost during TLS handshake
+        // Connection from tcp://127.0.0.1:39528 failed during TLS handshake: Connection lost during TLS handshake (ECONNRESET)
         $this->assertInstanceOf('RuntimeException', $error);
         $this->assertStringStartsWith('Connection from tcp://', $error->getMessage());
-        $this->assertStringEndsWith('failed during TLS handshake: Connection lost during TLS handshake', $error->getMessage());
+        $this->assertStringEndsWith('failed during TLS handshake: Connection lost during TLS handshake (ECONNRESET)', $error->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 104, $error->getCode());
         $this->assertNull($error->getPrevious());
     }

--- a/tests/FunctionalTcpServerTest.php
+++ b/tests/FunctionalTcpServerTest.php
@@ -352,7 +352,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $this->setExpectedException(
             'InvalidArgumentException',
-            'Invalid URI "tcp://///" given',
+            'Invalid URI "tcp://///" given (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         );
         new TcpServer('///', $loop);
@@ -364,7 +364,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $this->setExpectedException(
             'InvalidArgumentException',
-            'Invalid URI "tcp://127.0.0.1" given',
+            'Invalid URI "tcp://127.0.0.1" given (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         );
         new TcpServer('127.0.0.1', $loop);
@@ -376,7 +376,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $this->setExpectedException(
             'InvalidArgumentException',
-            'Invalid URI "udp://127.0.0.1:0" given',
+            'Invalid URI "udp://127.0.0.1:0" given (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         );
         new TcpServer('udp://127.0.0.1:0', $loop);
@@ -388,7 +388,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $this->setExpectedException(
             'InvalidArgumentException',
-            'Given URI "tcp://localhost:8080" does not contain a valid host IP',
+            'Given URI "tcp://localhost:8080" does not contain a valid host IP (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         );
         new TcpServer('localhost:8080', $loop);

--- a/tests/FunctionalTcpServerTest.php
+++ b/tests/FunctionalTcpServerTest.php
@@ -350,7 +350,11 @@ class FunctionalTcpServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Invalid URI "tcp://///" given',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        );
         new TcpServer('///', $loop);
     }
 
@@ -358,7 +362,11 @@ class FunctionalTcpServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Invalid URI "tcp://127.0.0.1" given',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        );
         new TcpServer('127.0.0.1', $loop);
     }
 
@@ -366,7 +374,11 @@ class FunctionalTcpServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Invalid URI "udp://127.0.0.1:0" given',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        );
         new TcpServer('udp://127.0.0.1:0', $loop);
     }
 
@@ -374,7 +386,11 @@ class FunctionalTcpServerTest extends TestCase
     {
         $loop = Factory::create();
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Given URI "tcp://localhost:8080" does not contain a valid host IP',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        );
         new TcpServer('localhost:8080', $loop);
     }
 }

--- a/tests/HappyEyeBallsConnectionBuilderTest.php
+++ b/tests/HappyEyeBallsConnectionBuilderTest.php
@@ -664,7 +664,10 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         });
 
         $this->assertInstanceOf('RuntimeException', $exception);
+        assert($exception instanceof \RuntimeException);
+
         $this->assertEquals('Connection to tcp://reactphp.org:80 cancelled during DNS lookup', $exception->getMessage());
+        $this->assertEquals(defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103, $exception->getCode());
     }
 
     public function testCancelConnectWillRejectPromiseAndCancelPendingIpv6LookupAndCancelDelayTimer()
@@ -701,7 +704,10 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         });
 
         $this->assertInstanceOf('RuntimeException', $exception);
+        assert($exception instanceof \RuntimeException);
+
         $this->assertEquals('Connection to tcp://reactphp.org:80 cancelled during DNS lookup', $exception->getMessage());
+        $this->assertEquals(defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103, $exception->getCode());
     }
 
     public function testCancelConnectWillRejectPromiseAndCancelPendingIpv6ConnectionAttemptAndPendingIpv4LookupAndCancelAttemptTimer()
@@ -744,7 +750,10 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         });
 
         $this->assertInstanceOf('RuntimeException', $exception);
+        assert($exception instanceof \RuntimeException);
+
         $this->assertEquals('Connection to tcp://reactphp.org:80 cancelled', $exception->getMessage());
+        $this->assertEquals(defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103, $exception->getCode());
     }
 
     public function testResolveWillReturnResolvedPromiseWithEmptyListWhenDnsResolverFails()

--- a/tests/HappyEyeBallsConnectionBuilderTest.php
+++ b/tests/HappyEyeBallsConnectionBuilderTest.php
@@ -62,7 +62,11 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         });
 
         $this->assertInstanceOf('RuntimeException', $exception);
+        assert($exception instanceof \RuntimeException);
+
         $this->assertEquals('Connection to tcp://reactphp.org:80 failed during DNS lookup: DNS lookup error', $exception->getMessage());
+        $this->assertEquals(0, $exception->getCode());
+        $this->assertInstanceOf('RuntimeException', $exception->getPrevious());
     }
 
     public function testConnectWillRejectWhenBothDnsLookupsRejectWithDifferentMessages()
@@ -98,7 +102,11 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         });
 
         $this->assertInstanceOf('RuntimeException', $exception);
+        assert($exception instanceof \RuntimeException);
+
         $this->assertEquals('Connection to tcp://reactphp.org:80 failed during DNS lookup. Last error for IPv6: DNS6 error. Previous error for IPv4: DNS4 error', $exception->getMessage());
+        $this->assertEquals(0, $exception->getCode());
+        $this->assertInstanceOf('RuntimeException', $exception->getPrevious());
     }
 
     public function testConnectWillStartDelayTimerWhenIpv4ResolvesAndIpv6IsPending()
@@ -468,7 +476,10 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
 
         $promise = $builder->connect();
-        $deferred->reject(new \RuntimeException('Connection refused'));
+        $deferred->reject(new \RuntimeException(
+            'Connection refused',
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
+        ));
 
         $exception = null;
         $promise->then(null, function ($e) use (&$exception) {
@@ -476,7 +487,11 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         });
 
         $this->assertInstanceOf('RuntimeException', $exception);
+        assert($exception instanceof \RuntimeException);
+
         $this->assertEquals('Connection to tcp://reactphp.org:80 failed: Last error for IPv6: Connection refused. Previous error for IPv4: DNS failed', $exception->getMessage());
+        $this->assertEquals(defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111, $exception->getCode());
+        $this->assertInstanceOf('RuntimeException', $exception->getPrevious());
     }
 
     public function testConnectWillRejectWhenOnlyTcp4ConnectionRejectsAndWillNeverStartNextAttemptTimer()
@@ -504,7 +519,10 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
 
         $promise = $builder->connect();
-        $deferred->reject(new \RuntimeException('Connection refused'));
+        $deferred->reject(new \RuntimeException(
+            'Connection refused',
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
+        ));
 
         $exception = null;
         $promise->then(null, function ($e) use (&$exception) {
@@ -512,7 +530,11 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         });
 
         $this->assertInstanceOf('RuntimeException', $exception);
+        assert($exception instanceof \RuntimeException);
+
         $this->assertEquals('Connection to tcp://reactphp.org:80 failed: Last error for IPv4: Connection refused. Previous error for IPv6: DNS failed', $exception->getMessage());
+        $this->assertEquals(defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111, $exception->getCode());
+        $this->assertInstanceOf('RuntimeException', $exception->getPrevious());
     }
 
     public function testConnectWillRejectWhenAllConnectionsRejectAndCancelNextAttemptTimerImmediately()
@@ -542,7 +564,10 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
 
         $promise = $builder->connect();
-        $deferred->reject(new \RuntimeException('Connection refused'));
+        $deferred->reject(new \RuntimeException(
+            'Connection refused',
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
+        ));
 
         $exception = null;
         $promise->then(null, function ($e) use (&$exception) {
@@ -550,7 +575,11 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         });
 
         $this->assertInstanceOf('RuntimeException', $exception);
+        assert($exception instanceof \RuntimeException);
+
         $this->assertEquals('Connection to tcp://reactphp.org:80 failed: Connection refused', $exception->getMessage());
+        $this->assertEquals(defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111, $exception->getCode());
+        $this->assertInstanceOf('RuntimeException', $exception->getPrevious());
     }
 
     public function testConnectWillRejectWithMessageWithoutHostnameWhenAllConnectionsRejectAndCancelNextAttemptTimerImmediately()

--- a/tests/HappyEyeBallsConnectionBuilderTest.php
+++ b/tests/HappyEyeBallsConnectionBuilderTest.php
@@ -477,7 +477,7 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
 
         $promise = $builder->connect();
         $deferred->reject(new \RuntimeException(
-            'Connection refused',
+            'Connection refused (ECONNREFUSED)',
             defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         ));
 
@@ -489,7 +489,7 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $this->assertInstanceOf('RuntimeException', $exception);
         assert($exception instanceof \RuntimeException);
 
-        $this->assertEquals('Connection to tcp://reactphp.org:80 failed: Last error for IPv6: Connection refused. Previous error for IPv4: DNS failed', $exception->getMessage());
+        $this->assertEquals('Connection to tcp://reactphp.org:80 failed: Last error for IPv6: Connection refused (ECONNREFUSED). Previous error for IPv4: DNS failed', $exception->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111, $exception->getCode());
         $this->assertInstanceOf('RuntimeException', $exception->getPrevious());
     }
@@ -520,7 +520,7 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
 
         $promise = $builder->connect();
         $deferred->reject(new \RuntimeException(
-            'Connection refused',
+            'Connection refused (ECONNREFUSED)',
             defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         ));
 
@@ -532,7 +532,7 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $this->assertInstanceOf('RuntimeException', $exception);
         assert($exception instanceof \RuntimeException);
 
-        $this->assertEquals('Connection to tcp://reactphp.org:80 failed: Last error for IPv4: Connection refused. Previous error for IPv6: DNS failed', $exception->getMessage());
+        $this->assertEquals('Connection to tcp://reactphp.org:80 failed: Last error for IPv4: Connection refused (ECONNREFUSED). Previous error for IPv6: DNS failed', $exception->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111, $exception->getCode());
         $this->assertInstanceOf('RuntimeException', $exception->getPrevious());
     }
@@ -565,7 +565,7 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
 
         $promise = $builder->connect();
         $deferred->reject(new \RuntimeException(
-            'Connection refused',
+            'Connection refused (ECONNREFUSED)',
             defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         ));
 
@@ -577,7 +577,7 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $this->assertInstanceOf('RuntimeException', $exception);
         assert($exception instanceof \RuntimeException);
 
-        $this->assertEquals('Connection to tcp://reactphp.org:80 failed: Connection refused', $exception->getMessage());
+        $this->assertEquals('Connection to tcp://reactphp.org:80 failed: Connection refused (ECONNREFUSED)', $exception->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111, $exception->getCode());
         $this->assertInstanceOf('RuntimeException', $exception->getPrevious());
     }
@@ -593,7 +593,10 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->exactly(2))->method('connect')->willReturnOnConsecutiveCalls(
             $deferred->promise(),
-            \React\Promise\reject(new \RuntimeException('Connection to tcp://127.0.0.1:80?hostname=localhost failed: Connection refused'))
+            \React\Promise\reject(new \RuntimeException(
+                'Connection to tcp://127.0.0.1:80?hostname=localhost failed: Connection refused (ECONNREFUSED)',
+                defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
+            ))
         );
 
         $resolver = $this->getMockBuilder('React\Dns\Resolver\ResolverInterface')->getMock();
@@ -612,7 +615,10 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
 
         $promise = $builder->connect();
-        $deferred->reject(new \RuntimeException('Connection to tcp://[::1]:80?hostname=localhost failed: Connection refused'));
+        $deferred->reject(new \RuntimeException(
+            'Connection to tcp://[::1]:80?hostname=localhost failed: Connection refused (ECONNREFUSED)',
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
+        ));
 
         $exception = null;
         $promise->then(null, function ($e) use (&$exception) {
@@ -620,7 +626,11 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         });
 
         $this->assertInstanceOf('RuntimeException', $exception);
-        $this->assertEquals('Connection to tcp://localhost:80 failed: Last error for IPv4: Connection to tcp://127.0.0.1:80 failed: Connection refused. Previous error for IPv6: Connection to tcp://[::1]:80 failed: Connection refused', $exception->getMessage());
+        assert($exception instanceof \RuntimeException);
+
+        $this->assertEquals('Connection to tcp://localhost:80 failed: Last error for IPv4: Connection to tcp://127.0.0.1:80 failed: Connection refused (ECONNREFUSED). Previous error for IPv6: Connection to tcp://[::1]:80 failed: Connection refused (ECONNREFUSED)', $exception->getMessage());
+        $this->assertEquals(defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111, $exception->getCode());
+        $this->assertInstanceOf('RuntimeException', $exception->getPrevious());
     }
 
     public function testCancelConnectWillRejectPromiseAndCancelBothDnsLookups()
@@ -666,7 +676,7 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $this->assertInstanceOf('RuntimeException', $exception);
         assert($exception instanceof \RuntimeException);
 
-        $this->assertEquals('Connection to tcp://reactphp.org:80 cancelled during DNS lookup', $exception->getMessage());
+        $this->assertEquals('Connection to tcp://reactphp.org:80 cancelled during DNS lookup (ECONNABORTED)', $exception->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103, $exception->getCode());
     }
 
@@ -706,7 +716,7 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $this->assertInstanceOf('RuntimeException', $exception);
         assert($exception instanceof \RuntimeException);
 
-        $this->assertEquals('Connection to tcp://reactphp.org:80 cancelled during DNS lookup', $exception->getMessage());
+        $this->assertEquals('Connection to tcp://reactphp.org:80 cancelled during DNS lookup (ECONNABORTED)', $exception->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103, $exception->getCode());
     }
 
@@ -752,7 +762,7 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $this->assertInstanceOf('RuntimeException', $exception);
         assert($exception instanceof \RuntimeException);
 
-        $this->assertEquals('Connection to tcp://reactphp.org:80 cancelled', $exception->getMessage());
+        $this->assertEquals('Connection to tcp://reactphp.org:80 cancelled (ECONNABORTED)', $exception->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103, $exception->getCode());
     }
 

--- a/tests/HappyEyeBallsConnectorTest.php
+++ b/tests/HappyEyeBallsConnectorTest.php
@@ -223,7 +223,7 @@ class HappyEyeBallsConnectorTest extends TestCase
 
         $promise->then(null, $this->expectCallableOnceWithException(
             'InvalidArgumentException',
-            'Given URI "////" is invalid',
+            'Given URI "////" is invalid (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         ));
     }
@@ -279,7 +279,7 @@ class HappyEyeBallsConnectorTest extends TestCase
 
         $this->setExpectedException(
             'RuntimeException',
-            'Connection to tcp://example.com:80 cancelled during DNS lookup',
+            'Connection to tcp://example.com:80 cancelled during DNS lookup (ECONNABORTED)',
             \defined('SOCKET_ECONNABORTED') ? \SOCKET_ECONNABORTED : 103
         );
         $this->loop->run();

--- a/tests/HappyEyeBallsConnectorTest.php
+++ b/tests/HappyEyeBallsConnectorTest.php
@@ -275,7 +275,11 @@ class HappyEyeBallsConnectorTest extends TestCase
             $that->throwRejection($promise);
         });
 
-        $this->setExpectedException('RuntimeException', 'Connection to tcp://example.com:80 cancelled during DNS lookup');
+        $this->setExpectedException(
+            'RuntimeException',
+            'Connection to tcp://example.com:80 cancelled during DNS lookup',
+            \defined('SOCKET_ECONNABORTED') ? \SOCKET_ECONNABORTED : 103
+        );
         $this->loop->run();
     }
 

--- a/tests/HappyEyeBallsConnectorTest.php
+++ b/tests/HappyEyeBallsConnectorTest.php
@@ -221,9 +221,11 @@ class HappyEyeBallsConnectorTest extends TestCase
 
         $promise = $this->connector->connect('////');
 
-        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
-
-        $this->loop->run();
+        $promise->then(null, $this->expectCallableOnceWithException(
+            'InvalidArgumentException',
+            'Given URI "////" is invalid',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        ));
     }
 
     public function testRejectsWithTcpConnectorRejectionIfGivenIp()

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -65,7 +65,11 @@ class SecureConnectorTest extends TestCase
 
         $promise = $this->connector->connect('tcp://example.com:80');
 
-        $promise->then(null, $this->expectCallableOnce());
+        $promise->then(null, $this->expectCallableOnceWithException(
+            'InvalidArgumentException',
+            'Given URI "tcp://example.com:80" is invalid',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        ));
     }
 
     public function testConnectWillRejectWithTlsUriWhenUnderlyingConnectorRejects()

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -187,7 +187,11 @@ class SecureConnectorTest extends TestCase
         $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
 
-        $this->setExpectedException('RuntimeException', 'Connection to tls://example.com:80 cancelled during TLS handshake');
+        $this->setExpectedException(
+            'RuntimeException',
+            'Connection to tls://example.com:80 cancelled during TLS handshake',
+            defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
+        );
         $this->throwRejection($promise);
     }
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -102,7 +102,7 @@ class ServerTest extends TestCase
                 $this->assertStringEndsWith('Unknown error', $e->getMessage());
             } else {
                 $this->assertEquals(SOCKET_EADDRINUSE, $e->getCode());
-                $this->assertStringEndsWith('Address already in use', $e->getMessage());
+                $this->assertStringEndsWith('Address already in use (EADDRINUSE)', $e->getMessage());
             }
         }
     }

--- a/tests/SocketServerTest.php
+++ b/tests/SocketServerTest.php
@@ -43,7 +43,7 @@ class SocketServerTest extends TestCase
     {
         $this->setExpectedException(
             'InvalidArgumentException',
-            'Invalid URI "tcp://invalid URI" given',
+            'Invalid URI "tcp://invalid URI" given (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         );
         new SocketServer('invalid URI');
@@ -53,7 +53,7 @@ class SocketServerTest extends TestCase
     {
         $this->setExpectedException(
             'InvalidArgumentException',
-            'Invalid URI given',
+            'Invalid URI given (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         );
         new SocketServer('0');
@@ -63,7 +63,7 @@ class SocketServerTest extends TestCase
     {
         $this->setExpectedException(
             'InvalidArgumentException',
-            'Invalid URI given',
+            'Invalid URI given (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         );
         new SocketServer('tcp://0');
@@ -125,7 +125,7 @@ class SocketServerTest extends TestCase
                 $this->assertStringEndsWith('Unknown error', $e->getMessage());
             } else {
                 $this->assertEquals(SOCKET_EADDRINUSE, $e->getCode());
-                $this->assertStringEndsWith('Address already in use', $e->getMessage());
+                $this->assertStringEndsWith('Address already in use (EADDRINUSE)', $e->getMessage());
             }
         }
     }

--- a/tests/SocketServerTest.php
+++ b/tests/SocketServerTest.php
@@ -41,19 +41,31 @@ class SocketServerTest extends TestCase
 
     public function testConstructorWithInvalidUriThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Invalid URI "tcp://invalid URI" given',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        );
         new SocketServer('invalid URI');
     }
 
     public function testConstructorWithInvalidUriWithPortOnlyThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Invalid URI given',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        );
         new SocketServer('0');
     }
 
     public function testConstructorWithInvalidUriWithSchemaAndPortOnlyThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Invalid URI given',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        );
         new SocketServer('tcp://0');
     }
 

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -324,7 +324,11 @@ class TcpConnectorTest extends TestCase
         $promise = $connector->connect($server->getAddress());
         $promise->cancel();
 
-        $this->setExpectedException('RuntimeException', 'Connection to ' . $server->getAddress() . ' cancelled during TCP/IP handshake');
+        $this->setExpectedException(
+            'RuntimeException',
+            'Connection to ' . $server->getAddress() . ' cancelled during TCP/IP handshake',
+            defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
+        );
         Block\await($promise, $loop);
     }
 

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -32,7 +32,11 @@ class TcpConnectorTest extends TestCase
         $connector = new TcpConnector($loop);
         $promise = $connector->connect('127.0.0.1:9999');
 
-        $this->setExpectedException('RuntimeException', 'Connection to tcp://127.0.0.1:9999 failed: Connection refused');
+        $this->setExpectedException(
+            'RuntimeException',
+            'Connection to tcp://127.0.0.1:9999 failed: Connection refused' . (function_exists('socket_import_stream') ? ' (ECONNREFUSED)' : ''),
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
+        );
         Block\await($promise, $loop, self::TIMEOUT);
     }
 
@@ -127,7 +131,7 @@ class TcpConnectorTest extends TestCase
 
         $this->setExpectedException(
             'RuntimeException',
-            'Connection to ' . $address . ' failed: ' . (function_exists('socket_strerror') ? socket_strerror($enetunreach) : 'Network is unreachable'),
+            'Connection to ' . $address . ' failed: ' . (function_exists('socket_strerror') ? socket_strerror($enetunreach) . ' (ENETUNREACH)' : 'Network is unreachable'),
             $enetunreach
         );
         Block\await($promise, $loop, self::TIMEOUT);
@@ -259,7 +263,7 @@ class TcpConnectorTest extends TestCase
 
         $promise->then(null, $this->expectCallableOnceWithException(
             'InvalidArgumentException',
-            'Given URI "tcp://www.google.com:80" does not contain a valid host IP',
+            'Given URI "tcp://www.google.com:80" does not contain a valid host IP (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         ));
     }
@@ -274,7 +278,7 @@ class TcpConnectorTest extends TestCase
 
         $promise->then(null, $this->expectCallableOnceWithException(
             'InvalidArgumentException',
-            'Given URI "tcp://255.255.255.255:12345678" is invalid',
+            'Given URI "tcp://255.255.255.255:12345678" is invalid (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         ));
     }
@@ -332,7 +336,7 @@ class TcpConnectorTest extends TestCase
 
         $this->setExpectedException(
             'RuntimeException',
-            'Connection to ' . $server->getAddress() . ' cancelled during TCP/IP handshake',
+            'Connection to ' . $server->getAddress() . ' cancelled during TCP/IP handshake (ECONNABORTED)',
             defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
         );
         Block\await($promise, $loop);

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -255,10 +255,13 @@ class TcpConnectorTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
         $connector = new TcpConnector($loop);
-        $connector->connect('www.google.com:80')->then(
-            $this->expectCallableNever(),
-            $this->expectCallableOnce()
-        );
+        $promise = $connector->connect('www.google.com:80');
+
+        $promise->then(null, $this->expectCallableOnceWithException(
+            'InvalidArgumentException',
+            'Given URI "tcp://www.google.com:80" does not contain a valid host IP',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        ));
     }
 
     /** @test */
@@ -267,10 +270,13 @@ class TcpConnectorTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
         $connector = new TcpConnector($loop);
-        $connector->connect('255.255.255.255:12345678')->then(
-            $this->expectCallableNever(),
-            $this->expectCallableOnce()
-        );
+        $promise = $connector->connect('255.255.255.255:12345678');
+
+        $promise->then(null, $this->expectCallableOnceWithException(
+            'InvalidArgumentException',
+            'Given URI "tcp://255.255.255.255:12345678" is invalid',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        ));
     }
 
     /** @test */

--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -319,7 +319,7 @@ class TcpServerTest extends TestCase
             $this->markTestSkipped('not supported on HHVM');
         }
 
-        $this->assertEquals('Unable to accept new connection: ' . socket_strerror(SOCKET_ETIMEDOUT), $exception->getMessage());
+        $this->assertEquals('Unable to accept new connection: ' . socket_strerror(SOCKET_ETIMEDOUT) . ' (ETIMEDOUT)', $exception->getMessage());
         $this->assertEquals(SOCKET_ETIMEDOUT, $exception->getCode());
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,6 +41,21 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
+    protected function expectCallableOnceWithException($type, $message = null, $code = null)
+    {
+        return $this->expectCallableOnceWith(
+            $this->logicalAnd(
+                $this->isInstanceOf($type),
+                $this->callback(function (\Exception $e) use ($message) {
+                    return $message === null || $e->getMessage() === $message;
+                }),
+                $this->callback(function (\Exception $e) use ($code) {
+                    return $code === null || $e->getCode() === $code;
+                })
+            )
+        );
+    }
+
     protected function expectCallableNever()
     {
         $mock = $this->createCallableMock();

--- a/tests/TimeoutConnectorTest.php
+++ b/tests/TimeoutConnectorTest.php
@@ -34,13 +34,17 @@ class TimeoutConnectorTest extends TestCase
 
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
-        $this->setExpectedException('RuntimeException', 'Connection to google.com:80 timed out after 0.01 seconds');
+        $this->setExpectedException(
+            'RuntimeException',
+            'Connection to google.com:80 timed out after 0.01 seconds',
+            \defined('SOCKET_ETIMEDOUT') ? \SOCKET_ETIMEDOUT : 110
+        );
         Block\await($timeout->connect('google.com:80'), $loop);
     }
 
     public function testRejectsWithOriginalReasonWhenConnectorRejects()
     {
-        $promise = Promise\reject(new \RuntimeException('Failed'));
+        $promise = Promise\reject(new \RuntimeException('Failed', 42));
 
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
@@ -49,7 +53,11 @@ class TimeoutConnectorTest extends TestCase
 
         $timeout = new TimeoutConnector($connector, 5.0, $loop);
 
-        $this->setExpectedException('RuntimeException', 'Failed');
+        $this->setExpectedException(
+            'RuntimeException',
+            'Failed',
+            42
+        );
         Block\await($timeout->connect('google.com:80'), $loop);
     }
 

--- a/tests/TimeoutConnectorTest.php
+++ b/tests/TimeoutConnectorTest.php
@@ -36,7 +36,7 @@ class TimeoutConnectorTest extends TestCase
 
         $this->setExpectedException(
             'RuntimeException',
-            'Connection to google.com:80 timed out after 0.01 seconds',
+            'Connection to google.com:80 timed out after 0.01 seconds (ETIMEDOUT)',
             \defined('SOCKET_ETIMEDOUT') ? \SOCKET_ETIMEDOUT : 110
         );
         Block\await($timeout->connect('google.com:80'), $loop);

--- a/tests/UnixConnectorTest.php
+++ b/tests/UnixConnectorTest.php
@@ -45,7 +45,7 @@ class UnixConnectorTest extends TestCase
 
         $promise->then(null, $this->expectCallableOnceWithException(
             'InvalidArgumentException',
-            'Given URI "tcp://google.com:80" is invalid',
+            'Given URI "tcp://google.com:80" is invalid (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         ));
     }

--- a/tests/UnixConnectorTest.php
+++ b/tests/UnixConnectorTest.php
@@ -33,13 +33,21 @@ class UnixConnectorTest extends TestCase
     public function testInvalid()
     {
         $promise = $this->connector->connect('google.com:80');
-        $promise->then(null, $this->expectCallableOnce());
+
+        $promise->then(null, $this->expectCallableOnceWithException(
+            'RuntimeException'
+        ));
     }
 
     public function testInvalidScheme()
     {
         $promise = $this->connector->connect('tcp://google.com:80');
-        $promise->then(null, $this->expectCallableOnce());
+
+        $promise->then(null, $this->expectCallableOnceWithException(
+            'InvalidArgumentException',
+            'Given URI "tcp://google.com:80" is invalid',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        ));
     }
 
     public function testValid()

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -232,8 +232,12 @@ class UnixServerTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $this->setExpectedException('InvalidArgumentException');
-        $server = new UnixServer('tcp://localhost:0', $loop);
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Given URI "tcp://localhost:0" is invalid',
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+        );
+        new UnixServer('tcp://localhost:0', $loop);
     }
 
     public function testCtorThrowsWhenPathIsNotWritable()

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -234,7 +234,7 @@ class UnixServerTest extends TestCase
 
         $this->setExpectedException(
             'InvalidArgumentException',
-            'Given URI "tcp://localhost:0" is invalid',
+            'Given URI "tcp://localhost:0" is invalid (EINVAL)',
             defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
         );
         new UnixServer('tcp://localhost:0', $loop);
@@ -328,7 +328,7 @@ class UnixServerTest extends TestCase
             $this->markTestSkipped('not supported on HHVM');
         }
 
-        $this->assertEquals('Unable to accept new connection: ' . socket_strerror(SOCKET_ETIMEDOUT), $exception->getMessage());
+        $this->assertEquals('Unable to accept new connection: ' . socket_strerror(SOCKET_ETIMEDOUT) . ' (ETIMEDOUT)', $exception->getMessage());
         $this->assertEquals(SOCKET_ETIMEDOUT, $exception->getCode());
     }
 


### PR DESCRIPTION
This changeset improves error messages for failed connections to include the errno (the internal error number exposed by the underlying system functions and its constant name).

```diff
- Connection to tcp://localhost:80 cancelled during DNS lookup
- Connection to tcp://localhost:80 failed: Last error for IPv4: Connection to tcp://127.0.0.1:80 failed: Connection refused. Previous error for IPv6: Connection to tcp://[::1]:80 failed: Connection refused
+ Connection to tcp://localhost:80 cancelled during DNS lookup (ECONNABORTED)
+ Connection to tcp://localhost:80 failed: Last error for IPv4: Connection to tcp://127.0.0.1:80 failed: Connection refused (ECONNREFUSED). Previous error for IPv6: Connection to tcp://[::1]:80 failed: Connection refused (ECONNREFUSED)
```

The errno value describes the type of error that has been encountered. This value is exposed by a number of system functions but not always exposed by many higher-level PHP functions. This changeset implements a number of ways to report or look up the errno value based on the errstr and find a matching errno constant name. This can be useful to provide more context and more descriptive error messages. The specific error conditions and codes used are system specific and in many cases are only exposed when `ext-sockets` is available (which is entirely optional, but the default on most installations of PHP). 

Builds on top of #270, #265, #266, #267 and others such as https://github.com/clue/reactphp-redis/pull/116, https://github.com/friends-of-reactphp/mysql/pull/141 and more