### PR TITLE
Skip legacy TLS 1.0 tests if disabled by system

### DIFF
--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -174,11 +174,13 @@ class FunctionalSecureServerTest extends TestCase
         try {
             $client = Block\await($promise, $loop, self::TIMEOUT);
         } catch (\RuntimeException $e) {
-            if (strpos($e->getMessage(), 'no protocols available') !== false || strpos($e->getMessage(), 'routines:state_machine:internal error') !== false) {
-                $this->markTestSkipped('TLS v1.0 not available on this system');
-            }
-
-            throw $e;
+            // legacy TLS 1.0 would be considered insecure by today's standards, so skip test if connection fails
+            // OpenSSL error messages are version/platform specific
+            // […] no protocols available
+            // […] routines:state_machine:internal error
+            // SSL operation failed with code 1. OpenSSL Error messages: error:0A000438:SSL routines::tlsv1 alert internal error
+            // Connection lost during TLS handshake (ECONNRESET)
+            $this->markTestSkipped('TLS 1.0 not available on this system (' . $e->getMessage() . ')');
         }
 
         $this->assertInstanceOf('React\Socket\Connection', $client);


### PR DESCRIPTION
Skip legacy TLS 1.0 tests if disabled by system. For example, this affects Fedora 36 installations which prohibit legacy TLS 1.0 connections by default. By today's standards, TLS 1.0 would be considered insecure, so it makes sense this is prohibited by default even if explicitly requested like in our test suite. Accordingly, this changeset only affects the test suite and has no effect on runtime.

For PHP, this can be reproduced (prior to applying this patch) by running the test suite in a default Fedora 36 installation like this:

```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data fedora:36 bash
# dnf install php-cli php-dom php-mbstring
# vendor/bin/phpunit
```

Resolves / closes #275
Builds on top of #229