### PR TITLE
Add Opportunistic TLS implementation

### DIFF
--- a/examples/31-opportunistic-tls.php
+++ b/examples/31-opportunistic-tls.php
@@ -1,0 +1,68 @@
+<?php
+
+// Opportunistic TLS example showing a basic negotiation before enabling the encryption. It starts out as an
+// unencrypted TCP connection. After both parties agreed to encrypt the connection they both enable the encryption.
+// After which any communication over the line is encrypted.
+//
+// This example is design to show both sides in one go, as such the server stops listening for new connection after
+// the first, this makes sure the loop shuts down after the example connection has closed.
+//
+// $ php examples/31-opportunistic-tls.php
+
+use React\EventLoop\Loop;
+use React\Socket\ConnectionInterface;
+use React\Socket\Connector;
+use React\Socket\OpportunisticTlsConnectionInterface;
+use React\Socket\SocketServer;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$server = new SocketServer('opportunistic+tls://127.0.0.1:0', array(
+    'tls' => array(
+        'local_cert' => __DIR__ . '/localhost.pem',
+    )
+));
+$server->on('connection', static function (OpportunisticTlsConnectionInterface $connection) use ($server) {
+    $server->close();
+
+    $connection->on('data', function ($data) {
+        echo 'From Client: ', $data, PHP_EOL;
+    });
+    React\Promise\Stream\first($connection)->then(function ($data) use ($connection) {
+        if ($data === 'Let\'s encrypt?') {
+            $connection->write('yes');
+            return $connection->enableEncryption();
+        }
+
+        return $connection;
+    })->then(static function (ConnectionInterface $connection) {
+        $connection->write('Encryption enabled!');
+    })->done();
+});
+
+$client = new Connector(array(
+    'tls' => array(
+        'verify_peer' => false,
+        'verify_peer_name' => false,
+        'allow_self_signed' => true,
+    ),
+));
+$client->connect($server->getAddress())->then(static function (OpportunisticTlsConnectionInterface $connection) {
+    $connection->on('data', function ($data) {
+        echo 'From Server: ', $data, PHP_EOL;
+    });
+    $connection->write('Let\'s encrypt?');
+
+    return React\Promise\Stream\first($connection)->then(function ($data) use ($connection) {
+        if ($data === 'yes') {
+            return $connection->enableEncryption();
+        }
+
+        return $connection;
+    });
+})->then(function (ConnectionInterface $connection) {
+    $connection->write('Encryption enabled!');
+    Loop::addTimer(1, static function () use ($connection) {
+        $connection->end('Cool! Bye!');
+    });
+})->done();

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -75,6 +75,7 @@ final class Connector implements ConnectorInterface
             'dns' => true,
             'timeout' => true,
             'happy_eyeballs' => true,
+            'opportunistic+tls' => true,
         );
 
         if ($context['timeout'] === true) {
@@ -150,6 +151,9 @@ final class Connector implements ConnectorInterface
             }
 
             $this->connectors['tls'] = $context['tls'];
+            if ($context['opportunistic+tls'] !== false) {
+                $this->connectors['opportunistic+tls'] = $this->connectors['tls'];
+            }
         }
 
         if ($context['unix'] !== false) {

--- a/src/OpportunisticTlsConnection.php
+++ b/src/OpportunisticTlsConnection.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace React\Socket;
+
+use Evenement\EventEmitter;
+use React\EventLoop\LoopInterface;
+use React\Promise\PromiseInterface;
+use React\Stream\DuplexResourceStream;
+use React\Stream\Util;
+use React\Stream\WritableResourceStream;
+use React\Stream\WritableStreamInterface;
+
+/**
+ * The actual connection implementation for StartTlsConnectionInterface
+ *
+ * This class should only be used internally, see StartTlsConnectionInterface instead.
+ *
+ * @see OpportunisticTlsConnectionInterface
+ * @internal
+ */
+class OpportunisticTlsConnection extends EventEmitter implements OpportunisticTlsConnectionInterface
+{
+    /** @var Connection */
+    private $connection;
+
+    /** @var StreamEncryption */
+    private $streamEncryption;
+
+    /** @var string */
+    private $uri;
+
+    public function __construct(Connection $connection, StreamEncryption $streamEncryption, $uri)
+    {
+        $this->connection = $connection;
+        $this->streamEncryption = $streamEncryption;
+        $this->uri = $uri;
+
+        Util::forwardEvents($connection, $this, array('data', 'end', 'error', 'close'));
+    }
+
+    public function getRemoteAddress()
+    {
+        return $this->connection->getRemoteAddress();
+    }
+
+    public function getLocalAddress()
+    {
+        return $this->connection->getLocalAddress();
+    }
+
+    public function isReadable()
+    {
+        return $this->connection->isReadable();
+    }
+
+    public function pause()
+    {
+        $this->connection->pause();
+    }
+
+    public function resume()
+    {
+        $this->connection->resume();
+    }
+
+    public function pipe(WritableStreamInterface $dest, array $options = array())
+    {
+        return $this->connection->pipe($dest, $options);
+    }
+
+    public function close()
+    {
+        $this->connection->close();
+    }
+
+    public function enableEncryption()
+    {
+        $that = $this;
+        $connection = $this->connection;
+        $uri = $this->uri;
+
+        return $this->streamEncryption->enable($connection)->then(function () use ($that) {
+            return $that;
+        }, function ($error) use ($connection, $uri) {
+            // establishing encryption failed => close invalid connection and return error
+            $connection->close();
+
+            throw new \RuntimeException(
+                'Connection to ' . $uri . ' failed during TLS handshake: ' . $error->getMessage(),
+                $error->getCode()
+            );
+        });
+    }
+
+    public function isWritable()
+    {
+        return $this->connection->isWritable();
+    }
+
+    public function write($data)
+    {
+        return $this->connection->write($data);
+    }
+
+    public function end($data = null)
+    {
+        $this->connection->end($data);
+    }
+}

--- a/src/OpportunisticTlsConnectionInterface.php
+++ b/src/OpportunisticTlsConnectionInterface.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace React\Socket;
+
+use React\Promise\PromiseInterface;
+
+/**
+ * The `OpportunisticTlsConnectionInterface` extends the
+ * [`ConnectionInterface`](#connectioninterface) and adds the ability of
+ * enabling the TLS encryption on the connection when desired.
+ *
+ * @see DuplexStreamInterface
+ * @see ServerInterface
+ * @see ConnectionInterface
+ */
+interface OpportunisticTlsConnectionInterface extends ConnectionInterface
+{
+    /**
+     * When negotiated with the server when to start encrypting traffic using TLS, you
+     * can enable it by calling `enableEncryption()`. This will either return a promise
+     * that resolves with a `OpportunisticTlsConnectionInterface` connection or throw a
+     * `RuntimeException` if the encryption failed. If successful, all traffic back and
+     * forth will be encrypted. In the following example we ask the server if they want
+     * to encrypt the connection, and when it responds with `yes` we enable the encryption:
+     *
+     * ```php
+     * $connector = new React\Socket\Connector();
+     * $connector->connect('opportunistic+tls://example.com:5432/')->then(function (React\Socket\OpportunisticTlsConnectionInterface $startTlsConnection) {
+     * $connection->write('let\'s encrypt?');
+     *
+     * return React\Promise\Stream\first($connection)->then(function ($data) use ($connection) {
+     *     if ($data === 'yes') {
+     *         return $connection->enableEncryption();
+     *     }
+     *
+     *     return $stream;
+     * });
+     * })->then(function (React\Socket\ConnectionInterface $connection) {
+     *     $connection->write('Hello!');
+     * });
+     * ```
+     *
+     * The `enableEncryption` function resolves with itself. As such you can't see the data
+     * encrypted when you hook into the events before enabling, as shown below:
+     *
+     * ```php
+     * $connector = new React\Socket\Connector();
+     * $connector->connect('opportunistic+tls://example.com:5432/')->then(function (React\Socket\OpportunisticTlsConnectionInterface $startTlsConnection) {
+     *     $connection->on('data', function ($data) {
+     *         echo 'Raw: ', $data, PHP_EOL;
+     *     });
+     *
+     *     return $connection->enableEncryption();
+     * })->then(function (React\Socket\ConnectionInterface $connection) {
+     *     $connection->on('data', function ($data) {
+     *         echo 'TLS: ', $data, PHP_EOL;
+     *     });
+     * });
+     * ```
+     *
+     * When the other side sends `Hello World!` over the encrypted connection, the output
+     * will be the following:
+     *
+     * ```
+     * Raw: Hello World!
+     * TLS: Hello World!
+     * ```
+     *
+     * @return PromiseInterface<OpportunisticTlsConnectionInterface>
+     */
+    public function enableEncryption();
+}

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -33,7 +33,7 @@ final class SecureConnector implements ConnectorInterface
         }
 
         $parts = \parse_url($uri);
-        if (!$parts || !isset($parts['scheme']) || $parts['scheme'] !== 'tls') {
+        if (!$parts || !isset($parts['scheme']) || ($parts['scheme'] !== 'tls' && $parts['scheme'] !== 'opportunistic+tls')) {
             return Promise\reject(new \InvalidArgumentException(
                 'Given URI "' . $uri . '" is invalid (EINVAL)',
                 \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
@@ -42,11 +42,12 @@ final class SecureConnector implements ConnectorInterface
 
         $context = $this->context;
         $encryption = $this->streamEncryption;
+        $opportunisticTls = $parts['scheme'] === 'opportunistic+tls';
         $connected = false;
         /** @var \React\Promise\PromiseInterface $promise */
         $promise = $this->connector->connect(
-            \str_replace('tls://', '', $uri)
-        )->then(function (ConnectionInterface $connection) use ($context, $encryption, $uri, &$promise, &$connected) {
+            \str_replace(array('opportunistic+tls://', 'tls://'), '', $uri)
+        )->then(function (ConnectionInterface $connection) use ($context, $encryption, $opportunisticTls, $uri, &$promise, &$connected) {
             // (unencrypted) TCP/IP connection succeeded
             $connected = true;
 
@@ -58,6 +59,10 @@ final class SecureConnector implements ConnectorInterface
             // set required SSL/TLS context options
             foreach ($context as $name => $value) {
                 \stream_context_set_option($connection->stream, 'ssl', $name, $value);
+            }
+
+            if ($opportunisticTls === true) {
+                return new OpportunisticTlsConnection($connection, $encryption, $uri);
             }
 
             // try to enable encryption

--- a/src/ServerInterface.php
+++ b/src/ServerInterface.php
@@ -60,9 +60,10 @@ interface ServerInterface extends EventEmitterInterface
      * after the socket has been closed), it MAY return a `NULL` value instead.
      *
      * Otherwise, it will return the full address (URI) as a string value, such
-     * as `tcp://127.0.0.1:8080`, `tcp://[::1]:80` or `tls://127.0.0.1:443`.
-     * Note that individual URI components are application specific and depend
-     * on the underlying transport protocol.
+     * as `tcp://127.0.0.1:8080`, `tcp://[::1]:80`, `tls://127.0.0.1:443`,
+     * `unix://example.sock`, `unix:///path/to/example.sock`, or
+     * `opportunistic+tls://127.0.0.1:443`.  Note that individual URI components
+     * are application specific and depend on the underlying transport protocol.
      *
      * If this is a TCP/IP based server and you only want the local port, you may
      * use something like this:

--- a/src/SocketServer.php
+++ b/src/SocketServer.php
@@ -58,10 +58,13 @@ final class SocketServer extends EventEmitter implements ServerInterface
                 );
             }
 
-            $server = new TcpServer(str_replace('tls://', '', $uri), $loop, $context['tcp']);
+            $server = new TcpServer(str_replace(array('opportunistic+tls://', 'tls://'), '', $uri), $loop, $context['tcp']);
 
             if ($scheme === 'tls') {
                 $server = new SecureServer($server, $loop, $context['tls']);
+            }
+            if ($scheme === 'opportunistic+tls') {
+                $server = new SecureServer($server, $loop, $context['tls'], true);
             }
         }
 

--- a/tests/FunctionalOpportunisticTLSTest.php
+++ b/tests/FunctionalOpportunisticTLSTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace React\Tests\Socket;
+
+use React\EventLoop\Factory;
+use React\EventLoop\Loop;
+use React\Promise\Stream;
+use React\Socket\ConnectionInterface;
+use React\Socket\Connector;
+use React\Socket\OpportunisticTlsConnectionInterface;
+use React\Socket\SocketServer;
+
+class FunctionalOpportunisticTLSTest extends TestCase
+{
+    const TIMEOUT = 2;
+
+    /**
+     * @before
+     */
+    public function setUpSkipTest()
+    {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on legacy HHVM');
+        }
+    }
+
+    public function testNegotiatedLSSSuccessful()
+    {
+        // let loop tick for reactphp/async v4 to clean up any remaining stream resources
+        // @link https://github.com/reactphp/async/pull/65 reported upstream // TODO remove me once merged
+        if (function_exists('React\Async\async')) {
+            \React\Async\await(\React\Promise\Timer\sleep(0));
+            Loop::run();
+        }
+
+        $expectCallableNever = $this->expectCallableNever();
+        $messagesExpected = array(
+            'client' => array(
+                'Let\'s encrypt?',
+                'Encryption enabled!',
+                'Cool! Bye!',
+            ),
+            'server' => array(
+                'yes',
+                'Encryption enabled!',
+            ),
+        );
+        $messages = array(
+            'client' => array(),
+            'server' => array(),
+        );
+        $server = new SocketServer('opportunistic+tls://127.0.0.1:0', array(
+            'tls' => array(
+                'local_cert' => dirname(__DIR__) . '/examples/localhost.pem',
+            )
+        ));
+        $server->on('connection', function (OpportunisticTlsConnectionInterface $connection) use ($expectCallableNever, $server, &$messages) {
+            $server->close();
+
+            $connection->on('data', function ($data) use (&$messages) {
+                $messages['client'][] = $data;
+            });
+            Stream\first($connection)->then(function ($data) use ($connection) {
+                if ($data === 'Let\'s encrypt?') {
+                    $connection->write('yes');
+                    return $connection->enableEncryption();
+                }
+
+                return $connection;
+            })->then(function (ConnectionInterface $connection) {
+                $connection->write('Encryption enabled!');
+            })->then(null, $expectCallableNever);
+        });
+
+        $client = new Connector(array(
+            'tls' => array(
+                'verify_peer' => false,
+                'verify_peer_name' => false,
+                'allow_self_signed' => true,
+            ),
+        ));
+        $client->connect($server->getAddress())->then(function (OpportunisticTlsConnectionInterface $connection) use (&$messages) {
+            $connection->on('data', function ($data) use (&$messages) {
+                $messages['server'][] = $data;
+            });
+            $connection->write('Let\'s encrypt?');
+
+            return Stream\first($connection)->then(function ($data) use ($connection) {
+                if ($data === 'yes') {
+                    return $connection->enableEncryption();
+                }
+
+                return $connection;
+            });
+        })->then(function (ConnectionInterface $connection) {
+            $connection->write('Encryption enabled!');
+            Loop::addTimer(1, function () use ($connection) {
+                $connection->end('Cool! Bye!');
+            });
+        })->then(null, $expectCallableNever);
+
+        Loop::run();
+
+        self::assertSame($messagesExpected, $messages);
+    }
+
+    public function testNegotiatedTLSUnsuccessful()
+    {
+        $this->setExpectedException('RuntimeException');
+
+        $server = new SocketServer('opportunistic+tls://127.0.0.1:0', array(
+            'tls' => array(
+                'local_cert' => dirname(__DIR__) . '/examples/localhost.pem',
+            )
+        ));
+        $server->on('connection', function (ConnectionInterface $connection) use ($server) {
+            $server->close();
+            $connection->write('Hi!');
+            $connection->enableEncryption();
+        });
+
+        $client = new Connector();
+        \React\Async\await($client->connect($server->getAddress())->then(function (OpportunisticTlsConnectionInterface $connection) use (&$messages) {
+            $connection->write('Hi!');
+            return $connection->enableEncryption();
+        }));
+    }
+}

--- a/tests/OpportunisticTlsConnectionTest.php
+++ b/tests/OpportunisticTlsConnectionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace React\Tests\Socket;
+
+use React\EventLoop\Loop;
+use React\Socket\Connection;
+use React\Socket\OpportunisticTlsConnection;
+use React\Socket\StreamEncryption;
+
+class OpportunisticTlsConnectionTest extends TestCase
+{
+    public function testGetRemoteAddressWillForwardCallToUnderlyingConnection()
+    {
+        $underlyingConnection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->getMock();
+        $underlyingConnection->expects($this->once())->method('getRemoteAddress')->willReturn('[::1]:13');
+
+        $connection = new OpportunisticTlsConnection($underlyingConnection, new StreamEncryption(Loop::get(), false), '');
+        $this->assertSame('[::1]:13', $connection->getRemoteAddress());
+    }
+
+    public function testGetLocalAddressWillForwardCallToUnderlyingConnection()
+    {
+        $underlyingConnection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->getMock();
+        $underlyingConnection->expects($this->once())->method('getLocalAddress')->willReturn('[::1]:13');
+
+        $connection = new OpportunisticTlsConnection($underlyingConnection, new StreamEncryption(Loop::get(), false), '');
+        $this->assertSame('[::1]:13', $connection->getLocalAddress());
+    }
+
+    public function testPauseWillForwardCallToUnderlyingConnection()
+    {
+        $underlyingConnection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->getMock();
+        $underlyingConnection->expects($this->once())->method('pause');
+
+        $connection = new OpportunisticTlsConnection($underlyingConnection, new StreamEncryption(Loop::get(), false), '');
+        $connection->pause();
+    }
+
+    public function testResumeWillForwardCallToUnderlyingConnection()
+    {
+        $underlyingConnection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->getMock();
+        $underlyingConnection->expects($this->once())->method('resume');
+
+        $connection = new OpportunisticTlsConnection($underlyingConnection, new StreamEncryption(Loop::get(), false), '');
+        $connection->resume();
+    }
+
+    public function testPipeWillForwardCallToUnderlyingConnection()
+    {
+        $underlyingConnection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->getMock();
+        $underlyingConnection->expects($this->once())->method('pipe');
+
+        $connection = new OpportunisticTlsConnection($underlyingConnection, new StreamEncryption(Loop::get(), false), '');
+        $connection->pipe($underlyingConnection);
+    }
+
+    public function testCloseWillForwardCallToUnderlyingConnection()
+    {
+        $underlyingConnection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->getMock();
+        $underlyingConnection->expects($this->once())->method('close');
+
+        $connection = new OpportunisticTlsConnection($underlyingConnection, new StreamEncryption(Loop::get(), false), '');
+        $connection->close();
+    }
+
+    public function testIsWritableWillForwardCallToUnderlyingConnection()
+    {
+        $underlyingConnection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->getMock();
+        $underlyingConnection->expects($this->once())->method('isWritable')->willReturn(true);
+
+        $connection = new OpportunisticTlsConnection($underlyingConnection, new StreamEncryption(Loop::get(), false), '');
+        $this->assertTrue($connection->isWritable());
+    }
+}


### PR DESCRIPTION
This PR introduces the functionality required to build opportunistic TLS clients and servers with ReactPHP. It does so by introducing a prefix to `tls://`, namely `opportunistic`, to create `opportunistic+tls://example.com:5432` for example as the full URL. This will create an `OpportunisticTlsConnectionInterface` (instead of a `ConnectionInterface`) that extends the `ConnectionInterface` and exposes the `enableEncryption` method to enable TLS encryption at the desired moment. Inside this PR is an example of a server and client negotiating when to enable TLS and enable it when ready.

Opportunistic Security described in RFC7435: https://www.rfc-editor.org/rfc/rfc7435
External PR using the proposed changes in this PR: https://github.com/voryx/PgAsync/pull/52