### PR TITLE
Improve test suite, clean up leftover `.sock` files

### DIFF
--- a/tests/FdServerTest.php
+++ b/tests/FdServerTest.php
@@ -192,6 +192,9 @@ class FdServerTest extends TestCase
             $this->markTestSkipped('Listening on Unix domain socket (UDS) not supported');
         }
 
+        assert(is_resource($socket));
+        unlink(str_replace('unix://', '', stream_socket_get_name($socket, false)));
+
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
         $server = new FdServer($fd, $loop);

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -76,6 +76,9 @@ class ServerTest extends TestCase
             ->then($this->expectCallableOnce(), $this->expectCallableNever());
 
         $connection = \React\Async\await(\React\Promise\Timer\timeout($connector->connect($server->getAddress()), self::TIMEOUT));
+        assert($connection instanceof ConnectionInterface);
+
+        unlink(str_replace('unix://', '', $connection->getRemoteAddress()));
 
         $connection->close();
         $server->close();

--- a/tests/SocketServerTest.php
+++ b/tests/SocketServerTest.php
@@ -97,7 +97,11 @@ class SocketServerTest extends TestCase
             ->then($this->expectCallableOnce(), $this->expectCallableNever());
 
         $connection = \React\Async\await(\React\Promise\Timer\timeout($connector->connect($socket->getAddress()), self::TIMEOUT));
+        assert($connection instanceof ConnectionInterface);
 
+        unlink(str_replace('unix://', '', $connection->getRemoteAddress()));
+
+        $connection->close();
         $socket->close();
     }
 


### PR DESCRIPTION
This changeset improves the test suite to clean up any leftover `.sock` files. Before applying this, the test suite created a bunch of temporary `.sock` files for testing Unix Domain Sockets (UDS). All temporary files will now be cleaned up properly.

Builds on top of #299 and #300