### PR TITLE
Fix invalid references in exception stack trace

### DIFF
--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -73,11 +73,11 @@ final class DnsConnector implements ConnectorInterface
 
                             // Exception trace arguments are not available on some PHP 7.4 installs
                             // @codeCoverageIgnoreStart
-                            foreach ($trace as &$one) {
+                            foreach ($trace as $ti => $one) {
                                 if (isset($one['args'])) {
-                                    foreach ($one['args'] as &$arg) {
+                                    foreach ($one['args'] as $ai => $arg) {
                                         if ($arg instanceof \Closure) {
-                                            $arg = 'Object(' . \get_class($arg) . ')';
+                                            $trace[$ti]['args'][$ai] = 'Object(' . \get_class($arg) . ')';
                                         }
                                     }
                                 }

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -43,6 +43,7 @@ final class SecureConnector implements ConnectorInterface
         $context = $this->context;
         $encryption = $this->streamEncryption;
         $connected = false;
+        /** @var \React\Promise\PromiseInterface $promise */
         $promise = $this->connector->connect(
             \str_replace('tls://', '', $uri)
         )->then(function (ConnectionInterface $connection) use ($context, $encryption, $uri, &$promise, &$connected) {

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -86,11 +86,11 @@ final class SecureConnector implements ConnectorInterface
 
                 // Exception trace arguments are not available on some PHP 7.4 installs
                 // @codeCoverageIgnoreStart
-                foreach ($trace as &$one) {
+                foreach ($trace as $ti => $one) {
                     if (isset($one['args'])) {
-                        foreach ($one['args'] as &$arg) {
+                        foreach ($one['args'] as $ai => $arg) {
                             if ($arg instanceof \Closure) {
-                                $arg = 'Object(' . \get_class($arg) . ')';
+                                $trace[$ti]['args'][$ai] = 'Object(' . \get_class($arg) . ')';
                             }
                         }
                     }

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -92,10 +92,18 @@ class DnsConnectorTest extends TestCase
         $this->tcp->expects($this->once())->method('connect')->with('1.2.3.4:80')->willReturn($promise);
 
         $promise = $this->connector->connect('1.2.3.4:80');
-        $promise->cancel();
 
-        $this->setExpectedException('RuntimeException', 'Connection to tcp://1.2.3.4:80 failed: Connection failed', 42);
-        $this->throwRejection($promise);
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        assert($exception instanceof \RuntimeException);
+        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertEquals('Connection to tcp://1.2.3.4:80 failed: Connection failed', $exception->getMessage());
+        $this->assertEquals(42, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+        $this->assertNotEquals('', $exception->getTraceAsString());
     }
 
     public function testConnectRejectsIfGivenIpAndTcpConnectorRejectsWithInvalidArgumentException()
@@ -105,10 +113,18 @@ class DnsConnectorTest extends TestCase
         $this->tcp->expects($this->once())->method('connect')->with('1.2.3.4:80')->willReturn($promise);
 
         $promise = $this->connector->connect('1.2.3.4:80');
-        $promise->cancel();
 
-        $this->setExpectedException('InvalidArgumentException', 'Invalid', 42);
-        $this->throwRejection($promise);
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        assert($exception instanceof \InvalidArgumentException);
+        $this->assertInstanceOf('InvalidArgumentException', $exception);
+        $this->assertEquals('Invalid', $exception->getMessage());
+        $this->assertEquals(42, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+        $this->assertNotEquals('', $exception->getTraceAsString());
     }
 
     public function testConnectRejectsWithOriginalHostnameInMessageAfterResolvingIfTcpConnectorRejectsWithRuntimeException()
@@ -139,10 +155,18 @@ class DnsConnectorTest extends TestCase
         $this->tcp->expects($this->once())->method('connect')->with('1.2.3.4:80?hostname=example.com')->willReturn($promise);
 
         $promise = $this->connector->connect('example.com:80');
-        $promise->cancel();
 
-        $this->setExpectedException('InvalidArgumentException', 'Invalid', 42);
-        $this->throwRejection($promise);
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        assert($exception instanceof \InvalidArgumentException);
+        $this->assertInstanceOf('InvalidArgumentException', $exception);
+        $this->assertEquals('Invalid', $exception->getMessage());
+        $this->assertEquals(42, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+        $this->assertNotEquals('', $exception->getTraceAsString());
     }
 
     public function testSkipConnectionIfDnsFails()
@@ -153,8 +177,17 @@ class DnsConnectorTest extends TestCase
 
         $promise = $this->connector->connect('example.invalid:80');
 
-        $this->setExpectedException('RuntimeException', 'Connection to tcp://example.invalid:80 failed during DNS lookup: DNS error');
-        $this->throwRejection($promise);
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        assert($exception instanceof \RuntimeException);
+        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertEquals('Connection to tcp://example.invalid:80 failed during DNS lookup: DNS error', $exception->getMessage());
+        $this->assertEquals(0, $exception->getCode());
+        $this->assertInstanceOf('RuntimeException', $exception->getPrevious());
+        $this->assertNotEquals('', $exception->getTraceAsString());
     }
 
     public function testRejectionExceptionUsesPreviousExceptionIfDnsFails()
@@ -179,12 +212,17 @@ class DnsConnectorTest extends TestCase
         $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
 
-        $this->setExpectedException(
-            'RuntimeException',
-            'Connection to tcp://example.com:80 cancelled during DNS lookup (ECONNABORTED)',
-            defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
-        );
-        $this->throwRejection($promise);
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        assert($exception instanceof \RuntimeException);
+        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertEquals('Connection to tcp://example.com:80 cancelled during DNS lookup (ECONNABORTED)', $exception->getMessage());
+        $this->assertEquals(defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+        $this->assertNotEquals('', $exception->getTraceAsString());
     }
 
     public function testCancelDuringTcpConnectionCancelsTcpConnectionIfGivenIp()
@@ -348,15 +386,5 @@ class DnsConnectorTest extends TestCase
         unset($promise, $dns, $tcp);
 
         $this->assertEquals(0, gc_collect_cycles());
-    }
-
-    private function throwRejection($promise)
-    {
-        $ex = null;
-        $promise->then(null, function ($e) use (&$ex) {
-            $ex = $e;
-        });
-
-        throw $ex;
     }
 }

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -80,14 +80,18 @@ class SecureConnectorTest extends TestCase
         )));
 
         $promise = $this->connector->connect('example.com:80');
-        $promise->cancel();
 
-        $this->setExpectedException(
-            'RuntimeException',
-            'Connection to tls://example.com:80 failed: Connection refused (ECONNREFUSED)',
-            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
-        );
-        $this->throwRejection($promise);
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        assert($exception instanceof \RuntimeException);
+        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertEquals('Connection to tls://example.com:80 failed: Connection refused (ECONNREFUSED)', $exception->getMessage());
+        $this->assertEquals(defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111, $exception->getCode());
+        $this->assertInstanceOf('RuntimeException', $exception->getPrevious());
+        $this->assertNotEquals('', $exception->getTraceAsString());
     }
 
     public function testConnectWillRejectWithOriginalMessageWhenUnderlyingConnectorRejectsWithInvalidArgumentException()
@@ -128,12 +132,17 @@ class SecureConnectorTest extends TestCase
         $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
 
-        $this->setExpectedException(
-            'RuntimeException',
-            'Connection to tls://example.com:80 cancelled (ECONNABORTED)',
-            defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
-        );
-        $this->throwRejection($promise);
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        assert($exception instanceof \RuntimeException);
+        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertEquals('Connection to tls://example.com:80 cancelled (ECONNABORTED)', $exception->getMessage());
+        $this->assertEquals(defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103, $exception->getCode());
+        $this->assertInstanceOf('RuntimeException', $exception->getPrevious());
+        $this->assertNotEquals('', $exception->getTraceAsString());
     }
 
     public function testConnectionWillBeClosedAndRejectedIfConnectionIsNoStream()


### PR DESCRIPTION
This changeset fixes any invalid references in the exception stack trace. This is a pretty nasty bug that has been introduced a few months ago with #270 that only happens on PHP 7+ when printing the exception trace (`$exception->getTraceAsString()`). This is now covered by the updated test suite and should work across all supported PHP versions.

Builds on top of https://github.com/clue/reactphp-socks/pull/104 and #270