### PR TITLE
Update test suite to use PCOV to avoid segfault with Xdebug 3.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: ${{ matrix.php < 8.0 && 'xdebug' || 'pcov' }}
           ini-file: development
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
@@ -45,6 +45,6 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.2
-          coverage: xdebug
+          coverage: pcov
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
This changeset updates the test suite to use PCOV instead of Xdebug on PHP 8+ to avoid a segfault with Xdebug 3.4.2 on PHP 8.1+ (https://bugs.xdebug.org/view.php?id=2332). 

Unfortunately, it doesn't look like the upstream bug in Xdebug is an easy fix nor like it is going to be fixed any time soon, so for the time being I'd propose switching to PCOV to unblock our development. PCOV is pretty much a drop-in replacement on newer PHP versions (but noticeably faster), and test coverage should not be affected at all. Once merged, we should apply similar changes to our other components and other supported branches.

Builds on top of https://github.com/clue/framework-x/pull/278 and #321 
Supersedes / closes #322