### PR TITLE
Use default loop in testsuite and close server and connection leftovers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "react/stream": "^1.2"
     },
     "require-dev": {
-        "clue/block-react": "^1.2",
+        "clue/block-react": "^1.5",
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
         "react/promise-stream": "^1.2"
     },

--- a/tests/FdServerTest.php
+++ b/tests/FdServerTest.php
@@ -3,7 +3,6 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\Loop;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
 use React\Socket\FdServer;
@@ -303,12 +302,12 @@ class FdServerTest extends TestCase
 
         $client = stream_socket_client('tcp://' . stream_socket_get_name($socket, false));
 
-        $server = new FdServer($fd, Loop::get());
+        $server = new FdServer($fd);
         $promise = new Promise(function ($resolve) use ($server) {
             $server->on('connection', $resolve);
         });
 
-        $connection = Block\await($promise, Loop::get(), 1.0);
+        $connection = Block\await($promise, null, 1.0);
 
         /**
          * @var ConnectionInterface $connection

--- a/tests/FdServerTest.php
+++ b/tests/FdServerTest.php
@@ -5,6 +5,7 @@ namespace React\Tests\Socket;
 use Clue\React\Block;
 use React\EventLoop\Loop;
 use React\Promise\Promise;
+use React\Socket\ConnectionInterface;
 use React\Socket\FdServer;
 
 class FdServerTest extends TestCase
@@ -309,9 +310,14 @@ class FdServerTest extends TestCase
 
         $connection = Block\await($promise, Loop::get(), 1.0);
 
+        /**
+         * @var ConnectionInterface $connection
+         */
         $this->assertInstanceOf('React\Socket\ConnectionInterface', $connection);
 
         fclose($client);
+        $connection->close();
+        $server->close();
     }
 
     public function testEmitsErrorWhenAcceptListenerFails()

--- a/tests/FunctionalConnectorTest.php
+++ b/tests/FunctionalConnectorTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Promise\Deferred;
 use React\Socket\ConnectionInterface;
 use React\Socket\Connector;
@@ -20,7 +20,7 @@ class FunctionalConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceedWithLocalhost()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(9998, $loop);
 
@@ -44,7 +44,7 @@ class FunctionalConnectorTest extends TestCase
             $this->markTestSkipped('Not supported on Windows for PHP versions < 7.0 and legacy HHVM');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $socket = stream_socket_server('udp://127.0.0.1:0', $errno, $errstr, STREAM_SERVER_BIND);
 
@@ -84,7 +84,7 @@ class FunctionalConnectorTest extends TestCase
         // max_nesting_level was set to 100 for PHP Versions < 5.4 which resulted in failing test for legacy PHP
         ini_set('xdebug.max_nesting_level', 256);
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $connector = new Connector(array('happy_eyeballs' => true), $loop);
 
@@ -99,7 +99,7 @@ class FunctionalConnectorTest extends TestCase
      */
     public function connectionToRemoteTCP4ServerShouldResultInOurIP()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $connector = new Connector(array('happy_eyeballs' => true), $loop);
 
@@ -120,7 +120,7 @@ class FunctionalConnectorTest extends TestCase
      */
     public function connectionToRemoteTCP6ServerShouldResultInOurIP()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $connector = new Connector(array('happy_eyeballs' => true), $loop);
 
@@ -141,7 +141,7 @@ class FunctionalConnectorTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $uri = str_replace('tcp://', 'tls://', $server->getAddress());

--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -4,7 +4,6 @@ namespace React\Tests\Socket;
 
 use Clue\React\Block;
 use Evenement\EventEmitterInterface;
-use React\EventLoop\Loop;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
 use React\Socket\SecureConnector;
@@ -29,8 +28,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testClientCanConnectToServer()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -42,7 +39,7 @@ class FunctionalSecureServerTest extends TestCase
         $promise = $connector->connect($server->getAddress());
 
         /* @var ConnectionInterface $client */
-        $client = Block\await($promise, $loop, self::TIMEOUT);
+        $client = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Socket\ConnectionInterface', $client);
         $this->assertEquals($server->getAddress(), $client->getRemoteAddress());
@@ -60,8 +57,6 @@ class FunctionalSecureServerTest extends TestCase
             $this->markTestSkipped('Test requires PHP 7+ for crypto meta data (but excludes PHP 7.3 because it implicitly limits to TLS 1.2) and OpenSSL 1.1.1+ for TLS 1.3');
         }
 
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -73,7 +68,7 @@ class FunctionalSecureServerTest extends TestCase
         $promise = $connector->connect($server->getAddress());
 
         /* @var ConnectionInterface $client */
-        $client = Block\await($promise, $loop, self::TIMEOUT);
+        $client = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Socket\Connection', $client);
         $this->assertTrue(isset($client->stream));
@@ -100,8 +95,6 @@ class FunctionalSecureServerTest extends TestCase
             $this->markTestSkipped('Test requires PHP 7+ for crypto meta data');
         }
 
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -114,7 +107,7 @@ class FunctionalSecureServerTest extends TestCase
         $promise = $connector->connect($server->getAddress());
 
         /* @var ConnectionInterface $client */
-        $client = Block\await($promise, $loop, self::TIMEOUT);
+        $client = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Socket\Connection', $client);
         $this->assertTrue(isset($client->stream));
@@ -133,8 +126,6 @@ class FunctionalSecureServerTest extends TestCase
             $this->markTestSkipped('Test requires PHP 7+ for crypto meta data');
         }
 
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem',
@@ -147,7 +138,7 @@ class FunctionalSecureServerTest extends TestCase
         $promise = $connector->connect($server->getAddress());
 
         /* @var ConnectionInterface $client */
-        $client = Block\await($promise, $loop, self::TIMEOUT);
+        $client = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Socket\Connection', $client);
         $this->assertTrue(isset($client->stream));
@@ -166,8 +157,6 @@ class FunctionalSecureServerTest extends TestCase
             $this->markTestSkipped('Test requires PHP 7+ for crypto meta data');
         }
 
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -181,7 +170,7 @@ class FunctionalSecureServerTest extends TestCase
 
         /* @var ConnectionInterface $client */
         try {
-            $client = Block\await($promise, $loop, self::TIMEOUT);
+            $client = Block\await($promise, null, self::TIMEOUT);
         } catch (\RuntimeException $e) {
             // legacy TLS 1.0 would be considered insecure by today's standards, so skip test if connection fails
             // OpenSSL error messages are version/platform specific
@@ -206,8 +195,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testServerEmitsConnectionForClientConnection()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -225,7 +212,7 @@ class FunctionalSecureServerTest extends TestCase
 
         // await both client and server side end of connection
         /* @var ConnectionInterface[] $both */
-        $both = Block\awaitAll(array($peer, $client), $loop, self::TIMEOUT);
+        $both = Block\awaitAll(array($peer, $client), null, self::TIMEOUT);
 
         // both ends of the connection are represented by different instances of ConnectionInterface
         $this->assertCount(2, $both);
@@ -245,8 +232,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testClientEmitsDataEventOnceForDataWrittenFromServer()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -267,7 +252,7 @@ class FunctionalSecureServerTest extends TestCase
             }, $reject);
         });
 
-        $data = Block\await($promise, $loop, self::TIMEOUT);
+        $data = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertEquals('foo', $data);
 
@@ -280,8 +265,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testWritesDataInMultipleChunksToConnection()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -310,7 +293,7 @@ class FunctionalSecureServerTest extends TestCase
             }, $reject);
         });
 
-        $received = Block\await($promise, $loop, self::TIMEOUT);
+        $received = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertEquals(400000, $received);
 
@@ -323,8 +306,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testWritesMoreDataInMultipleChunksToConnection()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -353,7 +334,7 @@ class FunctionalSecureServerTest extends TestCase
             }, $reject);
         });
 
-        $received = Block\await($promise, $loop, self::TIMEOUT);
+        $received = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertEquals(2000000, $received);
 
@@ -366,8 +347,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsDataFromConnection()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -388,7 +367,7 @@ class FunctionalSecureServerTest extends TestCase
             $connection->write('foo');
         });
 
-        $data = Block\await($promise, $loop, self::TIMEOUT);
+        $data = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertEquals('foo', $data);
 
@@ -401,8 +380,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsDataInMultipleChunksFromConnection()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -430,7 +407,7 @@ class FunctionalSecureServerTest extends TestCase
             $connection->write(str_repeat('*', 400000));
         });
 
-        $received = Block\await($promise, $loop, self::TIMEOUT);
+        $received = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertEquals(400000, $received);
 
@@ -443,8 +420,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testPipesDataBackInMultipleChunksFromConnection()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -474,7 +449,7 @@ class FunctionalSecureServerTest extends TestCase
             }, $reject);
         });
 
-        $received = Block\await($promise, $loop, self::TIMEOUT);
+        $received = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertEquals(400000, $received);
 
@@ -491,8 +466,6 @@ class FunctionalSecureServerTest extends TestCase
      */
     public function testEmitsConnectionForNewTlsv11Connection()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem',
@@ -506,7 +479,7 @@ class FunctionalSecureServerTest extends TestCase
         ));
         $promise = $connector->connect($server->getAddress());
 
-        Block\await($promise, $loop, self::TIMEOUT);
+        Block\await($promise, null, self::TIMEOUT);
 
         $server->close();
         $promise->then(function (ConnectionInterface $connection) {
@@ -520,8 +493,6 @@ class FunctionalSecureServerTest extends TestCase
      */
     public function testEmitsErrorForClientWithTlsVersionMismatch()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem',
@@ -539,7 +510,7 @@ class FunctionalSecureServerTest extends TestCase
         $this->setExpectedException('RuntimeException', 'handshake');
 
         try {
-            Block\await($promise, $loop, self::TIMEOUT);
+            Block\await($promise, null, self::TIMEOUT);
         } catch (\Exception $e) {
             $server->close();
 
@@ -549,8 +520,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testServerEmitsConnectionForNewConnectionWithEncryptedCertificate()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost_swordfish.pem',
@@ -567,7 +536,7 @@ class FunctionalSecureServerTest extends TestCase
         ));
         $connector->connect($server->getAddress());
 
-        $connection = Block\await($peer, $loop, self::TIMEOUT);
+        $connection = Block\await($peer, null, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Socket\ConnectionInterface', $connection);
 
@@ -577,8 +546,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testClientRejectsWithErrorForServerWithInvalidCertificate()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => 'invalid.pem'
@@ -592,7 +559,7 @@ class FunctionalSecureServerTest extends TestCase
         $this->setExpectedException('RuntimeException', 'handshake');
 
         try {
-            Block\await($promise, $loop, self::TIMEOUT);
+            Block\await($promise, null, self::TIMEOUT);
         } catch (\Exception $e) {
             $server->close();
 
@@ -602,8 +569,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testServerEmitsErrorForClientWithInvalidCertificate()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => 'invalid.pem'
@@ -624,7 +589,7 @@ class FunctionalSecureServerTest extends TestCase
         $this->setExpectedException('RuntimeException', 'handshake');
 
         try {
-            Block\await($peer, $loop, self::TIMEOUT);
+            Block\await($peer, null, self::TIMEOUT);
         } catch (\Exception $e) {
             $server->close();
 
@@ -637,8 +602,6 @@ class FunctionalSecureServerTest extends TestCase
         if (DIRECTORY_SEPARATOR === '\\') {
             $this->markTestSkipped('Not supported on Windows');
         }
-
-        $loop = Loop::get();
 
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
@@ -655,7 +618,7 @@ class FunctionalSecureServerTest extends TestCase
         $this->setExpectedException('RuntimeException', 'handshake');
 
         try {
-            Block\await($promise, $loop, self::TIMEOUT);
+            Block\await($promise, null, self::TIMEOUT);
         } catch (\Exception $e) {
             $server->close();
 
@@ -668,8 +631,6 @@ class FunctionalSecureServerTest extends TestCase
         if (DIRECTORY_SEPARATOR === '\\') {
             $this->markTestSkipped('Not supported on Windows');
         }
-
-        $loop = Loop::get();
 
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
@@ -687,7 +648,7 @@ class FunctionalSecureServerTest extends TestCase
         $this->setExpectedException('RuntimeException', 'handshake');
 
         try {
-            Block\await($promise, $loop, self::TIMEOUT);
+            Block\await($promise, null, self::TIMEOUT);
         } catch (\Exception $e) {
             $server->close();
 
@@ -697,8 +658,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsErrorForConnectionWithPeerVerification()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -712,7 +671,7 @@ class FunctionalSecureServerTest extends TestCase
         $promise = $connector->connect($server->getAddress());
         $promise->then(null, $this->expectCallableOnce());
 
-        Block\await($errorEvent, $loop, self::TIMEOUT);
+        Block\await($errorEvent, null, self::TIMEOUT);
 
         $server->close();
     }
@@ -722,8 +681,6 @@ class FunctionalSecureServerTest extends TestCase
         if (PHP_OS !== 'Linux') {
             $this->markTestSkipped('Linux only (OS is ' . PHP_OS . ')');
         }
-
-        $loop = Loop::get();
 
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
@@ -739,15 +696,13 @@ class FunctionalSecureServerTest extends TestCase
         $promise->cancel();
         $promise->then(null, $this->expectCallableOnce());
 
-        Block\await($errorEvent, $loop, self::TIMEOUT);
+        Block\await($errorEvent, null, self::TIMEOUT);
 
         $server->close();
     }
 
     public function testEmitsErrorIfConnectionIsClosedBeforeHandshake()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -762,7 +717,7 @@ class FunctionalSecureServerTest extends TestCase
             $stream->close();
         });
 
-        $error = Block\await($errorEvent, $loop, self::TIMEOUT);
+        $error = Block\await($errorEvent, null, self::TIMEOUT);
 
         // Connection from tcp://127.0.0.1:39528 failed during TLS handshake: Connection lost during TLS handshake (ECONNRESET)
         $this->assertInstanceOf('RuntimeException', $error);
@@ -776,8 +731,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsErrorIfConnectionIsClosedWithIncompleteHandshake()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -792,7 +745,7 @@ class FunctionalSecureServerTest extends TestCase
             $stream->end("\x1e");
         });
 
-        $error = Block\await($errorEvent, $loop, self::TIMEOUT);
+        $error = Block\await($errorEvent, null, self::TIMEOUT);
 
         // Connection from tcp://127.0.0.1:39528 failed during TLS handshake: Connection lost during TLS handshake (ECONNRESET)
         $this->assertInstanceOf('RuntimeException', $error);
@@ -806,8 +759,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsNothingIfPlaintextConnectionIsIdle()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -818,7 +769,7 @@ class FunctionalSecureServerTest extends TestCase
         $connector = new TcpConnector();
         $promise = $connector->connect(str_replace('tls://', '', $server->getAddress()));
 
-        $connection = Block\await($promise, $loop, self::TIMEOUT);
+        $connection = Block\await($promise, null, self::TIMEOUT);
         $this->assertInstanceOf('React\Socket\ConnectionInterface', $connection);
 
         $server->close();
@@ -829,8 +780,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsErrorIfConnectionIsHttpInsteadOfSecureHandshake()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -845,7 +794,7 @@ class FunctionalSecureServerTest extends TestCase
             $stream->write("GET / HTTP/1.0\r\n\r\n");
         });
 
-        $error = Block\await($errorEvent, $loop, self::TIMEOUT);
+        $error = Block\await($errorEvent, null, self::TIMEOUT);
 
         $this->assertInstanceOf('RuntimeException', $error);
 
@@ -860,8 +809,6 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsErrorIfConnectionIsUnknownProtocolInsteadOfSecureHandshake()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -876,7 +823,7 @@ class FunctionalSecureServerTest extends TestCase
             $stream->write("Hello world!\n");
         });
 
-        $error = Block\await($errorEvent, $loop, self::TIMEOUT);
+        $error = Block\await($errorEvent, null, self::TIMEOUT);
 
         $this->assertInstanceOf('RuntimeException', $error);
 

--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -4,7 +4,7 @@ namespace React\Tests\Socket;
 
 use Clue\React\Block;
 use Evenement\EventEmitterInterface;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
 use React\Socket\SecureConnector;
@@ -29,7 +29,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testClientCanConnectToServer()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -60,7 +60,7 @@ class FunctionalSecureServerTest extends TestCase
             $this->markTestSkipped('Test requires PHP 7+ for crypto meta data (but excludes PHP 7.3 because it implicitly limits to TLS 1.2) and OpenSSL 1.1.1+ for TLS 1.3');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -97,7 +97,7 @@ class FunctionalSecureServerTest extends TestCase
             $this->markTestSkipped('Test requires PHP 7+ for crypto meta data');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -127,7 +127,7 @@ class FunctionalSecureServerTest extends TestCase
             $this->markTestSkipped('Test requires PHP 7+ for crypto meta data');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -157,7 +157,7 @@ class FunctionalSecureServerTest extends TestCase
             $this->markTestSkipped('Test requires PHP 7+ for crypto meta data');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -193,7 +193,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testServerEmitsConnectionForClientConnection()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -232,7 +232,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testClientEmitsDataEventOnceForDataWrittenFromServer()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -261,7 +261,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testWritesDataInMultipleChunksToConnection()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -298,7 +298,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testWritesMoreDataInMultipleChunksToConnection()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -335,7 +335,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsDataFromConnection()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -363,7 +363,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsDataInMultipleChunksFromConnection()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -398,7 +398,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testPipesDataBackInMultipleChunksFromConnection()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -440,7 +440,7 @@ class FunctionalSecureServerTest extends TestCase
      */
     public function testEmitsConnectionForNewTlsv11Connection()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -464,7 +464,7 @@ class FunctionalSecureServerTest extends TestCase
      */
     public function testEmitsErrorForClientWithTlsVersionMismatch()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -486,7 +486,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testServerEmitsConnectionForNewConnectionWithEncryptedCertificate()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -511,7 +511,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testClientRejectsWithErrorForServerWithInvalidCertificate()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -529,7 +529,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testServerEmitsErrorForClientWithInvalidCertificate()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -558,7 +558,7 @@ class FunctionalSecureServerTest extends TestCase
             $this->markTestSkipped('Not supported on Windows');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -582,7 +582,7 @@ class FunctionalSecureServerTest extends TestCase
             $this->markTestSkipped('Not supported on Windows');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -603,7 +603,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsErrorForConnectionWithPeerVerification()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -627,7 +627,7 @@ class FunctionalSecureServerTest extends TestCase
             $this->markTestSkipped('Linux only (OS is ' . PHP_OS . ')');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -648,7 +648,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsErrorIfConnectionIsClosedBeforeHandshake()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -676,7 +676,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsErrorIfConnectionIsClosedWithIncompleteHandshake()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -704,7 +704,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsNothingIfPlaintextConnectionIsIdle()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -722,7 +722,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsErrorIfConnectionIsHttpInsteadOfSecureHandshake()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(
@@ -751,7 +751,7 @@ class FunctionalSecureServerTest extends TestCase
 
     public function testEmitsErrorIfConnectionIsUnknownProtocolInsteadOfSecureHandshake()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new SecureServer($server, $loop, array(

--- a/tests/FunctionalSecureServerTest.php
+++ b/tests/FunctionalSecureServerTest.php
@@ -31,12 +31,12 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
         $promise = $connector->connect($server->getAddress());
@@ -62,12 +62,12 @@ class FunctionalSecureServerTest extends TestCase
 
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
         $promise = $connector->connect($server->getAddress());
@@ -89,6 +89,9 @@ class FunctionalSecureServerTest extends TestCase
         } else {
             $this->assertEquals('TLSv1.3', $meta['crypto']['protocol']);
         }
+
+        $client->close();
+        $server->close();
     }
 
     public function testClientUsesTls12WhenCryptoMethodIsExplicitlyConfiguredByClient()
@@ -99,12 +102,12 @@ class FunctionalSecureServerTest extends TestCase
 
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false,
             'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT
         ));
@@ -119,6 +122,9 @@ class FunctionalSecureServerTest extends TestCase
         $meta = stream_get_meta_data($client->stream);
         $this->assertTrue(isset($meta['crypto']['protocol']));
         $this->assertEquals('TLSv1.2', $meta['crypto']['protocol']);
+
+        $client->close();
+        $server->close();
     }
 
     public function testClientUsesTls12WhenCryptoMethodIsExplicitlyConfiguredByServer()
@@ -129,13 +135,13 @@ class FunctionalSecureServerTest extends TestCase
 
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem',
             'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2_SERVER
         ));
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
         $promise = $connector->connect($server->getAddress());
@@ -149,6 +155,9 @@ class FunctionalSecureServerTest extends TestCase
         $meta = stream_get_meta_data($client->stream);
         $this->assertTrue(isset($meta['crypto']['protocol']));
         $this->assertEquals('TLSv1.2', $meta['crypto']['protocol']);
+
+        $client->close();
+        $server->close();
     }
 
     public function testClientUsesTls10WhenCryptoMethodIsExplicitlyConfiguredByClient()
@@ -159,12 +168,12 @@ class FunctionalSecureServerTest extends TestCase
 
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false,
             'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT
         ));
@@ -180,6 +189,7 @@ class FunctionalSecureServerTest extends TestCase
             // […] routines:state_machine:internal error
             // SSL operation failed with code 1. OpenSSL Error messages: error:0A000438:SSL routines::tlsv1 alert internal error
             // Connection lost during TLS handshake (ECONNRESET)
+            $server->close();
             $this->markTestSkipped('TLS 1.0 not available on this system (' . $e->getMessage() . ')');
         }
 
@@ -189,14 +199,17 @@ class FunctionalSecureServerTest extends TestCase
         $meta = stream_get_meta_data($client->stream);
         $this->assertTrue(isset($meta['crypto']['protocol']));
         $this->assertEquals('TLSv1', $meta['crypto']['protocol']);
+
+        $client->close();
+        $server->close();
     }
 
     public function testServerEmitsConnectionForClientConnection()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
 
@@ -205,7 +218,7 @@ class FunctionalSecureServerTest extends TestCase
             $server->on('error', $reject);
         });
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
         $client = $connector->connect($server->getAddress());
@@ -234,8 +247,8 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
 
@@ -243,13 +256,13 @@ class FunctionalSecureServerTest extends TestCase
             $conn->write('foo');
         });
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
-        $promise = $connector->connect($server->getAddress());
+        $connecting = $connector->connect($server->getAddress());
 
-        $promise = new Promise(function ($resolve, $reject) use ($promise) {
-            $promise->then(function (ConnectionInterface $connection) use ($resolve) {
+        $promise = new Promise(function ($resolve, $reject) use ($connecting) {
+            $connecting->then(function (ConnectionInterface $connection) use ($resolve) {
                 $connection->on('data', $resolve);
             }, $reject);
         });
@@ -257,14 +270,20 @@ class FunctionalSecureServerTest extends TestCase
         $data = Block\await($promise, $loop, self::TIMEOUT);
 
         $this->assertEquals('foo', $data);
+
+        $server->close();
+
+        $connecting->then(function (ConnectionInterface $connection) {
+            $connection->close();
+        });
     }
 
     public function testWritesDataInMultipleChunksToConnection()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
         $server->on('connection', $this->expectCallableOnce());
@@ -273,15 +292,15 @@ class FunctionalSecureServerTest extends TestCase
             $conn->write(str_repeat('*', 400000));
         });
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
-        $promise = $connector->connect($server->getAddress());
+        $connecting = $connector->connect($server->getAddress());
 
-        $promise = new Promise(function ($resolve, $reject) use ($promise) {
-            $promise->then(function (ConnectionInterface $connection) use ($resolve) {
+        $promise = new Promise(function ($resolve, $reject) use ($connecting) {
+            $connecting->then(function (ConnectionInterface $connection) use ($resolve) {
                 $received = 0;
-                $connection->on('data', function ($chunk) use (&$received, $resolve) {
+                $connection->on('data', function ($chunk) use (&$received, $resolve, $connection) {
                     $received += strlen($chunk);
 
                     if ($received >= 400000) {
@@ -294,14 +313,20 @@ class FunctionalSecureServerTest extends TestCase
         $received = Block\await($promise, $loop, self::TIMEOUT);
 
         $this->assertEquals(400000, $received);
+
+        $server->close();
+
+        $connecting->then(function (ConnectionInterface $connection) {
+            $connection->close();
+        });
     }
 
     public function testWritesMoreDataInMultipleChunksToConnection()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
         $server->on('connection', $this->expectCallableOnce());
@@ -310,13 +335,13 @@ class FunctionalSecureServerTest extends TestCase
             $conn->write(str_repeat('*', 2000000));
         });
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
-        $promise = $connector->connect($server->getAddress());
+        $connecting = $connector->connect($server->getAddress());
 
-        $promise = new Promise(function ($resolve, $reject) use ($promise) {
-            $promise->then(function (ConnectionInterface $connection) use ($resolve) {
+        $promise = new Promise(function ($resolve, $reject) use ($connecting) {
+            $connecting->then(function (ConnectionInterface $connection) use ($resolve) {
                 $received = 0;
                 $connection->on('data', function ($chunk) use (&$received, $resolve) {
                     $received += strlen($chunk);
@@ -331,14 +356,20 @@ class FunctionalSecureServerTest extends TestCase
         $received = Block\await($promise, $loop, self::TIMEOUT);
 
         $this->assertEquals(2000000, $received);
+
+        $server->close();
+
+        $connecting->then(function (ConnectionInterface $connection) {
+            $connection->close();
+        });
     }
 
     public function testEmitsDataFromConnection()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
         $server->on('connection', $this->expectCallableOnce());
@@ -349,24 +380,31 @@ class FunctionalSecureServerTest extends TestCase
             });
         });
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
-        $connector->connect($server->getAddress())->then(function (ConnectionInterface $connection) {
+        $connecting = $connector->connect($server->getAddress());
+        $connecting->then(function (ConnectionInterface $connection) {
             $connection->write('foo');
         });
 
         $data = Block\await($promise, $loop, self::TIMEOUT);
 
         $this->assertEquals('foo', $data);
+
+        $server->close();
+
+        $connecting->then(function (ConnectionInterface $connection) {
+            $connection->close();
+        });
     }
 
     public function testEmitsDataInMultipleChunksFromConnection()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
         $server->on('connection', $this->expectCallableOnce());
@@ -384,24 +422,31 @@ class FunctionalSecureServerTest extends TestCase
             });
         });
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
-        $connector->connect($server->getAddress())->then(function (ConnectionInterface $connection) {
+        $connecting = $connector->connect($server->getAddress());
+        $connecting->then(function (ConnectionInterface $connection) {
             $connection->write(str_repeat('*', 400000));
         });
 
         $received = Block\await($promise, $loop, self::TIMEOUT);
 
         $this->assertEquals(400000, $received);
+
+        $server->close();
+
+        $connecting->then(function (ConnectionInterface $connection) {
+            $connection->close();
+        });
     }
 
     public function testPipesDataBackInMultipleChunksFromConnection()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
         $server->on('connection', $this->expectCallableOnce());
@@ -410,13 +455,13 @@ class FunctionalSecureServerTest extends TestCase
             $conn->pipe($conn);
         });
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
-        $promise = $connector->connect($server->getAddress());
+        $connecting = $connector->connect($server->getAddress());
 
-        $promise = new Promise(function ($resolve, $reject) use ($promise) {
-            $promise->then(function (ConnectionInterface $connection) use ($resolve) {
+        $promise = new Promise(function ($resolve, $reject) use ($connecting) {
+            $connecting->then(function (ConnectionInterface $connection) use ($resolve) {
                 $received = 0;
                 $connection->on('data', function ($chunk) use (&$received, $resolve) {
                     $received += strlen($chunk);
@@ -432,6 +477,12 @@ class FunctionalSecureServerTest extends TestCase
         $received = Block\await($promise, $loop, self::TIMEOUT);
 
         $this->assertEquals(400000, $received);
+
+        $server->close();
+
+        $connecting->then(function (ConnectionInterface $connection) {
+            $connection->close();
+        });
     }
 
     /**
@@ -442,20 +493,25 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem',
             'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_1_SERVER
         ));
         $server->on('connection', $this->expectCallableOnce());
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false,
             'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
         ));
         $promise = $connector->connect($server->getAddress());
 
         Block\await($promise, $loop, self::TIMEOUT);
+
+        $server->close();
+        $promise->then(function (ConnectionInterface $connection) {
+            $connection->close();
+        });
     }
 
     /**
@@ -466,30 +522,37 @@ class FunctionalSecureServerTest extends TestCase
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem',
             'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_1_SERVER|STREAM_CRYPTO_METHOD_TLSv1_2_SERVER
         ));
         $server->on('connection', $this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false,
             'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT
         ));
         $promise = $connector->connect($server->getAddress());
 
         $this->setExpectedException('RuntimeException', 'handshake');
-        Block\await($promise, $loop, self::TIMEOUT);
+
+        try {
+            Block\await($promise, $loop, self::TIMEOUT);
+        } catch (\Exception $e) {
+            $server->close();
+
+            throw $e;
+        }
     }
 
     public function testServerEmitsConnectionForNewConnectionWithEncryptedCertificate()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost_swordfish.pem',
             'passphrase' => 'swordfish'
         ));
@@ -499,7 +562,7 @@ class FunctionalSecureServerTest extends TestCase
             $server->on('error', $reject);
         });
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
         $connector->connect($server->getAddress());
@@ -507,32 +570,42 @@ class FunctionalSecureServerTest extends TestCase
         $connection = Block\await($peer, $loop, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Socket\ConnectionInterface', $connection);
+
+        $server->close();
+        $connection->close();
     }
 
     public function testClientRejectsWithErrorForServerWithInvalidCertificate()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => 'invalid.pem'
         ));
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
         $promise = $connector->connect($server->getAddress());
 
         $this->setExpectedException('RuntimeException', 'handshake');
-        Block\await($promise, $loop, self::TIMEOUT);
+
+        try {
+            Block\await($promise, $loop, self::TIMEOUT);
+        } catch (\Exception $e) {
+            $server->close();
+
+            throw $e;
+        }
     }
 
     public function testServerEmitsErrorForClientWithInvalidCertificate()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => 'invalid.pem'
         ));
 
@@ -543,13 +616,20 @@ class FunctionalSecureServerTest extends TestCase
             $server->on('error', $reject);
         });
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
         $connector->connect($server->getAddress());
 
         $this->setExpectedException('RuntimeException', 'handshake');
-        Block\await($peer, $loop, self::TIMEOUT);
+
+        try {
+            Block\await($peer, $loop, self::TIMEOUT);
+        } catch (\Exception $e) {
+            $server->close();
+
+            throw $e;
+        }
     }
 
     public function testEmitsErrorForServerWithEncryptedCertificateMissingPassphrase()
@@ -560,20 +640,27 @@ class FunctionalSecureServerTest extends TestCase
 
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost_swordfish.pem'
         ));
         $server->on('connection', $this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
         $promise = $connector->connect($server->getAddress());
 
         $this->setExpectedException('RuntimeException', 'handshake');
-        Block\await($promise, $loop, self::TIMEOUT);
+
+        try {
+            Block\await($promise, $loop, self::TIMEOUT);
+        } catch (\Exception $e) {
+            $server->close();
+
+            throw $e;
+        }
     }
 
     public function testEmitsErrorForServerWithEncryptedCertificateWithInvalidPassphrase()
@@ -584,41 +671,50 @@ class FunctionalSecureServerTest extends TestCase
 
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost_swordfish.pem',
             'passphrase' => 'nope'
         ));
         $server->on('connection', $this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
         $promise = $connector->connect($server->getAddress());
 
         $this->setExpectedException('RuntimeException', 'handshake');
-        Block\await($promise, $loop, self::TIMEOUT);
+
+        try {
+            Block\await($promise, $loop, self::TIMEOUT);
+        } catch (\Exception $e) {
+            $server->close();
+
+            throw $e;
+        }
     }
 
     public function testEmitsErrorForConnectionWithPeerVerification()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
         $server->on('connection', $this->expectCallableNever());
         $errorEvent = $this->createPromiseForServerError($server);
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => true
         ));
         $promise = $connector->connect($server->getAddress());
         $promise->then(null, $this->expectCallableOnce());
 
         Block\await($errorEvent, $loop, self::TIMEOUT);
+
+        $server->close();
     }
 
     public function testEmitsErrorIfConnectionIsCancelled()
@@ -629,14 +725,14 @@ class FunctionalSecureServerTest extends TestCase
 
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
         $server->on('connection', $this->expectCallableNever());
         $errorEvent = $this->createPromiseForServerError($server);
 
-        $connector = new SecureConnector(new TcpConnector($loop), $loop, array(
+        $connector = new SecureConnector(new TcpConnector(), null, array(
             'verify_peer' => false
         ));
         $promise = $connector->connect($server->getAddress());
@@ -644,20 +740,22 @@ class FunctionalSecureServerTest extends TestCase
         $promise->then(null, $this->expectCallableOnce());
 
         Block\await($errorEvent, $loop, self::TIMEOUT);
+
+        $server->close();
     }
 
     public function testEmitsErrorIfConnectionIsClosedBeforeHandshake()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
         $server->on('connection', $this->expectCallableNever());
         $errorEvent = $this->createPromiseForServerError($server);
 
-        $connector = new TcpConnector($loop);
+        $connector = new TcpConnector();
         $promise = $connector->connect(str_replace('tls://', '', $server->getAddress()));
 
         $promise->then(function (ConnectionInterface $stream) {
@@ -672,20 +770,22 @@ class FunctionalSecureServerTest extends TestCase
         $this->assertStringEndsWith('failed during TLS handshake: Connection lost during TLS handshake (ECONNRESET)', $error->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 104, $error->getCode());
         $this->assertNull($error->getPrevious());
+
+        $server->close();
     }
 
     public function testEmitsErrorIfConnectionIsClosedWithIncompleteHandshake()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
         $server->on('connection', $this->expectCallableNever());
         $errorEvent = $this->createPromiseForServerError($server);
 
-        $connector = new TcpConnector($loop);
+        $connector = new TcpConnector();
         $promise = $connector->connect(str_replace('tls://', '', $server->getAddress()));
 
         $promise->then(function (ConnectionInterface $stream) {
@@ -700,38 +800,45 @@ class FunctionalSecureServerTest extends TestCase
         $this->assertStringEndsWith('failed during TLS handshake: Connection lost during TLS handshake (ECONNRESET)', $error->getMessage());
         $this->assertEquals(defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 104, $error->getCode());
         $this->assertNull($error->getPrevious());
+
+        $server->close();
     }
 
     public function testEmitsNothingIfPlaintextConnectionIsIdle()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
         $server->on('connection', $this->expectCallableNever());
         $server->on('error', $this->expectCallableNever());
 
-        $connector = new TcpConnector($loop);
+        $connector = new TcpConnector();
         $promise = $connector->connect(str_replace('tls://', '', $server->getAddress()));
 
         $connection = Block\await($promise, $loop, self::TIMEOUT);
         $this->assertInstanceOf('React\Socket\ConnectionInterface', $connection);
+
+        $server->close();
+        $promise->then(function (ConnectionInterface $connection) {
+            $connection->close();
+        });
     }
 
     public function testEmitsErrorIfConnectionIsHttpInsteadOfSecureHandshake()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
         $server->on('connection', $this->expectCallableNever());
         $errorEvent = $this->createPromiseForServerError($server);
 
-        $connector = new TcpConnector($loop);
+        $connector = new TcpConnector();
         $promise = $connector->connect(str_replace('tls://', '', $server->getAddress()));
 
         $promise->then(function (ConnectionInterface $stream) {
@@ -747,20 +854,22 @@ class FunctionalSecureServerTest extends TestCase
         // Unable to complete TLS handshake: SSL operation failed with code 1. OpenSSL Error messages: error:1408F10B:SSL routines:ssl3_get_record:wrong version number
         // Unable to complete TLS handshake: SSL operation failed with code 1. OpenSSL Error messages: error:1408F10B:SSL routines:func(143):reason(267)
         // Unable to complete TLS handshake: Failed setting RSA key
+
+        $server->close();
     }
 
     public function testEmitsErrorIfConnectionIsUnknownProtocolInsteadOfSecureHandshake()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
-        $server = new SecureServer($server, $loop, array(
+        $server = new TcpServer(0);
+        $server = new SecureServer($server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
         ));
         $server->on('connection', $this->expectCallableNever());
         $errorEvent = $this->createPromiseForServerError($server);
 
-        $connector = new TcpConnector($loop);
+        $connector = new TcpConnector();
         $promise = $connector->connect(str_replace('tls://', '', $server->getAddress()));
 
         $promise->then(function (ConnectionInterface $stream) {
@@ -776,6 +885,8 @@ class FunctionalSecureServerTest extends TestCase
         // Unable to complete TLS handshake: SSL operation failed with code 1. OpenSSL Error messages: error:1408F10B:SSL routines:ssl3_get_record:wrong version number
         // Unable to complete TLS handshake: SSL operation failed with code 1. OpenSSL Error messages: error:1408F10B:SSL routines:func(143):reason(267)
         // Unable to complete TLS handshake: Failed setting RSA key
+
+        $server->close();
     }
 
     private function createPromiseForServerError(ServerInterface $server)

--- a/tests/FunctionalTcpServerTest.php
+++ b/tests/FunctionalTcpServerTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
 use React\Socket\TcpConnector;
@@ -15,7 +15,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionForNewConnection()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server->on('connection', $this->expectCallableOnce());
@@ -34,7 +34,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsNoConnectionForNewConnectionWhenPaused()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server->on('connection', $this->expectCallableNever());
@@ -50,7 +50,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testConnectionForNewConnectionWhenResumedAfterPause()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server->on('connection', $this->expectCallableOnce());
@@ -71,7 +71,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionWithRemoteIp()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $peer = new Promise(function ($resolve, $reject) use ($server) {
@@ -92,7 +92,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionWithLocalIp()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $peer = new Promise(function ($resolve, $reject) use ($server) {
@@ -120,7 +120,7 @@ class FunctionalTcpServerTest extends TestCase
             $this->markTestSkipped('Skipping on Windows due to default firewall rules');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer('0.0.0.0:0', $loop);
         $peer = new Promise(function ($resolve, $reject) use ($server) {
@@ -141,7 +141,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionWithRemoteIpAfterConnectionIsClosedByPeer()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $peer = new Promise(function ($resolve, $reject) use ($server) {
@@ -164,7 +164,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionWithRemoteNullAddressAfterConnectionIsClosedByServer()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $peer = new Promise(function ($resolve, $reject) use ($server) {
@@ -190,7 +190,7 @@ class FunctionalTcpServerTest extends TestCase
             $this->markTestSkipped('Linux only (OS is ' . PHP_OS . ')');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server->on('connection', $this->expectCallableOnce());
@@ -210,7 +210,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionForNewIpv6Connection()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         try {
             $server = new TcpServer('[::1]:0', $loop);
@@ -234,7 +234,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionWithRemoteIpv6()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         try {
             $server = new TcpServer('[::1]:0', $loop);
@@ -260,7 +260,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionWithLocalIpv6()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         try {
             $server = new TcpServer('[::1]:0', $loop);
@@ -287,7 +287,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testServerPassesContextOptionsToSocket()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop, array(
             'backlog' => 4
@@ -304,7 +304,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testServerPassesDefaultBacklogSizeViaContextOptionsToSocket()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
 
@@ -324,7 +324,7 @@ class FunctionalTcpServerTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM < 3.13');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop, array(
             'backlog' => 4
@@ -348,7 +348,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testFailsToListenOnInvalidUri()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $this->setExpectedException(
             'InvalidArgumentException',
@@ -360,7 +360,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testFailsToListenOnUriWithoutPort()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $this->setExpectedException(
             'InvalidArgumentException',
@@ -372,7 +372,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testFailsToListenOnUriWithWrongScheme()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $this->setExpectedException(
             'InvalidArgumentException',
@@ -384,7 +384,7 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testFailsToListenOnUriWIthHostname()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $this->setExpectedException(
             'InvalidArgumentException',

--- a/tests/FunctionalTcpServerTest.php
+++ b/tests/FunctionalTcpServerTest.php
@@ -3,7 +3,6 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\Loop;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
 use React\Socket\TcpConnector;
@@ -15,8 +14,6 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionForNewConnection()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server->on('connection', $this->expectCallableOnce());
 
@@ -29,7 +26,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $promise->then($this->expectCallableOnce());
 
-        Block\await($peer, $loop, self::TIMEOUT);
+        Block\await($peer, null, self::TIMEOUT);
 
         $server->close();
 
@@ -40,8 +37,6 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsNoConnectionForNewConnectionWhenPaused()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server->on('connection', $this->expectCallableNever());
         $server->pause();
@@ -51,13 +46,11 @@ class FunctionalTcpServerTest extends TestCase
 
         $promise->then($this->expectCallableOnce());
 
-        Block\await($promise, $loop, self::TIMEOUT);
+        Block\await($promise, null, self::TIMEOUT);
     }
 
     public function testConnectionForNewConnectionWhenResumedAfterPause()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server->on('connection', $this->expectCallableOnce());
         $server->pause();
@@ -72,7 +65,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $promise->then($this->expectCallableOnce());
 
-        Block\await($peer, $loop, self::TIMEOUT);
+        Block\await($peer, null, self::TIMEOUT);
 
         $server->close();
         $promise->then(function (ConnectionInterface $connection) {
@@ -82,8 +75,6 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionWithRemoteIp()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $peer = new Promise(function ($resolve, $reject) use ($server) {
             $server->on('connection', function (ConnectionInterface $connection) use ($resolve) {
@@ -96,7 +87,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $promise->then($this->expectCallableOnce());
 
-        $peer = Block\await($peer, $loop, self::TIMEOUT);
+        $peer = Block\await($peer, null, self::TIMEOUT);
 
         $this->assertContainsString('127.0.0.1:', $peer);
 
@@ -108,8 +99,6 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionWithLocalIp()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $peer = new Promise(function ($resolve, $reject) use ($server) {
             $server->on('connection', function (ConnectionInterface $connection) use ($resolve) {
@@ -124,7 +113,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $promise->then($this->expectCallableOnce());
 
-        $local = Block\await($peer, $loop, self::TIMEOUT);
+        $local = Block\await($peer, null, self::TIMEOUT);
 
         $this->assertContainsString('127.0.0.1:', $local);
         $this->assertEquals($server->getAddress(), $local);
@@ -141,8 +130,6 @@ class FunctionalTcpServerTest extends TestCase
             $this->markTestSkipped('Skipping on Windows due to default firewall rules');
         }
 
-        $loop = Loop::get();
-
         $server = new TcpServer('0.0.0.0:0');
         $peer = new Promise(function ($resolve, $reject) use ($server) {
             $server->on('connection', function (ConnectionInterface $connection) use ($resolve) {
@@ -155,7 +142,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $promise->then($this->expectCallableOnce());
 
-        $local = Block\await($peer, $loop, self::TIMEOUT);
+        $local = Block\await($peer, null, self::TIMEOUT);
 
         $this->assertContainsString('127.0.0.1:', $local);
 
@@ -167,8 +154,6 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionWithRemoteIpAfterConnectionIsClosedByPeer()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $peer = new Promise(function ($resolve, $reject) use ($server) {
             $server->on('connection', function (ConnectionInterface $connection) use ($resolve) {
@@ -183,7 +168,7 @@ class FunctionalTcpServerTest extends TestCase
             $connection->end();
         });
 
-        $peer = Block\await($peer, $loop, self::TIMEOUT);
+        $peer = Block\await($peer, null, self::TIMEOUT);
 
         $this->assertContainsString('127.0.0.1:', $peer);
 
@@ -192,8 +177,6 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionWithRemoteNullAddressAfterConnectionIsClosedByServer()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $peer = new Promise(function ($resolve, $reject) use ($server) {
             $server->on('connection', function (ConnectionInterface $connection) use ($resolve) {
@@ -207,7 +190,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $promise->then($this->expectCallableOnce());
 
-        $peer = Block\await($peer, $loop, self::TIMEOUT);
+        $peer = Block\await($peer, null, self::TIMEOUT);
 
         $this->assertNull($peer);
 
@@ -219,8 +202,6 @@ class FunctionalTcpServerTest extends TestCase
         if (PHP_OS !== 'Linux') {
             $this->markTestSkipped('Linux only (OS is ' . PHP_OS . ')');
         }
-
-        $loop = Loop::get();
 
         $server = new TcpServer(0);
         $server->on('connection', $this->expectCallableOnce());
@@ -235,15 +216,13 @@ class FunctionalTcpServerTest extends TestCase
 
         $promise->then(null, $this->expectCallableOnce());
 
-        Block\await($peer, $loop, self::TIMEOUT);
+        Block\await($peer, null, self::TIMEOUT);
 
         $server->close();
     }
 
     public function testEmitsConnectionForNewIpv6Connection()
     {
-        $loop = Loop::get();
-
         try {
             $server = new TcpServer('[::1]:0');
         } catch (\RuntimeException $e) {
@@ -261,7 +240,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $promise->then($this->expectCallableOnce());
 
-        Block\await($peer, $loop, self::TIMEOUT);
+        Block\await($peer, null, self::TIMEOUT);
 
         $server->close();
         $promise->then(function (ConnectionInterface $connection) {
@@ -271,8 +250,6 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionWithRemoteIpv6()
     {
-        $loop = Loop::get();
-
         try {
             $server = new TcpServer('[::1]:0');
         } catch (\RuntimeException $e) {
@@ -290,7 +267,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $promise->then($this->expectCallableOnce());
 
-        $peer = Block\await($peer, $loop, self::TIMEOUT);
+        $peer = Block\await($peer, null, self::TIMEOUT);
 
         $this->assertContainsString('[::1]:', $peer);
 
@@ -302,8 +279,6 @@ class FunctionalTcpServerTest extends TestCase
 
     public function testEmitsConnectionWithLocalIpv6()
     {
-        $loop = Loop::get();
-
         try {
             $server = new TcpServer('[::1]:0');
         } catch (\RuntimeException $e) {
@@ -321,7 +296,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $promise->then($this->expectCallableOnce());
 
-        $local = Block\await($peer, $loop, self::TIMEOUT);
+        $local = Block\await($peer, null, self::TIMEOUT);
 
         $this->assertContainsString('[::1]:', $local);
         $this->assertEquals($server->getAddress(), $local);
@@ -371,8 +346,6 @@ class FunctionalTcpServerTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM < 3.13');
         }
 
-        $loop = Loop::get();
-
         $server = new TcpServer(0, null, array(
             'backlog' => 4
         ));
@@ -388,7 +361,7 @@ class FunctionalTcpServerTest extends TestCase
 
         $promise->then($this->expectCallableOnce());
 
-        $all = Block\await($peer, $loop, self::TIMEOUT);
+        $all = Block\await($peer, null, self::TIMEOUT);
 
         $this->assertEquals(array('socket' => array('backlog' => 4)), $all);
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -19,7 +19,7 @@ class IntegrationTest extends TestCase
     public function gettingStuffFromGoogleShouldWork()
     {
         $loop = Loop::get();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector(array());
 
         $conn = Block\await($connector->connect('google.com:80'), $loop);
 
@@ -41,7 +41,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Loop::get();
-        $secureConnector = new Connector(array(), $loop);
+        $secureConnector = new Connector(array());
 
         $conn = Block\await($secureConnector->connect('tls://google.com:443'), $loop);
 
@@ -62,12 +62,11 @@ class IntegrationTest extends TestCase
         $loop = Loop::get();
 
         $factory = new ResolverFactory();
-        $dns = $factory->create('8.8.8.8', $loop);
+        $dns = $factory->create('8.8.8.8');
 
         $connector = new DnsConnector(
             new SecureConnector(
-                new TcpConnector($loop),
-                $loop
+                new TcpConnector()
             ),
             $dns
         );
@@ -85,7 +84,7 @@ class IntegrationTest extends TestCase
     public function gettingPlaintextStuffFromEncryptedGoogleShouldNotWork()
     {
         $loop = Loop::get();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector(array());
 
         $conn = Block\await($connector->connect('google.com:443'), $loop);
 
@@ -108,7 +107,7 @@ class IntegrationTest extends TestCase
         $loop = Loop::get();
 
         $factory = new ResolverFactory();
-        $dns = $factory->create('255.255.255.255', $loop);
+        $dns = $factory->create('255.255.255.255');
 
         $connector = new Connector(array(
             'dns' => $dns
@@ -124,8 +123,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
         }
 
-        $loop = Loop::get();
-        $connector = new Connector(array('timeout' => false), $loop);
+        $connector = new Connector(array('timeout' => false));
 
         gc_collect_cycles();
         gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
@@ -143,8 +141,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
         }
 
-        $loop = Loop::get();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector(array());
 
         gc_collect_cycles();
         $promise = $connector->connect('8.8.8.8:80');
@@ -161,7 +158,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Loop::get();
-        $connector = new Connector(array('timeout' => false), $loop);
+        $connector = new Connector(array('timeout' => false));
 
         gc_collect_cycles();
 
@@ -197,7 +194,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Loop::get();
-        $connector = new Connector(array('timeout' => 0.001), $loop);
+        $connector = new Connector(array('timeout' => 0.001));
 
         gc_collect_cycles();
 
@@ -230,7 +227,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Loop::get();
-        $connector = new Connector(array('timeout' => 0.000001), $loop);
+        $connector = new Connector(array('timeout' => 0.000001));
 
         gc_collect_cycles();
 
@@ -263,7 +260,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Loop::get();
-        $connector = new Connector(array('timeout' => false), $loop);
+        $connector = new Connector(array('timeout' => false));
 
         gc_collect_cycles();
 
@@ -306,7 +303,7 @@ class IntegrationTest extends TestCase
             'tls' => array(
                 'verify_peer' => true
             )
-        ), $loop);
+        ));
 
         gc_collect_cycles();
 
@@ -342,7 +339,7 @@ class IntegrationTest extends TestCase
         }
 
         $loop = Loop::get();
-        $connector = new Connector(array('timeout' => false), $loop);
+        $connector = new Connector(array('timeout' => false));
 
         gc_collect_cycles();
         $promise = $connector->connect('google.com:80')->then(
@@ -362,7 +359,7 @@ class IntegrationTest extends TestCase
 
         $connector = new Connector(array(
             'timeout' => 0.001
-        ), $loop);
+        ));
 
         $this->setExpectedException('RuntimeException');
         Block\await($connector->connect('google.com:80'), $loop, self::TIMEOUT);
@@ -380,7 +377,7 @@ class IntegrationTest extends TestCase
             'tls' => array(
                 'verify_peer' => true
             )
-        ), $loop);
+        ));
 
         $this->setExpectedException('RuntimeException');
         Block\await($connector->connect('tls://self-signed.badssl.com:443'), $loop, self::TIMEOUT);
@@ -398,7 +395,7 @@ class IntegrationTest extends TestCase
             'tls' => array(
                 'verify_peer' => false
             )
-        ), $loop);
+        ));
 
         $conn = Block\await($connector->connect('tls://self-signed.badssl.com:443'), $loop, self::TIMEOUT);
         $conn->close();

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -4,7 +4,7 @@ namespace React\Tests\Socket;
 
 use Clue\React\Block;
 use React\Dns\Resolver\Factory as ResolverFactory;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Socket\Connector;
 use React\Socket\DnsConnector;
 use React\Socket\SecureConnector;
@@ -18,7 +18,7 @@ class IntegrationTest extends TestCase
     /** @test */
     public function gettingStuffFromGoogleShouldWork()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
         $connector = new Connector(array(), $loop);
 
         $conn = Block\await($connector->connect('google.com:80'), $loop);
@@ -40,7 +40,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
         $secureConnector = new Connector(array(), $loop);
 
         $conn = Block\await($secureConnector->connect('tls://google.com:443'), $loop);
@@ -59,7 +59,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $factory = new ResolverFactory();
         $dns = $factory->create('8.8.8.8', $loop);
@@ -84,7 +84,7 @@ class IntegrationTest extends TestCase
     /** @test */
     public function gettingPlaintextStuffFromEncryptedGoogleShouldNotWork()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
         $connector = new Connector(array(), $loop);
 
         $conn = Block\await($connector->connect('google.com:443'), $loop);
@@ -105,7 +105,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Skipped on macOS due to a bug in reactphp/dns (solved in reactphp/dns#171)');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $factory = new ResolverFactory();
         $dns = $factory->create('255.255.255.255', $loop);
@@ -124,7 +124,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
         $connector = new Connector(array('timeout' => false), $loop);
 
         gc_collect_cycles();
@@ -143,7 +143,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
         $connector = new Connector(array(), $loop);
 
         gc_collect_cycles();
@@ -160,7 +160,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
         $connector = new Connector(array('timeout' => false), $loop);
 
         gc_collect_cycles();
@@ -196,7 +196,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
         $connector = new Connector(array('timeout' => 0.001), $loop);
 
         gc_collect_cycles();
@@ -229,7 +229,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
         $connector = new Connector(array('timeout' => 0.000001), $loop);
 
         gc_collect_cycles();
@@ -262,7 +262,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
         $connector = new Connector(array('timeout' => false), $loop);
 
         gc_collect_cycles();
@@ -301,7 +301,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
         $connector = new Connector(array(
             'tls' => array(
                 'verify_peer' => true
@@ -341,7 +341,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
         $connector = new Connector(array('timeout' => false), $loop);
 
         gc_collect_cycles();
@@ -358,7 +358,7 @@ class IntegrationTest extends TestCase
 
     public function testConnectingFailsIfTimeoutIsTooSmall()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $connector = new Connector(array(
             'timeout' => 0.001
@@ -374,7 +374,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $connector = new Connector(array(
             'tls' => array(
@@ -392,7 +392,7 @@ class IntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $connector = new Connector(array(
             'tls' => array(

--- a/tests/LimitingServerTest.php
+++ b/tests/LimitingServerTest.php
@@ -3,7 +3,6 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\Loop;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
 use React\Socket\LimitingServer;
@@ -143,8 +142,6 @@ class LimitingServerTest extends TestCase
 
     public function testSocketDisconnectionWillRemoveFromList()
     {
-        $loop = Loop::get();
-
         $tcp = new TcpServer(0);
 
         $socket = stream_socket_client($tcp->getAddress());
@@ -160,7 +157,7 @@ class LimitingServerTest extends TestCase
             });
         });
 
-        Block\await($peer, $loop, self::TIMEOUT);
+        Block\await($peer, null, self::TIMEOUT);
 
         $this->assertEquals(array(), $server->getConnections());
 
@@ -169,8 +166,6 @@ class LimitingServerTest extends TestCase
 
     public function testPausingServerWillEmitOnlyOneButAcceptTwoConnectionsDueToOperatingSystem()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new LimitingServer($server, 1, true);
         $server->on('connection', $this->expectCallableOnce());
@@ -183,7 +178,7 @@ class LimitingServerTest extends TestCase
         $first = stream_socket_client($server->getAddress());
         $second = stream_socket_client($server->getAddress());
 
-        Block\await($peer, $loop, self::TIMEOUT);
+        Block\await($peer, null, self::TIMEOUT);
 
         fclose($first);
         fclose($second);
@@ -193,8 +188,6 @@ class LimitingServerTest extends TestCase
 
     public function testPausingServerWillEmitTwoConnectionsFromBacklog()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(0);
         $server = new LimitingServer($server, 1, true);
         $server->on('error', $this->expectCallableNever());
@@ -215,7 +208,7 @@ class LimitingServerTest extends TestCase
         $second = stream_socket_client($server->getAddress());
         fclose($second);
 
-        Block\await($peer, $loop, self::TIMEOUT);
+        Block\await($peer, null, self::TIMEOUT);
 
         $server->close();
     }

--- a/tests/LimitingServerTest.php
+++ b/tests/LimitingServerTest.php
@@ -145,7 +145,7 @@ class LimitingServerTest extends TestCase
     {
         $loop = Loop::get();
 
-        $tcp = new TcpServer(0, $loop);
+        $tcp = new TcpServer(0);
 
         $socket = stream_socket_client($tcp->getAddress());
         fclose($socket);
@@ -163,13 +163,15 @@ class LimitingServerTest extends TestCase
         Block\await($peer, $loop, self::TIMEOUT);
 
         $this->assertEquals(array(), $server->getConnections());
+
+        $server->close();
     }
 
     public function testPausingServerWillEmitOnlyOneButAcceptTwoConnectionsDueToOperatingSystem()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
+        $server = new TcpServer(0);
         $server = new LimitingServer($server, 1, true);
         $server->on('connection', $this->expectCallableOnce());
         $server->on('error', $this->expectCallableNever());
@@ -185,13 +187,15 @@ class LimitingServerTest extends TestCase
 
         fclose($first);
         fclose($second);
+
+        $server->close();
     }
 
     public function testPausingServerWillEmitTwoConnectionsFromBacklog()
     {
         $loop = Loop::get();
 
-        $server = new TcpServer(0, $loop);
+        $server = new TcpServer(0);
         $server = new LimitingServer($server, 1, true);
         $server->on('error', $this->expectCallableNever());
 
@@ -212,5 +216,7 @@ class LimitingServerTest extends TestCase
         fclose($second);
 
         Block\await($peer, $loop, self::TIMEOUT);
+
+        $server->close();
     }
 }

--- a/tests/LimitingServerTest.php
+++ b/tests/LimitingServerTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
 use React\Socket\LimitingServer;
@@ -143,7 +143,7 @@ class LimitingServerTest extends TestCase
 
     public function testSocketDisconnectionWillRemoveFromList()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $tcp = new TcpServer(0, $loop);
 
@@ -167,7 +167,7 @@ class LimitingServerTest extends TestCase
 
     public function testPausingServerWillEmitOnlyOneButAcceptTwoConnectionsDueToOperatingSystem()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new LimitingServer($server, 1, true);
@@ -189,7 +189,7 @@ class LimitingServerTest extends TestCase
 
     public function testPausingServerWillEmitTwoConnectionsFromBacklog()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(0, $loop);
         $server = new LimitingServer($server, 1, true);

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -5,7 +5,6 @@ namespace React\Tests\Socket;
 use React\Promise;
 use React\Promise\Deferred;
 use React\Socket\SecureConnector;
-use React\EventLoop\Loop;
 
 class SecureConnectorTest extends TestCase
 {

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -5,6 +5,7 @@ namespace React\Tests\Socket;
 use React\Promise;
 use React\Promise\Deferred;
 use React\Socket\SecureConnector;
+use React\EventLoop\Loop;
 
 class SecureConnectorTest extends TestCase
 {

--- a/tests/SecureIntegrationTest.php
+++ b/tests/SecureIntegrationTest.php
@@ -2,7 +2,6 @@
 
 namespace React\Tests\Socket;
 
-use React\EventLoop\Loop;
 use React\Socket\TcpServer;
 use React\Socket\SecureServer;
 use React\Socket\TcpConnector;
@@ -17,7 +16,6 @@ class SecureIntegrationTest extends TestCase
 {
     const TIMEOUT = 2;
 
-    private $loop;
     private $server;
     private $connector;
     private $address;
@@ -31,7 +29,6 @@ class SecureIntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
-        $this->loop = Loop::get();
         $this->server = new TcpServer(0);
         $this->server = new SecureServer($this->server, null, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -53,7 +50,7 @@ class SecureIntegrationTest extends TestCase
 
     public function testConnectToServer()
     {
-        $client = Block\await($this->connector->connect($this->address), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect($this->address), null, self::TIMEOUT);
         /* @var $client ConnectionInterface */
 
         $client->close();
@@ -68,7 +65,7 @@ class SecureIntegrationTest extends TestCase
 
         $promiseClient = $this->connector->connect($this->address);
 
-        list($_, $client) = Block\awaitAll(array($promiseServer, $promiseClient), $this->loop, self::TIMEOUT);
+        list($_, $client) = Block\awaitAll(array($promiseServer, $promiseClient), null, self::TIMEOUT);
         /* @var $client ConnectionInterface */
 
         $client->close();
@@ -84,13 +81,13 @@ class SecureIntegrationTest extends TestCase
             });
         });
 
-        $client = Block\await($this->connector->connect($this->address), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect($this->address), null, self::TIMEOUT);
         /* @var $client ConnectionInterface */
 
         $client->write('hello');
 
         // await server to report one "data" event
-        $data = Block\await($received->promise(), $this->loop, self::TIMEOUT);
+        $data = Block\await($received->promise(), null, self::TIMEOUT);
 
         $client->close();
 
@@ -125,14 +122,14 @@ class SecureIntegrationTest extends TestCase
             });
         });
 
-        $client = Block\await($this->connector->connect($this->address), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect($this->address), null, self::TIMEOUT);
         /* @var $client ConnectionInterface */
 
         $data = str_repeat('a', 200000);
         $client->end($data);
 
         // await server to report connection "close" event
-        $received = Block\await($disconnected->promise(), $this->loop, self::TIMEOUT);
+        $received = Block\await($disconnected->promise(), null, self::TIMEOUT);
 
         $this->assertEquals(strlen($data), strlen($received));
         $this->assertEquals($data, $received);
@@ -160,7 +157,7 @@ class SecureIntegrationTest extends TestCase
             $connection->write($data);
         });
 
-        $received = Block\await($promise, $this->loop, self::TIMEOUT);
+        $received = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertEquals(strlen($data), strlen($received));
         $this->assertEquals($data, $received);
@@ -176,12 +173,12 @@ class SecureIntegrationTest extends TestCase
             $peer->write('hello');
         });
 
-        $client = Block\await($this->connector->connect($this->address), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect($this->address), null, self::TIMEOUT);
         /* @var $client ConnectionInterface */
 
         // await client to report one "data" event
         $receive = $this->createPromiseForEvent($client, 'data', $this->expectCallableOnceWith('hello'));
-        Block\await($receive, $this->loop, self::TIMEOUT);
+        Block\await($receive, null, self::TIMEOUT);
 
         $client->close();
     }
@@ -193,11 +190,11 @@ class SecureIntegrationTest extends TestCase
             $peer->end($data);
         });
 
-        $client = Block\await($this->connector->connect($this->address), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect($this->address), null, self::TIMEOUT);
         /* @var $client ConnectionInterface */
 
         // await data from client until it closes
-        $received = $this->buffer($client, $this->loop, self::TIMEOUT);
+        $received = $this->buffer($client, self::TIMEOUT);
 
         $this->assertEquals($data, $received);
     }
@@ -224,7 +221,7 @@ class SecureIntegrationTest extends TestCase
             }, $reject);
         });
 
-        $received = Block\await($promise, $this->loop, self::TIMEOUT);
+        $received = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertEquals(strlen($data), $received);
 

--- a/tests/SecureIntegrationTest.php
+++ b/tests/SecureIntegrationTest.php
@@ -2,7 +2,7 @@
 
 namespace React\Tests\Socket;
 
-use React\EventLoop\Factory as LoopFactory;
+use React\EventLoop\Loop;
 use React\Socket\TcpServer;
 use React\Socket\SecureServer;
 use React\Socket\TcpConnector;
@@ -31,7 +31,7 @@ class SecureIntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
-        $this->loop = LoopFactory::create();
+        $this->loop = Loop::get();
         $this->server = new TcpServer(0, $this->loop);
         $this->server = new SecureServer($this->server, $this->loop, array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
 use React\Socket\Server;
@@ -31,7 +31,7 @@ class ServerTest extends TestCase
 
     public function testCreateServerWithZeroPortAssignsRandomPort()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new Server(0, $loop);
         $this->assertNotEquals(0, $server->getAddress());
@@ -48,7 +48,7 @@ class ServerTest extends TestCase
 
     public function testConstructorCreatesExpectedTcpServer()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new Server(0, $loop);
 
@@ -71,7 +71,7 @@ class ServerTest extends TestCase
             $this->markTestSkipped('Unix domain sockets (UDS) not supported on your platform (Windows?)');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new Server($this->getRandomSocketUri(), $loop);
 
@@ -91,7 +91,7 @@ class ServerTest extends TestCase
             $this->markTestSkipped('Unix domain sockets (UDS) not supported on your platform (Windows?)');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         try {
             $server = new Server('unix://' . __FILE__, $loop);
@@ -109,7 +109,7 @@ class ServerTest extends TestCase
 
     public function testEmitsErrorWhenUnderlyingTcpServerEmitsError()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new Server(0, $loop);
 
@@ -126,7 +126,7 @@ class ServerTest extends TestCase
 
     public function testEmitsConnectionForNewConnection()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new Server(0, $loop);
         $server->on('connection', $this->expectCallableOnce());
@@ -142,7 +142,7 @@ class ServerTest extends TestCase
 
     public function testDoesNotEmitConnectionForNewConnectionToPausedServer()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new Server(0, $loop);
         $server->pause();
@@ -155,7 +155,7 @@ class ServerTest extends TestCase
 
     public function testDoesEmitConnectionForNewConnectionToResumedServer()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new Server(0, $loop);
         $server->pause();
@@ -174,7 +174,7 @@ class ServerTest extends TestCase
 
     public function testDoesNotAllowConnectionToClosedServer()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new Server(0, $loop);
         $server->on('connection', $this->expectCallableNever());
@@ -193,7 +193,7 @@ class ServerTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM < 3.13');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new Server(0, $loop, array(
             'backlog' => 4
@@ -219,7 +219,7 @@ class ServerTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new Server('tls://127.0.0.1:0', $loop, array(
             'tls' => array(

--- a/tests/SocketServerTest.php
+++ b/tests/SocketServerTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
 use React\Socket\SocketServer;
@@ -32,7 +32,7 @@ class SocketServerTest extends TestCase
 
     public function testCreateServerWithZeroPortAssignsRandomPort()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $socket = new SocketServer('127.0.0.1:0', array(), $loop);
         $this->assertNotEquals(0, $socket->getAddress());
@@ -71,7 +71,7 @@ class SocketServerTest extends TestCase
 
     public function testConstructorCreatesExpectedTcpServer()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $socket = new SocketServer('127.0.0.1:0', array(), $loop);
 
@@ -94,7 +94,7 @@ class SocketServerTest extends TestCase
             $this->markTestSkipped('Unix domain sockets (UDS) not supported on your platform (Windows?)');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $socket = new SocketServer($this->getRandomSocketUri(), array(), $loop);
 
@@ -114,7 +114,7 @@ class SocketServerTest extends TestCase
             $this->markTestSkipped('Unix domain sockets (UDS) not supported on your platform (Windows?)');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         try {
             new SocketServer('unix://' . __FILE__, array(), $loop);
@@ -147,7 +147,7 @@ class SocketServerTest extends TestCase
 
     public function testEmitsErrorWhenUnderlyingTcpServerEmitsError()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $socket = new SocketServer('127.0.0.1:0', array(), $loop);
 
@@ -164,7 +164,7 @@ class SocketServerTest extends TestCase
 
     public function testEmitsConnectionForNewConnection()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $socket = new SocketServer('127.0.0.1:0', array(), $loop);
         $socket->on('connection', $this->expectCallableOnce());
@@ -180,7 +180,7 @@ class SocketServerTest extends TestCase
 
     public function testDoesNotEmitConnectionForNewConnectionToPausedServer()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $socket = new SocketServer('127.0.0.1:0', array(), $loop);
         $socket->pause();
@@ -193,7 +193,7 @@ class SocketServerTest extends TestCase
 
     public function testDoesEmitConnectionForNewConnectionToResumedServer()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $socket = new SocketServer('127.0.0.1:0', array(), $loop);
         $socket->pause();
@@ -212,7 +212,7 @@ class SocketServerTest extends TestCase
 
     public function testDoesNotAllowConnectionToClosedServer()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $socket = new SocketServer('127.0.0.1:0', array(), $loop);
         $socket->on('connection', $this->expectCallableNever());
@@ -231,7 +231,7 @@ class SocketServerTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM < 3.13');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $socket = new SocketServer('127.0.0.1:0', array(
             'tcp' => array(
@@ -259,7 +259,7 @@ class SocketServerTest extends TestCase
             $this->markTestSkipped('Not supported on legacy HHVM');
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $socket = new SocketServer('tls://127.0.0.1:0', array(
             'tls' => array(

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -27,8 +27,6 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToEmptyPortShouldFail()
     {
-        $loop = Loop::get();
-
         $connector = new TcpConnector();
         $promise = $connector->connect('127.0.0.1:9999');
 
@@ -37,7 +35,7 @@ class TcpConnectorTest extends TestCase
             'Connection to tcp://127.0.0.1:9999 failed: Connection refused' . (function_exists('socket_import_stream') ? ' (ECONNREFUSED)' : ''),
             defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         );
-        Block\await($promise, $loop, self::TIMEOUT);
+        Block\await($promise, null, self::TIMEOUT);
     }
 
     /** @test */
@@ -61,13 +59,11 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceed()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(9999);
 
         $connector = new TcpConnector();
 
-        $connection = Block\await($connector->connect('127.0.0.1:9999'), $loop, self::TIMEOUT);
+        $connection = Block\await($connector->connect('127.0.0.1:9999'), null, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Socket\ConnectionInterface', $connection);
 
@@ -78,8 +74,6 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldFailIfFileDescriptorsAreExceeded()
     {
-        $loop = Loop::get();
-
         $connector = new TcpConnector();
 
         /** @var string[] $_ */
@@ -121,7 +115,7 @@ class TcpConnectorTest extends TestCase
         }
 
         $this->setExpectedException('RuntimeException');
-        Block\await($connector->connect('127.0.0.1:9999'), $loop, self::TIMEOUT);
+        Block\await($connector->connect('127.0.0.1:9999'), null, self::TIMEOUT);
     }
 
     /** @test */
@@ -144,7 +138,6 @@ class TcpConnectorTest extends TestCase
             $this->markTestSkipped('Expected error ' . $enetunreach . ' but got ' . $errno . ' (' . $errstr . ') for ' . $address);
         }
 
-        $loop = Loop::get();
         $connector = new TcpConnector();
 
         $promise = $connector->connect($address);
@@ -156,7 +149,7 @@ class TcpConnectorTest extends TestCase
         );
 
         try {
-            Block\await($promise, $loop, self::TIMEOUT);
+            Block\await($promise, null, self::TIMEOUT);
         } catch (\Exception $e) {
             fclose($client);
 
@@ -167,13 +160,11 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceedWithRemoteAdressSameAsTarget()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(9999);
 
         $connector = new TcpConnector();
 
-        $connection = Block\await($connector->connect('127.0.0.1:9999'), $loop, self::TIMEOUT);
+        $connection = Block\await($connector->connect('127.0.0.1:9999'), null, self::TIMEOUT);
         /* @var $connection ConnectionInterface */
 
         $this->assertEquals('tcp://127.0.0.1:9999', $connection->getRemoteAddress());
@@ -185,13 +176,11 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceedWithLocalAdressOnLocalhost()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(9999);
 
         $connector = new TcpConnector();
 
-        $connection = Block\await($connector->connect('127.0.0.1:9999'), $loop, self::TIMEOUT);
+        $connection = Block\await($connector->connect('127.0.0.1:9999'), null, self::TIMEOUT);
         /* @var $connection ConnectionInterface */
 
         $this->assertContainsString('tcp://127.0.0.1:', $connection->getLocalAddress());
@@ -204,13 +193,11 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceedWithNullAddressesAfterConnectionClosed()
     {
-        $loop = Loop::get();
-
         $server = new TcpServer(9999);
 
         $connector = new TcpConnector();
 
-        $connection = Block\await($connector->connect('127.0.0.1:9999'), $loop, self::TIMEOUT);
+        $connection = Block\await($connector->connect('127.0.0.1:9999'), null, self::TIMEOUT);
         /* @var $connection ConnectionInterface */
 
         $server->close();
@@ -256,8 +243,6 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToIp6TcpServerShouldSucceed()
     {
-        $loop = Loop::get();
-
         try {
             $server = new TcpServer('[::1]:9999');
         } catch (\Exception $e) {
@@ -266,7 +251,7 @@ class TcpConnectorTest extends TestCase
 
         $connector = new TcpConnector();
 
-        $connection = Block\await($connector->connect('[::1]:9999'), $loop, self::TIMEOUT);
+        $connection = Block\await($connector->connect('[::1]:9999'), null, self::TIMEOUT);
         /* @var $connection ConnectionInterface */
 
         $this->assertEquals('tcp://[::1]:9999', $connection->getRemoteAddress());
@@ -351,7 +336,6 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function cancellingConnectionShouldRejectPromise()
     {
-        $loop = Loop::get();
         $connector = new TcpConnector();
 
         $server = new TcpServer(0);
@@ -366,7 +350,7 @@ class TcpConnectorTest extends TestCase
         );
 
         try {
-            Block\await($promise, $loop);
+            Block\await($promise);
         } catch (\Exception $e) {
             $server->close();
             throw $e;

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Socket\ConnectionInterface;
 use React\Socket\TcpConnector;
 use React\Socket\TcpServer;
@@ -27,7 +27,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToEmptyPortShouldFail()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $connector = new TcpConnector($loop);
         $promise = $connector->connect('127.0.0.1:9999');
@@ -61,7 +61,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceed()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(9999, $loop);
 
@@ -78,7 +78,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldFailIfFileDescriptorsAreExceeded()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $connector = new TcpConnector($loop);
 
@@ -144,7 +144,7 @@ class TcpConnectorTest extends TestCase
             $this->markTestSkipped('Expected error ' . $enetunreach . ' but got ' . $errno . ' (' . $errstr . ') for ' . $address);
         }
 
-        $loop = Factory::create();
+        $loop = Loop::get();
         $connector = new TcpConnector($loop);
 
         $promise = $connector->connect($address);
@@ -160,7 +160,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceedWithRemoteAdressSameAsTarget()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(9999, $loop);
 
@@ -178,7 +178,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceedWithLocalAdressOnLocalhost()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(9999, $loop);
 
@@ -197,7 +197,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerShouldSucceedWithNullAddressesAfterConnectionClosed()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $server = new TcpServer(9999, $loop);
 
@@ -216,7 +216,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToTcpServerWillCloseWhenOtherSideCloses()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         // immediately close connection and server once connection is in
         $server = new TcpServer(0, $loop);
@@ -238,7 +238,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToEmptyIp6PortShouldFail()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $connector = new TcpConnector($loop);
         $connector
@@ -251,7 +251,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function connectionToIp6TcpServerShouldSucceed()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         try {
             $server = new TcpServer('[::1]:9999', $loop);
@@ -346,7 +346,7 @@ class TcpConnectorTest extends TestCase
     /** @test */
     public function cancellingConnectionShouldRejectPromise()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
         $connector = new TcpConnector($loop);
 
         $server = new TcpServer(0, $loop);

--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -12,14 +12,8 @@ class TcpServerTest extends TestCase
 {
     const TIMEOUT = 5.0;
 
-    private $loop;
     private $server;
     private $port;
-
-    private function createLoop()
-    {
-        return Loop::get();
-    }
 
     /**
      * @before
@@ -28,7 +22,6 @@ class TcpServerTest extends TestCase
      */
     public function setUpServer()
     {
-        $this->loop = $this->createLoop();
         $this->server = new TcpServer(0);
 
         $this->port = parse_url($this->server->getAddress(), PHP_URL_PORT);
@@ -60,7 +53,7 @@ class TcpServerTest extends TestCase
             $server->on('connection', $resolve);
         });
 
-        $connection = Block\await($promise, $this->loop, self::TIMEOUT);
+        $connection = Block\await($promise, null, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Socket\ConnectionInterface', $connection);
     }
@@ -373,6 +366,6 @@ class TcpServerTest extends TestCase
             $this->markTestSkipped('Not supported on Windows');
         }
 
-        Block\sleep(0, $this->loop);
+        Block\sleep(0);
     }
 }

--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Socket\TcpServer;
 use React\Stream\DuplexResourceStream;
 use React\Promise\Promise;
@@ -18,7 +18,7 @@ class TcpServerTest extends TestCase
 
     private function createLoop()
     {
-        return Factory::create();
+        return Loop::get();
     }
 
     /**

--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -29,7 +29,7 @@ class TcpServerTest extends TestCase
     public function setUpServer()
     {
         $this->loop = $this->createLoop();
-        $this->server = new TcpServer(0, $this->loop);
+        $this->server = new TcpServer(0);
 
         $this->port = parse_url($this->server->getAddress(), PHP_URL_PORT);
     }
@@ -43,6 +43,8 @@ class TcpServerTest extends TestCase
         $loop = $ref->getValue($server);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+
+        $server->close();
     }
 
     /**
@@ -129,7 +131,7 @@ class TcpServerTest extends TestCase
         $this->server->close();
         $this->server = null;
 
-        $this->loop->run();
+        Loop::run();
 
         // if we reach this, then everything is good
         $this->assertNull(null);
@@ -165,7 +167,7 @@ class TcpServerTest extends TestCase
             $server->close();
         });
 
-        $this->loop->run();
+        Loop::run();
 
         // if we reach this, then everything is good
         $this->assertNull(null);
@@ -174,7 +176,7 @@ class TcpServerTest extends TestCase
     public function testDataWillBeEmittedInMultipleChunksWhenClientSendsExcessiveAmounts()
     {
         $client = stream_socket_client('tcp://localhost:' . $this->port);
-        $stream = new DuplexResourceStream($client, $this->loop);
+        $stream = new DuplexResourceStream($client);
 
         $bytes = 1024 * 1024;
         $stream->end(str_repeat('*', $bytes));
@@ -199,7 +201,7 @@ class TcpServerTest extends TestCase
             $server->close();
         });
 
-        $this->loop->run();
+        Loop::run();
 
         $this->assertEquals($bytes, $received);
     }
@@ -342,7 +344,7 @@ class TcpServerTest extends TestCase
             'Failed to listen on "tcp://127.0.0.1:' . $this->port . '": ' . (function_exists('socket_strerror') ? socket_strerror(SOCKET_EADDRINUSE) . ' (EADDRINUSE)' : 'Address already in use'),
             defined('SOCKET_EADDRINUSE') ? SOCKET_EADDRINUSE : 0
         );
-        new TcpServer($this->port, $this->loop);
+        new TcpServer($this->port);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,6 @@
 namespace React\Tests\Socket;
 
 use React\Stream\ReadableStreamInterface;
-use React\EventLoop\LoopInterface;
 use Clue\React\Block;
 use React\Promise\Promise;
 use PHPUnit\Framework\TestCase as BaseTestCase;
@@ -71,7 +70,7 @@ class TestCase extends BaseTestCase
         return $this->getMockBuilder('React\Tests\Socket\Stub\CallableStub')->getMock();
     }
 
-    protected function buffer(ReadableStreamInterface $stream, LoopInterface $loop, $timeout)
+    protected function buffer(ReadableStreamInterface $stream, $timeout)
     {
         if (!$stream->isReadable()) {
             return '';
@@ -94,7 +93,7 @@ class TestCase extends BaseTestCase
                 $stream->close();
                 throw new \RuntimeException();
             }
-        ), $loop, $timeout);
+        ), null, $timeout);
     }
 
     public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)

--- a/tests/TimeoutConnectorTest.php
+++ b/tests/TimeoutConnectorTest.php
@@ -30,8 +30,6 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
-        $loop = Loop::get();
-
         $timeout = new TimeoutConnector($connector, 0.01);
 
         $this->setExpectedException(
@@ -39,7 +37,7 @@ class TimeoutConnectorTest extends TestCase
             'Connection to google.com:80 timed out after 0.01 seconds (ETIMEDOUT)',
             \defined('SOCKET_ETIMEDOUT') ? \SOCKET_ETIMEDOUT : 110
         );
-        Block\await($timeout->connect('google.com:80'), $loop);
+        Block\await($timeout->connect('google.com:80'));
     }
 
     public function testRejectsWithOriginalReasonWhenConnectorRejects()
@@ -49,8 +47,6 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
-        $loop = Loop::get();
-
         $timeout = new TimeoutConnector($connector, 5.0);
 
         $this->setExpectedException(
@@ -58,7 +54,7 @@ class TimeoutConnectorTest extends TestCase
             'Failed',
             42
         );
-        Block\await($timeout->connect('google.com:80'), $loop);
+        Block\await($timeout->connect('google.com:80'));
     }
 
     public function testResolvesWhenConnectorResolves()

--- a/tests/TimeoutConnectorTest.php
+++ b/tests/TimeoutConnectorTest.php
@@ -32,7 +32,7 @@ class TimeoutConnectorTest extends TestCase
 
         $loop = Loop::get();
 
-        $timeout = new TimeoutConnector($connector, 0.01, $loop);
+        $timeout = new TimeoutConnector($connector, 0.01);
 
         $this->setExpectedException(
             'RuntimeException',
@@ -51,7 +51,7 @@ class TimeoutConnectorTest extends TestCase
 
         $loop = Loop::get();
 
-        $timeout = new TimeoutConnector($connector, 5.0, $loop);
+        $timeout = new TimeoutConnector($connector, 5.0);
 
         $this->setExpectedException(
             'RuntimeException',
@@ -68,16 +68,14 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
-        $loop = Loop::get();
-
-        $timeout = new TimeoutConnector($connector, 5.0, $loop);
+        $timeout = new TimeoutConnector($connector, 5.0);
 
         $timeout->connect('google.com:80')->then(
             $this->expectCallableOnce(),
             $this->expectCallableNever()
         );
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testRejectsAndCancelsPendingPromiseOnTimeout()
@@ -87,16 +85,14 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
-        $loop = Loop::get();
-
-        $timeout = new TimeoutConnector($connector, 0.01, $loop);
+        $timeout = new TimeoutConnector($connector, 0.01);
 
         $timeout->connect('google.com:80')->then(
             $this->expectCallableNever(),
             $this->expectCallableOnce()
         );
 
-        $loop->run();
+        Loop::run();
     }
 
     public function testCancelsPendingPromiseOnCancel()
@@ -106,9 +102,7 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
-        $loop = Loop::get();
-
-        $timeout = new TimeoutConnector($connector, 0.01, $loop);
+        $timeout = new TimeoutConnector($connector, 0.01);
 
         $out = $timeout->connect('google.com:80');
         $out->cancel();
@@ -128,8 +122,7 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('example.com:80')->willReturn($connection->promise());
 
-        $loop = Loop::get();
-        $timeout = new TimeoutConnector($connector, 0.01, $loop);
+        $timeout = new TimeoutConnector($connector, 0.01);
 
         $promise = $timeout->connect('example.com:80');
         $connection->reject(new \RuntimeException('Connection failed'));
@@ -152,12 +145,11 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('example.com:80')->willReturn($connection->promise());
 
-        $loop = Loop::get();
-        $timeout = new TimeoutConnector($connector, 0, $loop);
+        $timeout = new TimeoutConnector($connector, 0);
 
         $promise = $timeout->connect('example.com:80');
 
-        $loop->run();
+        Loop::run();
         unset($promise, $connection);
 
         $this->assertEquals(0, gc_collect_cycles());

--- a/tests/TimeoutConnectorTest.php
+++ b/tests/TimeoutConnectorTest.php
@@ -5,7 +5,7 @@ namespace React\Tests\Socket;
 use Clue\React\Block;
 use React\Socket\TimeoutConnector;
 use React\Promise;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Promise\Deferred;
 
 class TimeoutConnectorTest extends TestCase
@@ -30,7 +30,7 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
@@ -49,7 +49,7 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $timeout = new TimeoutConnector($connector, 5.0, $loop);
 
@@ -68,7 +68,7 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $timeout = new TimeoutConnector($connector, 5.0, $loop);
 
@@ -87,7 +87,7 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
@@ -106,7 +106,7 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
@@ -128,7 +128,7 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('example.com:80')->willReturn($connection->promise());
 
-        $loop = Factory::create();
+        $loop = Loop::get();
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
         $promise = $timeout->connect('example.com:80');
@@ -152,7 +152,7 @@ class TimeoutConnectorTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('example.com:80')->willReturn($connection->promise());
 
-        $loop = Factory::create();
+        $loop = Loop::get();
         $timeout = new TimeoutConnector($connector, 0, $loop);
 
         $promise = $timeout->connect('example.com:80');

--- a/tests/TimerSpeedUpEventLoop.php
+++ b/tests/TimerSpeedUpEventLoop.php
@@ -4,7 +4,6 @@ namespace React\Tests\Socket;
 
 use React\Dns\Model\Message;
 use React\Dns\Resolver\ResolverInterface;
-use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\TimerInterface;
 use React\Promise;
@@ -17,12 +16,12 @@ final class TimerSpeedUpEventLoop implements LoopInterface
 {
     /** @var LoopInterface */
     private $loop;
-    
+
     public function __construct(LoopInterface $loop)
     {
         $this->loop = $loop;
     }
-    
+
     public function addReadStream($stream, $listener)
     {
         return $this->loop->addReadStream($stream, $listener);

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -26,7 +26,7 @@ class UnixServerTest extends TestCase
 
         $this->loop = Loop::get();
         $this->uds = $this->getRandomSocketUri();
-        $this->server = new UnixServer($this->uds, $this->loop);
+        $this->server = new UnixServer($this->uds);
     }
 
     public function testConstructWithoutLoopAssignsLoopAutomatically()
@@ -38,6 +38,8 @@ class UnixServerTest extends TestCase
         $loop = $ref->getValue($server);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+
+        $server->close();
     }
 
     /**
@@ -115,7 +117,7 @@ class UnixServerTest extends TestCase
         $this->server->close();
         $this->server = null;
 
-        $this->loop->run();
+        Loop::run();
 
         // if we reach this, then everything is good
         $this->assertNull(null);
@@ -150,7 +152,7 @@ class UnixServerTest extends TestCase
             $server->close();
         });
 
-        $this->loop->run();
+        Loop::run();
 
         // if we reach this, then everything is good
         $this->assertNull(null);
@@ -159,7 +161,7 @@ class UnixServerTest extends TestCase
     public function testDataWillBeEmittedInMultipleChunksWhenClientSendsExcessiveAmounts()
     {
         $client = stream_socket_client($this->uds);
-        $stream = new DuplexResourceStream($client, $this->loop);
+        $stream = new DuplexResourceStream($client);
 
         $bytes = 1024 * 1024;
         $stream->end(str_repeat('*', $bytes));
@@ -184,7 +186,7 @@ class UnixServerTest extends TestCase
             $server->close();
         });
 
-        $this->loop->run();
+        Loop::run();
 
         $this->assertEquals($bytes, $received);
     }
@@ -339,7 +341,7 @@ class UnixServerTest extends TestCase
         }
 
         $this->setExpectedException('RuntimeException');
-        $another = new UnixServer($this->uds, $this->loop);
+        $another = new UnixServer($this->uds);
     }
 
     /**

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Socket;
 
 use Clue\React\Block;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Socket\UnixServer;
 use React\Stream\DuplexResourceStream;
 
@@ -24,7 +24,7 @@ class UnixServerTest extends TestCase
             $this->markTestSkipped('Unix domain sockets (UDS) not supported on your platform (Windows?)');
         }
 
-        $this->loop = Factory::create();
+        $this->loop = Loop::get();
         $this->uds = $this->getRandomSocketUri();
         $this->server = new UnixServer($this->uds, $this->loop);
     }

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -9,7 +9,6 @@ use React\Stream\DuplexResourceStream;
 
 class UnixServerTest extends TestCase
 {
-    private $loop;
     private $server;
     private $uds;
 
@@ -24,7 +23,6 @@ class UnixServerTest extends TestCase
             $this->markTestSkipped('Unix domain sockets (UDS) not supported on your platform (Windows?)');
         }
 
-        $this->loop = Loop::get();
         $this->uds = $this->getRandomSocketUri();
         $this->server = new UnixServer($this->uds);
     }
@@ -362,6 +360,6 @@ class UnixServerTest extends TestCase
 
     private function tick()
     {
-        Block\sleep(0, $this->loop);
+        Block\sleep(0);
     }
 }


### PR DESCRIPTION
I noticed that this testsuite still uses the old eventloop implementation. After I changed everything to the new default loop some tests got stuck in execution, because other tests didn't close their servers/connections.

Builds on top of #260 and  clue/reactphp-block#60.