### PR TITLE
Work around broken composer install for legacy PHP on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
           ini-file: development
+      - run: composer config secure-http false && composer config repo.packagist composer http://packagist.org && composer config preferred-install source
+        if: ${{ matrix.php < 5.5 && matrix.os == 'windows-2022' }} # legacy PHP on Windows is allowed to use insecure downloads until it will be removed again
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
         if: ${{ matrix.php >= 7.3 }}


### PR DESCRIPTION
This changeset applies a *lovely* work-around for the broken composer install on legacy PHP on Windows. We've seen broken composer installs on such legacy platforms for the better half of the day and we've already wasted too much time on legacy platforms, so disabling HTTPS here seems reasonable. Note that this will likely be removed as part of upcoming ReactPHP v3 as discussed in https://github.com/orgs/reactphp/discussions/481 or in case the legacy platforms start working again, whichever comes first.

Refs #305 and https://github.com/composer/composer/issues/5436
Builds on top of #299 and #238