### PR TITLE
[3.x] Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,16 +28,16 @@
     "require": {
         "php": ">=7.1",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/dns": "^1.11",
+        "react/dns": "^1.13",
         "react/event-loop": "^1.2",
-        "react/promise": "^3 || ^2.6 || ^1.2.1",
-        "react/stream": "^1.2"
+        "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+        "react/stream": "^1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^7.5",
-        "react/async": "^4 || ^3",
+        "react/async": "^4.3 || ^3",
         "react/promise-stream": "^1.4",
-        "react/promise-timer": "^1.10"
+        "react/promise-timer": "^1.11"
     },
     "autoload": {
         "psr-4": {

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -50,7 +50,7 @@ final class Connector implements ConnectorInterface
      * @param ?LoopInterface $loop
      * @throws \InvalidArgumentException for invalid arguments
      */
-    public function __construct(array $context = array(), LoopInterface $loop = null)
+    public function __construct(array $context = [], ?LoopInterface $loop = null)
     {
         // apply default options if not explicitly given
         $context += [

--- a/src/FdServer.php
+++ b/src/FdServer.php
@@ -75,7 +75,7 @@ final class FdServer extends EventEmitter implements ServerInterface
      * @throws \InvalidArgumentException if the listening address is invalid
      * @throws \RuntimeException if listening on this address fails (already in use etc.)
      */
-    public function __construct($fd, LoopInterface $loop = null)
+    public function __construct($fd, ?LoopInterface $loop = null)
     {
         if (\preg_match('#^php://fd/(\d+)$#', $fd, $m)) {
             $fd = (int) $m[1];

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -13,7 +13,7 @@ final class SecureConnector implements ConnectorInterface
     private $streamEncryption;
     private $context;
 
-    public function __construct(ConnectorInterface $connector, LoopInterface $loop = null, array $context = [])
+    public function __construct(ConnectorInterface $connector, ?LoopInterface $loop = null, array $context = [])
     {
         $this->connector = $connector;
         $this->streamEncryption = new StreamEncryption($loop ?? Loop::get(), false);

--- a/src/SecureServer.php
+++ b/src/SecureServer.php
@@ -119,7 +119,7 @@ final class SecureServer extends EventEmitter implements ServerInterface
      * @see TcpServer
      * @link https://www.php.net/manual/en/context.ssl.php for TLS context options
      */
-    public function __construct(ServerInterface $tcp, LoopInterface $loop = null, array $context = [])
+    public function __construct(ServerInterface $tcp, ?LoopInterface $loop = null, array $context = [])
     {
         // default to empty passphrase to suppress blocking passphrase prompt
         $context += [

--- a/src/SocketServer.php
+++ b/src/SocketServer.php
@@ -31,7 +31,7 @@ final class SocketServer extends EventEmitter implements ServerInterface
      * @throws \InvalidArgumentException if the listening address is invalid
      * @throws \RuntimeException if listening on this address fails (already in use etc.)
      */
-    public function __construct($uri, array $context = [], LoopInterface $loop = null)
+    public function __construct($uri, array $context = [], ?LoopInterface $loop = null)
     {
         // apply default options if not explicitly given
         $context += [

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -12,7 +12,7 @@ final class TcpConnector implements ConnectorInterface
     private $loop;
     private $context;
 
-    public function __construct(LoopInterface $loop = null, array $context = [])
+    public function __construct(?LoopInterface $loop = null, array $context = [])
     {
         $this->loop = $loop ?? Loop::get();
         $this->context = $context;

--- a/src/TcpServer.php
+++ b/src/TcpServer.php
@@ -126,7 +126,7 @@ final class TcpServer extends EventEmitter implements ServerInterface
      * @throws \InvalidArgumentException if the listening address is invalid
      * @throws \RuntimeException if listening on this address fails (already in use etc.)
      */
-    public function __construct($uri, LoopInterface $loop = null, array $context = [])
+    public function __construct($uri, ?LoopInterface $loop = null, array $context = [])
     {
         $this->loop = $loop ?? Loop::get();
 

--- a/src/TimeoutConnector.php
+++ b/src/TimeoutConnector.php
@@ -12,7 +12,7 @@ final class TimeoutConnector implements ConnectorInterface
     private $timeout;
     private $loop;
 
-    public function __construct(ConnectorInterface $connector, $timeout, LoopInterface $loop = null)
+    public function __construct(ConnectorInterface $connector, $timeout, ?LoopInterface $loop = null)
     {
         $this->connector = $connector;
         $this->timeout = $timeout;

--- a/src/UnixConnector.php
+++ b/src/UnixConnector.php
@@ -17,7 +17,7 @@ final class UnixConnector implements ConnectorInterface
 {
     private $loop;
 
-    public function __construct(LoopInterface $loop = null)
+    public function __construct(?LoopInterface $loop = null)
     {
         $this->loop = $loop ?? Loop::get();
     }

--- a/src/UnixServer.php
+++ b/src/UnixServer.php
@@ -48,7 +48,7 @@ final class UnixServer extends EventEmitter implements ServerInterface
      * @throws \InvalidArgumentException if the listening address is invalid
      * @throws \RuntimeException if listening on this address fails (already in use etc.)
      */
-    public function __construct($path, LoopInterface $loop = null, array $context = [])
+    public function __construct($path, ?LoopInterface $loop = null, array $context = [])
     {
         $this->loop = $loop ?? Loop::get();
 


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260.

I'm planning to add native types to the public API and introduce PHPStan in follow-up PRs.

Once merged, we should apply similar changes to all our upcoming v3 components. On top of this, we should backport similar changes to the v1 branch.

Builds on top of #316, #315, #310, #260, reactphp/promise#260, https://github.com/reactphp/dns/pull/224, https://github.com/reactphp/stream/pull/179, reactphp/async#87 and reactphp/promise-timer#70