### PR TITLE
Include timeout logic to avoid dependency on reactphp/promise-timer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,16 +28,16 @@
     "require": {
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/dns": "^1.8",
+        "react/dns": "^1.11",
         "react/event-loop": "^1.2",
         "react/promise": "^3 || ^2.6 || ^1.2.1",
-        "react/promise-timer": "^1.9",
         "react/stream": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
         "react/async": "^4 || ^3 || ^2",
-        "react/promise-stream": "^1.4"
+        "react/promise-stream": "^1.4",
+        "react/promise-timer": "^1.9"
     },
     "autoload": {
         "psr-4": {

--- a/src/TimeoutConnector.php
+++ b/src/TimeoutConnector.php
@@ -4,8 +4,7 @@ namespace React\Socket;
 
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
-use React\Promise\Timer;
-use React\Promise\Timer\TimeoutException;
+use React\Promise\Promise;
 
 final class TimeoutConnector implements ConnectorInterface
 {
@@ -22,30 +21,50 @@ final class TimeoutConnector implements ConnectorInterface
 
     public function connect($uri)
     {
-        return Timer\timeout($this->connector->connect($uri), $this->timeout, $this->loop)->then(null, self::handler($uri));
-    }
+        $promise = $this->connector->connect($uri);
 
-    /**
-     * Creates a static rejection handler that reports a proper error message in case of a timeout.
-     *
-     * This uses a private static helper method to ensure this closure is not
-     * bound to this instance and the exception trace does not include a
-     * reference to this instance and its connector stack as a result.
-     *
-     * @param string $uri
-     * @return callable
-     */
-    private static function handler($uri)
-    {
-        return function (\Exception $e) use ($uri) {
-            if ($e instanceof TimeoutException) {
-                throw new \RuntimeException(
-                    'Connection to ' . $uri . ' timed out after ' . $e->getTimeout() . ' seconds (ETIMEDOUT)',
-                    \defined('SOCKET_ETIMEDOUT') ? \SOCKET_ETIMEDOUT : 110
-                );
+        $loop = $this->loop;
+        $time = $this->timeout;
+        return new Promise(function ($resolve, $reject) use ($loop, $time, $promise, $uri) {
+            $timer = null;
+            $promise = $promise->then(function ($v) use (&$timer, $loop, $resolve) {
+                if ($timer) {
+                    $loop->cancelTimer($timer);
+                }
+                $timer = false;
+                $resolve($v);
+            }, function ($v) use (&$timer, $loop, $reject) {
+                if ($timer) {
+                    $loop->cancelTimer($timer);
+                }
+                $timer = false;
+                $reject($v);
+            });
+
+            // promise already resolved => no need to start timer
+            if ($timer === false) {
+                return;
             }
 
-            throw $e;
-        };
+            // start timeout timer which will cancel the pending promise
+            $timer = $loop->addTimer($time, function () use ($time, &$promise, $reject, $uri) {
+                $reject(new \RuntimeException(
+                    'Connection to ' . $uri . ' timed out after ' . $time . ' seconds (ETIMEDOUT)',
+                    \defined('SOCKET_ETIMEDOUT') ? \SOCKET_ETIMEDOUT : 110
+                ));
+
+                // Cancel pending connection to clean up any underlying resources and references.
+                // Avoid garbage references in call stack by passing pending promise by reference.
+                assert(\method_exists($promise, 'cancel'));
+                $promise->cancel();
+                $promise = null;
+            });
+        }, function () use (&$promise) {
+            // Cancelling this promise will cancel the pending connection, thus triggering the rejection logic above.
+            // Avoid garbage references in call stack by passing pending promise by reference.
+            assert(\method_exists($promise, 'cancel'));
+            $promise->cancel();
+            $promise = null;
+        });
     }
 }


### PR DESCRIPTION
This changeset adds timeout logic to avoid the otherwise unneeded dependency on [reactphp/promise-timer](https://github.com/reactphp/promise-timer). There are plans to deprecate the reactphp/promise-stream package as discussed in https://github.com/orgs/reactphp/discussions/475 and in either case I'd like to remove additional dependencies where possible.

In particular, reactphp/socket appears to be the only ReactPHP packages that still depends on reactphp/promise-timer at the moment. This means that once this PR is merged, most consumers of this package would no longer install reactphp/promise-timer by default. Perhaps most notably, this means that IDE autocompletion for `resolve()` and `reject()` would now only suggest the correct `React\Promise\resolve()` and `React\Promise\reject()` functions instead of the rarely useful and deprecated ones (see https://github.com/reactphp/promise-timer/pull/51).

This changeset does not otherwise affect our public API, so this should be safe to apply. The test suite confirms this has 100% code coverage and does not otherwise affect our APIs.

Note that this changeset does not preclude the discussion in https://github.com/orgs/reactphp/discussions/475, so whether or not or when the package will be deprecated is still up for debate. If you want to explicitly install this dependency, you can still install it like this:

```bash
composer require react/promise-timer
```

Builds on top of https://github.com/reactphp/dns/pull/213 and others
See also https://github.com/reactphp/http/pull/482 for similar changes to remove reactphp/promise-stream from reactphp/http