### PR TITLE
Avoid dependency on `ext-filter`

### DIFF
--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -39,7 +39,7 @@ final class DnsConnector implements ConnectorInterface
         $connector = $this->connector;
 
         // skip DNS lookup / URI manipulation if this URI already contains an IP
-        if (false !== \filter_var($host, \FILTER_VALIDATE_IP)) {
+        if (@\inet_pton($host) !== false) {
             return $connector->connect($original);
         }
 

--- a/src/HappyEyeBallsConnector.php
+++ b/src/HappyEyeBallsConnector.php
@@ -50,7 +50,7 @@ final class HappyEyeBallsConnector implements ConnectorInterface
         $host = \trim($parts['host'], '[]');
 
         // skip DNS lookup / URI manipulation if this URI already contains an IP
-        if (false !== \filter_var($host, \FILTER_VALIDATE_IP)) {
+        if (@\inet_pton($host) !== false) {
             return $this->connector->connect($original);
         }
 

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -34,7 +34,7 @@ final class TcpConnector implements ConnectorInterface
         }
 
         $ip = \trim($parts['host'], '[]');
-        if (false === \filter_var($ip, \FILTER_VALIDATE_IP)) {
+        if (@\inet_pton($ip) === false) {
             return Promise\reject(new \InvalidArgumentException(
                 'Given URI "' . $uri . '" does not contain a valid host IP (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -160,7 +160,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
             );
         }
 
-        if (false === \filter_var(\trim($parts['host'], '[]'), \FILTER_VALIDATE_IP)) {
+        if (@\inet_pton(\trim($parts['host'], '[]')) === false) {
             throw new \InvalidArgumentException(
                 'Given URI "' . $uri . '" does not contain a valid host IP (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22

--- a/tests/FunctionalConnectorTest.php
+++ b/tests/FunctionalConnectorTest.php
@@ -90,7 +90,7 @@ class FunctionalConnectorTest extends TestCase
 
         $ip = Block\await($this->request('dual.tlund.se', $connector), $loop, self::TIMEOUT);
 
-        $this->assertSame($ip, filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6), $ip);
+        $this->assertNotFalse(inet_pton($ip));
     }
 
     /**
@@ -110,8 +110,8 @@ class FunctionalConnectorTest extends TestCase
             throw $e;
         }
 
-        $this->assertSame($ip, filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4), $ip);
-        $this->assertFalse(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6), $ip);
+        $this->assertNotFalse(inet_pton($ip));
+        $this->assertEquals(4, strlen(inet_pton($ip)));
     }
 
     /**
@@ -131,8 +131,8 @@ class FunctionalConnectorTest extends TestCase
             throw $e;
         }
 
-        $this->assertFalse(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4), $ip);
-        $this->assertSame($ip, filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6), $ip);
+        $this->assertNotFalse(inet_pton($ip));
+        $this->assertEquals(16, strlen(inet_pton($ip)));
     }
 
     public function testCancelPendingTlsConnectionDuringTlsHandshakeShouldCloseTcpConnectionToServer()


### PR DESCRIPTION
This simple changeset avoids an unneeded (and undeclared!) dependency on `ext-filter`. The extension is enabled by default, but can explicitly be disabled with `--without-filter`.

The code in question is already covered by the test suite, so the test suite confirms this changeset does not affect behavior or our public API in any way. Accordingly, this is entirely transparent for all consumers of this package, plus now also supports consumers that happen use `--without-filter`.

The changes have been ported from https://github.com/reactphp/dns/pull/185
See https://www.php.net/manual/en/filter.installation.php
Originally reported in https://github.com/leproxy/leproxy/issues/80
Refs https://github.com/reactphp/socket/pull/17