### PR TITLE
Update test suite to future-proof base images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
-          - windows-2019
+          - ubuntu-22.04
+          - windows-2022
         php:
           - 8.2
           - 8.1
@@ -27,7 +27,7 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -43,7 +43,7 @@ jobs:
     runs-on: macos-12
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.1
@@ -53,13 +53,16 @@ jobs:
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: azjezz/setup-hhvm@v1
+      - uses: actions/checkout@v3
+      - run: cp `which composer` composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
+      - name: Run hhvm composer.phar install
+        uses: docker://hhvm/hhvm:3.30-lts-latest
         with:
-          version: lts-3.30
-      - run: composer self-update --2.2 # downgrade Composer for HHVM
-      - run: hhvm $(which composer) install
-      - run: hhvm vendor/bin/phpunit
+          args: hhvm composer.phar install
+      - name: Run hhvm vendor/bin/phpunit
+        uses: docker://hhvm/hhvm:3.30-lts-latest
+        with:
+          args: hhvm vendor/bin/phpunit

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -109,7 +109,7 @@ class TcpConnectorTest extends TestCase
         }
 
         // each file descriptor takes ~600 bytes of memory, so skip test if this would exceed memory_limit
-        if ($ulimit * 600 > $memory) {
+        if ($ulimit * 600 > $memory || $ulimit > 100000) {
             $this->markTestSkipped('Test requires ~' . round($ulimit * 600 / 1024 / 1024) . '/' . round($memory / 1024 / 1024) . ' MiB memory with ' . $ulimit . ' file descriptors');
         }
 


### PR DESCRIPTION
This simple changeset updates the test suite to future-proof base images. Likewise, legacy HHVM is now executed in an up-to-date base image, but using a legacy container instead. This way, we no longer depend on any legacy base images that will be removed in the future as per https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/, https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/ and https://github.com/actions/runner-images/issues/6002. I've confirmed pulling container images from Docker Hub does not appear to be rate-limited as per https://github.com/actions/runner-images/issues/1445. Once these changes are merged, we should apply similar updates to all our other components.

Builds on top of #297 and #289