### PR TITLE
[RFC] Improve tests to temporarily downgrade to Xdebug 3.4.1 due to segfaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os == 'windows-2022' }}
     strategy:
       matrix:
         os:
@@ -28,7 +29,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: ${{ (matrix.os != 'windows-2022' || matrix.php < 8.1) && 'xdebug' || '' }} # temporarily skip Xdebug on Windows with PHP 8.1+ due to segfault with Xdebug 3.4.2
           ini-file: development
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
@@ -45,6 +46,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.2
+          extensions: xdebug-3.4.1 # temporarily downgrade Xdebug due to segfault on macOS with Xdebug 3.4.2
           coverage: xdebug
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
This changeset updates the test environment to work around a segfault with Xdebug 3.4.2. Right now, this causes an unrelated build error for all builds on Windows and macOS with PHP 8.1+ (see also https://github.com/clue/reactphp-redis/pull/173 and https://github.com/clue/framework-x/pull/276).

I've tried multiple approaches and it looks like this issue does not occur in Xdebug 3.4.1. The Linux builds happen to use the correct version, macOS can be downgraded just fine, but unfortunately I've been unable to downgrade on Windows (https://github.com/shivammathur/setup-php/issues/923).

I wonder how widespread this problem would be exactly, as I don't see anything special that this project would execute (except perhaps for Fibers as of #296?). In either case, we should probably report this upstream to Xdebug and/or shivammathur/setup-php.

Builds on top of #321, #238 and https://github.com/clue/framework-x/pull/276 and https://github.com/clue/reactphp-redis/pull/173