### PR TITLE
Fix cancelling happy eyeballs when IPv6 resolution is pending

### DIFF
--- a/src/HappyEyeBallsConnectionBuilder.php
+++ b/src/HappyEyeBallsConnectionBuilder.php
@@ -65,9 +65,8 @@ final class HappyEyeBallsConnectionBuilder
 
     public function connect()
     {
-        $timer = null;
         $that = $this;
-        return new Promise\Promise(function ($resolve, $reject) use ($that, &$timer) {
+        return new Promise\Promise(function ($resolve, $reject) use ($that) {
             $lookupResolve = function ($type) use ($that, $resolve, $reject) {
                 return function (array $ips) use ($that, $type, $resolve, $reject) {
                     unset($that->resolverPromises[$type]);
@@ -83,26 +82,29 @@ final class HappyEyeBallsConnectionBuilder
             };
 
             $that->resolverPromises[Message::TYPE_AAAA] = $that->resolve(Message::TYPE_AAAA, $reject)->then($lookupResolve(Message::TYPE_AAAA));
-            $that->resolverPromises[Message::TYPE_A] = $that->resolve(Message::TYPE_A, $reject)->then(function (array $ips) use ($that, &$timer) {
+            $that->resolverPromises[Message::TYPE_A] = $that->resolve(Message::TYPE_A, $reject)->then(function (array $ips) use ($that) {
                 // happy path: IPv6 has resolved already (or could not resolve), continue with IPv4 addresses
                 if ($that->resolved[Message::TYPE_AAAA] === true || !$ips) {
                     return $ips;
                 }
 
                 // Otherwise delay processing IPv4 lookup until short timer passes or IPv6 resolves in the meantime
-                $deferred = new Promise\Deferred();
+                $deferred = new Promise\Deferred(function () use (&$ips) {
+                    // discard all IPv4 addresses if cancelled
+                    $ips = array();
+                });
                 $timer = $that->loop->addTimer($that::RESOLUTION_DELAY, function () use ($deferred, $ips) {
                     $deferred->resolve($ips);
                 });
 
-                $that->resolverPromises[Message::TYPE_AAAA]->then(function () use ($that, $timer, $deferred, $ips) {
+                $that->resolverPromises[Message::TYPE_AAAA]->then(function () use ($that, $timer, $deferred, &$ips) {
                     $that->loop->cancelTimer($timer);
                     $deferred->resolve($ips);
                 });
 
                 return $deferred->promise();
             })->then($lookupResolve(Message::TYPE_A));
-        }, function ($_, $reject) use ($that, &$timer) {
+        }, function ($_, $reject) use ($that) {
             $reject(new \RuntimeException(
                 'Connection to ' . $that->uri . ' cancelled' . (!$that->connectionPromises ? ' during DNS lookup' : '') . ' (ECONNABORTED)',
                 \defined('SOCKET_ECONNABORTED') ? \SOCKET_ECONNABORTED : 103
@@ -110,9 +112,6 @@ final class HappyEyeBallsConnectionBuilder
             $_ = $reject = null;
 
             $that->cleanUp();
-            if ($timer instanceof TimerInterface) {
-                $that->loop->cancelTimer($timer);
-            }
         });
     }
 
@@ -247,13 +246,15 @@ final class HappyEyeBallsConnectionBuilder
         // clear list of outstanding IPs to avoid creating new connections
         $this->connectQueue = array();
 
+        // cancel pending connection attempts
         foreach ($this->connectionPromises as $connectionPromise) {
             if ($connectionPromise instanceof PromiseInterface && \method_exists($connectionPromise, 'cancel')) {
                 $connectionPromise->cancel();
             }
         }
 
-        foreach ($this->resolverPromises as $resolverPromise) {
+        // cancel pending DNS resolution (cancel IPv4 first in case it is awaiting IPv6 resolution delay)
+        foreach (\array_reverse($this->resolverPromises) as $resolverPromise) {
             if ($resolverPromise instanceof PromiseInterface && \method_exists($resolverPromise, 'cancel')) {
                 $resolverPromise->cancel();
             }

--- a/tests/HappyEyeBallsConnectionBuilderTest.php
+++ b/tests/HappyEyeBallsConnectionBuilderTest.php
@@ -695,7 +695,9 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
             array('reactphp.org', Message::TYPE_AAAA),
             array('reactphp.org', Message::TYPE_A)
         )->willReturnOnConsecutiveCalls(
-            new Promise(function () { }, $this->expectCallableOnce()),
+            new Promise(function () { }, function () {
+                throw new \RuntimeException('DNS cancelled');
+            }),
             \React\Promise\resolve(array('127.0.0.1'))
         );
 


### PR DESCRIPTION
This changeset fixes a super nasty bug that would only show when cancelling a happy eyeballs connection attempt during the 50ms resolution delay when IPv4 resolution has already completed, but IPv6 resolution is still pending. In this case, it would (successfully) reject the promise and (successfully) cancel the IPv6 resolution but erroneously start new IPv4 connections that would occupy resources and keep the loop running until the server side decides to close these idle connections.

Interestingly, this is relatively easy to reproduce on dual-stack hosts by immediately cancelling a connection attempt to a host such as `localhost` that resolves to an IPv4 address instantly due to a `/etc/hosts` entry but requires a full DNS lookup for IPv6:

```php
$connector = new React\Socket\Connector();
$connector->connect('localhost:6379')->cancel();
```

It looks like this problem was originally introduced with #258 in [`v1.7.0`](https://github.com/reactphp/socket/releases/tag/v1.7.0) quite some time ago. The updated test suite confirms we now successfully reject DNS resolution without starting any additional connection attempts in this case. The existing test suite confirms this does not affect any other cases, such as when DNS resolution is already completed.

I've stumbled upon this while updating the functional test suite of [clue/reactphp-redis](https://github.com/clue/reactphp-redis) to use https://github.com/reactphp/async (as per https://github.com/clue/reactphp-redis/pull/135), as the functional test suite happens to run the loop to test the cancellation behavior. Prior to applying these changes, the test suite would keep running for minutes.

Builds on top of #258, #225, #196 and potentially others