### PR TITLE
Improve error reporting when custom error handler is used

### DIFF
--- a/src/FdServer.php
+++ b/src/FdServer.php
@@ -89,15 +89,21 @@ final class FdServer extends EventEmitter implements ServerInterface
 
         $this->loop = $loop ?: Loop::get();
 
-        $this->master = @\fopen('php://fd/' . $fd, 'r+');
-        if (false === $this->master) {
+        $errno = 0;
+        $errstr = '';
+        \set_error_handler(function ($_, $error) use (&$errno, &$errstr) {
             // Match errstr from PHP's warning message.
             // fopen(php://fd/3): Failed to open stream: Error duping file descriptor 3; possibly it doesn't exist: [9]: Bad file descriptor
-            $error = \error_get_last();
-            \preg_match('/\[(\d+)\]: (.*)/', $error['message'], $m);
+            \preg_match('/\[(\d+)\]: (.*)/', $error, $m);
             $errno = isset($m[1]) ? (int) $m[1] : 0;
-            $errstr = isset($m[2]) ? $m[2] : $error['message'];
+            $errstr = isset($m[2]) ? $m[2] : $error;
+        });
 
+        $this->master = \fopen('php://fd/' . $fd, 'r+');
+
+        \restore_error_handler();
+
+        if (false === $this->master) {
             throw new \RuntimeException(
                 'Failed to listen on FD ' . $fd . ': ' . $errstr . SocketServer::errconst($errno),
                 $errno

--- a/src/SocketServer.php
+++ b/src/SocketServer.php
@@ -106,15 +106,20 @@ final class SocketServer extends EventEmitter implements ServerInterface
      */
     public static function accept($socket)
     {
-        $newSocket = @\stream_socket_accept($socket, 0);
-
-        if (false === $newSocket) {
+        $errno = 0;
+        $errstr = '';
+        \set_error_handler(function ($_, $error) use (&$errno, &$errstr) {
             // Match errstr from PHP's warning message.
             // stream_socket_accept(): accept failed: Connection timed out
-            $error = \error_get_last();
-            $errstr = \preg_replace('#.*: #', '', $error['message']);
-            $errno = self::errno($errstr);
+            $errstr = \preg_replace('#.*: #', '', $error);
+            $errno = SocketServer::errno($errstr);
+        });
 
+        $newSocket = \stream_socket_accept($socket, 0);
+
+        \restore_error_handler();
+
+        if (false === $newSocket) {
             throw new \RuntimeException(
                 'Unable to accept new connection: ' . $errstr . self::errconst($errno),
                 $errno

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -116,13 +116,19 @@ final class TcpConnector implements ConnectorInterface
                         // Linux reports socket errno and errstr again when trying to write to the dead socket.
                         // Suppress error reporting to get error message below and close dead socket before rejecting.
                         // This is only known to work on Linux, Mac and Windows are known to not support this.
-                        @\fwrite($stream, \PHP_EOL);
-                        $error = \error_get_last();
+                        $errno = 0;
+                        $errstr = '';
+                        \set_error_handler(function ($_, $error) use (&$errno, &$errstr) {
+                            // Match errstr from PHP's warning message.
+                            // fwrite(): send of 1 bytes failed with errno=111 Connection refused
+                            \preg_match('/errno=(\d+) (.+)/', $error, $m);
+                            $errno = isset($m[1]) ? (int) $m[1] : 0;
+                            $errstr = isset($m[2]) ? $m[2] : $error;
+                        });
 
-                        // fwrite(): send of 2 bytes failed with errno=111 Connection refused
-                        \preg_match('/errno=(\d+) (.+)/', $error['message'], $m);
-                        $errno = isset($m[1]) ? (int) $m[1] : 0;
-                        $errstr = isset($m[2]) ? $m[2] : $error['message'];
+                        \fwrite($stream, \PHP_EOL);
+
+                        \restore_error_handler();
                     } else {
                         // Not on Linux and ext-sockets not available? Too bad.
                         $errno = \defined('SOCKET_ECONNREFUSED') ? \SOCKET_ECONNREFUSED : 111;


### PR DESCRIPTION
This changeset improves error reporting when custom error handler is used (`set_error_handler()`). In particular, a global error handler may interrupt our code flow and unset the error reported to us (#286). The updated logic makes sure to set a custom error handler before invoking any functions that may report an error and restore the original error handler afterwards.

The gist is that using `error_get_last()` in library code is almost always broken and should be avoided: https://twitter.com/another_clue/status/1503830137132957696 and https://github.com/thecodingmachine/safe/issues/332

Resolves / closes #286
Builds on top of #266, #267, #269, #168, and others
Also refs https://github.com/reactphp/event-loop/pull/245