### PR TITLE
Fix legacy HHVM build by downgrading Composer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,6 @@ jobs:
       - uses: azjezz/setup-hhvm@v1
         with:
           version: lts-3.30
+      - run: composer self-update --2.2 # downgrade Composer for HHVM
       - run: hhvm $(which composer) install
       - run: hhvm vendor/bin/phpunit


### PR DESCRIPTION
This changeset fixes the legacy HHVM build by downgrading Composer. Composer 2.3 does not longer support legacy PHP or legacy HHVM, so we have to downgrade to Composer LTS in order to run our test suite.

I'm filing this as an RFC to see if we want to apply this change to all our components (all HHVM builds currently fail). I'm not going to argue there's a lot of value in supporting a legacy HHVM build that accounts for less than 0.1% of our installation base, but at this point fixing legacy support is actually easier than dropping it entirely. At the same time, this is not the first fix for HHVM: https://github.com/reactphp/socket/pulls?q=hhvm

As much as I dislike having to address this, my vote would probably be to merge this as is and look into dropping legacy environments in a concentrated effort not too far in the future. WDYT?