### PR TITLE
Improve errno detection for failed connections without ext-sockets

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -170,7 +170,7 @@ final class Connector implements ConnectorInterface
         if (!isset($this->connectors[$scheme])) {
             return \React\Promise\reject(new \RuntimeException(
                 'No connector available for URI scheme "' . $scheme . '" (EINVAL)',
-                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : (\defined('PCNTL_EINVAL') ? \PCNTL_EINVAL : 22)
             ));
         }
 

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -33,7 +33,7 @@ final class DnsConnector implements ConnectorInterface
         if (!$parts || !isset($parts['host'])) {
             return Promise\reject(new \InvalidArgumentException(
                 'Given URI "' . $original . '" is invalid (EINVAL)',
-                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : (\defined('PCNTL_EINVAL') ? \PCNTL_EINVAL : 22)
             ));
         }
 

--- a/src/FdServer.php
+++ b/src/FdServer.php
@@ -83,7 +83,7 @@ final class FdServer extends EventEmitter implements ServerInterface
         if (!\is_int($fd) || $fd < 0 || $fd >= \PHP_INT_MAX) {
             throw new \InvalidArgumentException(
                 'Invalid FD number given (EINVAL)',
-                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : (\defined('PCNTL_EINVAL') ? \PCNTL_EINVAL : 22)
             );
         }
 

--- a/src/HappyEyeBallsConnector.php
+++ b/src/HappyEyeBallsConnector.php
@@ -45,7 +45,7 @@ final class HappyEyeBallsConnector implements ConnectorInterface
         if (!$parts || !isset($parts['host'])) {
             return Promise\reject(new \InvalidArgumentException(
                 'Given URI "' . $original . '" is invalid (EINVAL)',
-                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : (\defined('PCNTL_EINVAL') ? \PCNTL_EINVAL : 22)
             ));
         }
 

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -36,7 +36,7 @@ final class SecureConnector implements ConnectorInterface
         if (!$parts || !isset($parts['scheme']) || $parts['scheme'] !== 'tls') {
             return Promise\reject(new \InvalidArgumentException(
                 'Given URI "' . $uri . '" is invalid (EINVAL)',
-                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : (\defined('PCNTL_EINVAL') ? \PCNTL_EINVAL : 22)
             ));
         }
 

--- a/src/SocketServer.php
+++ b/src/SocketServer.php
@@ -54,7 +54,7 @@ final class SocketServer extends EventEmitter implements ServerInterface
             if (preg_match('#^(?:\w+://)?\d+$#', $uri)) {
                 throw new \InvalidArgumentException(
                     'Invalid URI given (EINVAL)',
-                    \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                    \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : (\defined('PCNTL_EINVAL') ? \PCNTL_EINVAL : 22)
                 );
             }
 
@@ -135,25 +135,42 @@ final class SocketServer extends EventEmitter implements ServerInterface
      * The errno and errstr values describes the type of error that has been
      * encountered. This method tries to look up the given errstr and find a
      * matching errno value which can be useful to provide more context to error
-     * messages. It goes through the list of known errno constants when
-     * ext-sockets is available to find an errno matching the given errstr.
+     * messages. It goes through the list of known errno constants when either
+     * `ext-sockets`, `ext-posix` or `ext-pcntl` is available to find an errno
+     * matching the given errstr.
      *
      * @param string $errstr
      * @return int errno value (e.g. value of `SOCKET_ECONNREFUSED`) or 0 if not found
      * @internal
-     * @copyright Copyright (c) 2018 Christian Lück, taken from https://github.com/clue/errno with permission
+     * @copyright Copyright (c) 2023 Christian Lück, taken from https://github.com/clue/errno with permission
      * @codeCoverageIgnore
      */
     public static function errno($errstr)
     {
-        if (\function_exists('socket_strerror')) {
+        // PHP defines the required `strerror()` function through either `ext-sockets`, `ext-posix` or `ext-pcntl`
+        $strerror = \function_exists('socket_strerror') ? 'socket_strerror' : (\function_exists('posix_strerror') ? 'posix_strerror' : (\function_exists('pcntl_strerror') ? 'pcntl_strerror' : null));
+        if ($strerror !== null) {
+            assert(\is_string($strerror) && \is_callable($strerror));
+
+            // PHP defines most useful errno constants like `ECONNREFUSED` through constants in `ext-sockets` like `SOCKET_ECONNREFUSED`
+            // PHP also defines a hand full of errno constants like `EMFILE` through constants in `ext-pcntl` like `PCNTL_EMFILE`
+            // go through list of all defined constants like `SOCKET_E*` and `PCNTL_E*` and see if they match the given `$errstr`
             foreach (\get_defined_constants(false) as $name => $value) {
-                if (\strpos($name, 'SOCKET_E') === 0 && \socket_strerror($value) === $errstr) {
+                if (\is_int($value) && (\strpos($name, 'SOCKET_E') === 0 || \strpos($name, 'PCNTL_E') === 0) && $strerror($value) === $errstr) {
                     return $value;
+                }
+            }
+
+            // if we reach this, no matching errno constant could be found (unlikely when `ext-sockets` is available)
+            // go through list of all possible errno values from 1 to `MAX_ERRNO` and see if they match the given `$errstr`
+            for ($errno = 1, $max = \defined('MAX_ERRNO') ? \MAX_ERRNO : 4095; $errno <= $max; ++$errno) {
+                if ($strerror($errno) === $errstr) {
+                    return $errno;
                 }
             }
         }
 
+        // if we reach this, no matching errno value could be found (unlikely when either `ext-sockets`, `ext-posix` or `ext-pcntl` is available)
         return 0;
     }
 
@@ -164,8 +181,8 @@ final class SocketServer extends EventEmitter implements ServerInterface
      * This method tries to look up the given errno value and find a matching
      * errno constant name which can be useful to provide more context and more
      * descriptive error messages. It goes through the list of known errno
-     * constants when ext-sockets is available to find the matching errno
-     * constant name.
+     * constants when either `ext-sockets` or `ext-pcntl` is available to find
+     * the matching errno constant name.
      *
      * Because this method is used to append more context to error messages, the
      * constant name will be prefixed with a space and put between parenthesis
@@ -174,19 +191,21 @@ final class SocketServer extends EventEmitter implements ServerInterface
      * @param int $errno
      * @return string e.g. ` (ECONNREFUSED)` or empty string if no matching const for the given errno could be found
      * @internal
-     * @copyright Copyright (c) 2018 Christian Lück, taken from https://github.com/clue/errno with permission
+     * @copyright Copyright (c) 2023 Christian Lück, taken from https://github.com/clue/errno with permission
      * @codeCoverageIgnore
      */
     public static function errconst($errno)
     {
-        if (\function_exists('socket_strerror')) {
-            foreach (\get_defined_constants(false) as $name => $value) {
-                if ($value === $errno && \strpos($name, 'SOCKET_E') === 0) {
-                    return ' (' . \substr($name, 7) . ')';
-                }
+        // PHP defines most useful errno constants like `ECONNREFUSED` through constants in `ext-sockets` like `SOCKET_ECONNREFUSED`
+        // PHP also defines a hand full of errno constants like `EMFILE` through constants in `ext-pcntl` like `PCNTL_EMFILE`
+        // go through list of all defined constants like `SOCKET_E*` and `PCNTL_E*` and see if they match the given `$errno`
+        foreach (\get_defined_constants(false) as $name => $value) {
+            if ($value === $errno && (\strpos($name, 'SOCKET_E') === 0 || \strpos($name, 'PCNTL_E') === 0)) {
+                return ' (' . \substr($name, \strpos($name, '_') + 1) . ')';
             }
         }
 
+        // if we reach this, no matching errno constant could be found (unlikely when `ext-sockets` is available)
         return '';
     }
 }

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -29,7 +29,7 @@ final class TcpConnector implements ConnectorInterface
         if (!$parts || !isset($parts['scheme'], $parts['host'], $parts['port']) || $parts['scheme'] !== 'tcp') {
             return Promise\reject(new \InvalidArgumentException(
                 'Given URI "' . $uri . '" is invalid (EINVAL)',
-                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : (\defined('PCNTL_EINVAL') ? \PCNTL_EINVAL : 22)
             ));
         }
 
@@ -37,7 +37,7 @@ final class TcpConnector implements ConnectorInterface
         if (@\inet_pton($ip) === false) {
             return Promise\reject(new \InvalidArgumentException(
                 'Given URI "' . $uri . '" does not contain a valid host IP (EINVAL)',
-                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : (\defined('PCNTL_EINVAL') ? \PCNTL_EINVAL : 22)
             ));
         }
 

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -156,14 +156,14 @@ final class TcpServer extends EventEmitter implements ServerInterface
         if (!$parts || !isset($parts['scheme'], $parts['host'], $parts['port']) || $parts['scheme'] !== 'tcp') {
             throw new \InvalidArgumentException(
                 'Invalid URI "' . $uri . '" given (EINVAL)',
-                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : (\defined('PCNTL_EINVAL') ? \PCNTL_EINVAL : 22)
             );
         }
 
         if (@\inet_pton(\trim($parts['host'], '[]')) === false) {
             throw new \InvalidArgumentException(
                 'Given URI "' . $uri . '" does not contain a valid host IP (EINVAL)',
-                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : (\defined('PCNTL_EINVAL') ? \PCNTL_EINVAL : 22)
             );
         }
 

--- a/src/UnixConnector.php
+++ b/src/UnixConnector.php
@@ -30,7 +30,7 @@ final class UnixConnector implements ConnectorInterface
         } elseif (\substr($path, 0, 7) !== 'unix://') {
             return Promise\reject(new \InvalidArgumentException(
                 'Given URI "' . $path . '" is invalid (EINVAL)',
-                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : (\defined('PCNTL_EINVAL') ? \PCNTL_EINVAL : 22)
             ));
         }
 

--- a/src/UnixServer.php
+++ b/src/UnixServer.php
@@ -59,7 +59,7 @@ final class UnixServer extends EventEmitter implements ServerInterface
         } elseif (\substr($path, 0, 7) !== 'unix://') {
             throw new \InvalidArgumentException(
                 'Given URI "' . $path . '" is invalid (EINVAL)',
-                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : 22
+                \defined('SOCKET_EINVAL') ? \SOCKET_EINVAL : (\defined('PCNTL_EINVAL') ? \PCNTL_EINVAL : 22)
             );
         }
 

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -173,7 +173,7 @@ class ConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'No connector available for URI scheme "unknown" (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         ));
     }
 
@@ -189,7 +189,7 @@ class ConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'No connector available for URI scheme "tcp" (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         ));
     }
 
@@ -205,7 +205,7 @@ class ConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'No connector available for URI scheme "tcp" (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         ));
     }
 
@@ -221,7 +221,7 @@ class ConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'No connector available for URI scheme "tls" (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         ));
     }
 
@@ -237,7 +237,7 @@ class ConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'No connector available for URI scheme "unix" (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         ));
     }
 

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -81,7 +81,7 @@ class DnsConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'InvalidArgumentException',
             'Given URI "////" is invalid (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         ));
     }
 

--- a/tests/FdServerTest.php
+++ b/tests/FdServerTest.php
@@ -32,7 +32,7 @@ class FdServerTest extends TestCase
         $this->setExpectedException(
             'InvalidArgumentException',
             'Invalid FD number given (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         );
         new FdServer(-1, $loop);
     }
@@ -45,7 +45,7 @@ class FdServerTest extends TestCase
         $this->setExpectedException(
             'InvalidArgumentException',
             'Invalid FD number given (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         );
         new FdServer('tcp://127.0.0.1:8080', $loop);
     }

--- a/tests/FunctionalTcpServerTest.php
+++ b/tests/FunctionalTcpServerTest.php
@@ -394,7 +394,7 @@ class FunctionalTcpServerTest extends TestCase
         $this->setExpectedException(
             'InvalidArgumentException',
             'Invalid URI "tcp://///" given (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         );
         new TcpServer('///');
     }
@@ -404,7 +404,7 @@ class FunctionalTcpServerTest extends TestCase
         $this->setExpectedException(
             'InvalidArgumentException',
             'Invalid URI "tcp://127.0.0.1" given (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         );
         new TcpServer('127.0.0.1');
     }
@@ -414,7 +414,7 @@ class FunctionalTcpServerTest extends TestCase
         $this->setExpectedException(
             'InvalidArgumentException',
             'Invalid URI "udp://127.0.0.1:0" given (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         );
         new TcpServer('udp://127.0.0.1:0');
     }
@@ -424,7 +424,7 @@ class FunctionalTcpServerTest extends TestCase
         $this->setExpectedException(
             'InvalidArgumentException',
             'Given URI "tcp://localhost:8080" does not contain a valid host IP (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         );
         new TcpServer('localhost:8080');
     }

--- a/tests/HappyEyeBallsConnectorTest.php
+++ b/tests/HappyEyeBallsConnectorTest.php
@@ -230,7 +230,7 @@ class HappyEyeBallsConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'InvalidArgumentException',
             'Given URI "////" is invalid (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         ));
     }
 

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -68,7 +68,7 @@ class SecureConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'InvalidArgumentException',
             'Given URI "tcp://example.com:80" is invalid (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         ));
     }
 

--- a/tests/SocketServerTest.php
+++ b/tests/SocketServerTest.php
@@ -40,7 +40,7 @@ class SocketServerTest extends TestCase
         $this->setExpectedException(
             'InvalidArgumentException',
             'Invalid URI "tcp://invalid URI" given (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         );
         new SocketServer('invalid URI');
     }
@@ -50,7 +50,7 @@ class SocketServerTest extends TestCase
         $this->setExpectedException(
             'InvalidArgumentException',
             'Invalid URI given (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         );
         new SocketServer('0');
     }
@@ -60,7 +60,7 @@ class SocketServerTest extends TestCase
         $this->setExpectedException(
             'InvalidArgumentException',
             'Invalid URI given (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         );
         new SocketServer('tcp://0');
     }

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -281,7 +281,7 @@ class TcpConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'InvalidArgumentException',
             'Given URI "tcp://www.google.com:80" does not contain a valid host IP (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         ));
     }
 
@@ -296,7 +296,7 @@ class TcpConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'InvalidArgumentException',
             'Given URI "tcp://255.255.255.255:12345678" is invalid (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         ));
     }
 

--- a/tests/UnixConnectorTest.php
+++ b/tests/UnixConnectorTest.php
@@ -46,7 +46,7 @@ class UnixConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'InvalidArgumentException',
             'Given URI "tcp://google.com:80" is invalid (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         ));
     }
 

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -252,7 +252,7 @@ class UnixServerTest extends TestCase
         $this->setExpectedException(
             'InvalidArgumentException',
             'Given URI "tcp://localhost:0" is invalid (EINVAL)',
-            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            defined('SOCKET_EINVAL') ? SOCKET_EINVAL : (defined('PCNTL_EINVAL') ? PCNTL_EINVAL : 22)
         );
         new UnixServer('tcp://localhost:0', $loop);
     }


### PR DESCRIPTION
This changeset improves errno detection for failed connections without ext-sockets. Reporting the errstr already works on most platforms even when `ext-sockets` is not installed, consistently reporting the correct errno previously required `ext-sockets`. With these changes applied, we now also take the errno constants from `ext-pcntl` and `ext-posix` into account. This is particularly useful for lightweight container images (Docker) that by default come with `ext-sockets` and `ext-pcntl` disabled but `ext-posix` enabled. All extensions remain entirely optional.

Link dump:
* https://man7.org/linux/man-pages/man3/errno.3.html
* https://man7.org/linux/man-pages/man3/strerror.3.html
* https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno.h
* https://learn.microsoft.com/en-us/cpp/c-runtime-library/errno-constants?view=msvc-170

Builds on top of #271, #267, #266 and others