### PR TITLE
Support PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "react/dns": "^1.8",
         "react/event-loop": "^1.2",
         "react/promise": "^2.6.0 || ^1.2.1",
-        "react/promise-timer": "^1.4.0",
+        "react/promise-timer": "^1.8",
         "react/stream": "^1.2"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         cacheResult="false"
          colors="true"
-         cacheResult="false">
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="React Test Suite">
             <directory>./tests/</directory>

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -23,7 +23,9 @@ final class DnsConnector implements ConnectorInterface
         if (\strpos($uri, '://') === false) {
             $uri = 'tcp://' . $uri;
             $parts = \parse_url($uri);
-            unset($parts['scheme']);
+            if (isset($parts['scheme'])) {
+                unset($parts['scheme']);
+            }
         } else {
             $parts = \parse_url($uri);
         }

--- a/src/HappyEyeBallsConnector.php
+++ b/src/HappyEyeBallsConnector.php
@@ -35,7 +35,9 @@ final class HappyEyeBallsConnector implements ConnectorInterface
         if (\strpos($uri, '://') === false) {
             $uri = 'tcp://' . $uri;
             $parts = \parse_url($uri);
-            unset($parts['scheme']);
+            if (isset($parts['scheme'])) {
+                unset($parts['scheme']);
+            }
         } else {
             $parts = \parse_url($uri);
         }


### PR DESCRIPTION
This changeset adds support for PHP 8.1.

~~I'm marking this as WIP because it currently reports a deprecation notice that needs to be addressed upstream first (https://github.com/reactphp/promise-timer/pull/50). I'll update this PR once this version is released.~~

Builds on top of #274
Refs https://github.com/friends-of-reactphp/mysql/pull/150