### PR TITLE
[1.x] Improve PHP 8.5+ support by avoiding deprecated `setAccessible()` calls

### DIFF
--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -68,7 +68,9 @@ final class DnsConnector implements ConnectorInterface
                             // avoid garbage references by replacing all closures in call stack.
                             // what a lovely piece of code!
                             $r = new \ReflectionProperty('Exception', 'trace');
-                            $r->setAccessible(true);
+                            if (\PHP_VERSION_ID < 80100) {
+                                $r->setAccessible(true);
+                            }
                             $trace = $r->getValue($e);
 
                             // Exception trace arguments are not available on some PHP 7.4 installs

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -91,7 +91,9 @@ final class SecureConnector implements ConnectorInterface
                 // avoid garbage references by replacing all closures in call stack.
                 // what a lovely piece of code!
                 $r = new \ReflectionProperty('Exception', 'trace');
-                $r->setAccessible(true);
+                if (\PHP_VERSION_ID < 80100) {
+                    $r->setAccessible(true);
+                }
                 $trace = $r->getValue($e);
 
                 // Exception trace arguments are not available on some PHP 7.4 installs

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -12,11 +12,15 @@ class ConnectorTest extends TestCase
         $connector = new Connector();
 
         $ref = new \ReflectionProperty($connector, 'connectors');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $connectors = $ref->getValue($connector);
 
         $ref = new \ReflectionProperty($connectors['tcp'], 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connectors['tcp']);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
@@ -29,11 +33,15 @@ class ConnectorTest extends TestCase
         $connector = new Connector(array(), $loop);
 
         $ref = new \ReflectionProperty($connector, 'connectors');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $connectors = $ref->getValue($connector);
 
         $ref = new \ReflectionProperty($connectors['tcp'], 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connectors['tcp']);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
@@ -50,7 +58,9 @@ class ConnectorTest extends TestCase
         ));
 
         $ref = new \ReflectionProperty($connector, 'connectors');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $connectors = $ref->getValue($connector);
 
         $this->assertSame($tcp, $connectors['tcp']);
@@ -67,7 +77,9 @@ class ConnectorTest extends TestCase
         ));
 
         $ref = new \ReflectionProperty($connector, 'connectors');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $connectors = $ref->getValue($connector);
 
         $this->assertSame($tcp, $connectors['tcp']);
@@ -80,11 +92,15 @@ class ConnectorTest extends TestCase
         $connector = new Connector($loop);
 
         $ref = new \ReflectionProperty($connector, 'connectors');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $connectors = $ref->getValue($connector);
 
         $ref = new \ReflectionProperty($connectors['tcp'], 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connectors['tcp']);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/FunctionalTcpServerTest.php
+++ b/tests/FunctionalTcpServerTest.php
@@ -331,7 +331,9 @@ class FunctionalTcpServerTest extends TestCase
         ));
 
         $ref = new \ReflectionProperty($server, 'master');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $socket = $ref->getValue($server);
 
         $context = stream_context_get_options($socket);
@@ -346,7 +348,9 @@ class FunctionalTcpServerTest extends TestCase
         $server = new TcpServer(0);
 
         $ref = new \ReflectionProperty($server, 'master');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $socket = $ref->getValue($server);
 
         $context = stream_context_get_options($socket);

--- a/tests/HappyEyeBallsConnectionBuilderTest.php
+++ b/tests/HappyEyeBallsConnectionBuilderTest.php
@@ -844,13 +844,17 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
 
         $ref = new \ReflectionProperty($builder, 'connectQueue');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($builder, array('::1'));
 
         $builder->check($this->expectCallableNever(), function () { });
 
         $ref = new \ReflectionProperty($builder, 'connectionPromises');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $promises = $ref->getValue($builder);
 
         $this->assertEquals(array(), $promises);
@@ -876,7 +880,9 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
 
         $ref = new \ReflectionProperty($builder, 'connectQueue');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($builder, array('::1', '::1'));
 
         $builder->check($this->expectCallableNever(), function () { });
@@ -904,7 +910,9 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
 
         $ref = new \ReflectionProperty($builder, 'connectQueue');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($builder, array('::1', '::1'));
 
         $builder->check($this->expectCallableNever(), function () { });
@@ -927,7 +935,9 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
             $builder->mixIpsIntoConnectQueue(array('::1', '::2'));
 
             $ref = new \ReflectionProperty($builder, 'connectQueue');
-            $ref->setAccessible(true);
+            if (\PHP_VERSION_ID < 80100) {
+                $ref->setAccessible(true);
+            }
             $value = $ref->getValue($builder);
 
             if ($value === array('::1', '::2')) {
@@ -953,7 +963,9 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
             $builder->mixIpsIntoConnectQueue(array('::1', '::2'));
 
             $ref = new \ReflectionProperty($builder, 'connectQueue');
-            $ref->setAccessible(true);
+            if (\PHP_VERSION_ID < 80100) {
+                $ref->setAccessible(true);
+            }
             $value = $ref->getValue($builder);
 
             if ($value === array('::2', '::1')) {

--- a/tests/HappyEyeBallsConnectorTest.php
+++ b/tests/HappyEyeBallsConnectorTest.php
@@ -34,7 +34,9 @@ class HappyEyeBallsConnectorTest extends TestCase
         $connector = new HappyEyeBallsConnector(null, $this->tcp, $this->resolver);
 
         $ref = new \ReflectionProperty($connector, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connector);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -37,11 +37,15 @@ class SecureConnectorTest extends TestCase
         $connector = new SecureConnector($this->tcp);
 
         $ref = new \ReflectionProperty($connector, 'streamEncryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $streamEncryption = $ref->getValue($connector);
 
         $ref = new \ReflectionProperty($streamEncryption, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($streamEncryption);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
@@ -185,7 +189,9 @@ class SecureConnectorTest extends TestCase
         $encryption->expects($this->once())->method('enable')->with($connection)->willReturn(new \React\Promise\Promise(function () { }));
 
         $ref = new \ReflectionProperty($this->connector, 'streamEncryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->connector, $encryption);
 
         $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com:80'))->willReturn(Promise\resolve($connection));
@@ -202,7 +208,9 @@ class SecureConnectorTest extends TestCase
         $encryption->expects($this->once())->method('enable')->willReturn(Promise\reject(new \RuntimeException('TLS error', 123)));
 
         $ref = new \ReflectionProperty($this->connector, 'streamEncryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->connector, $encryption);
 
         $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com:80'))->willReturn(Promise\resolve($connection));
@@ -234,7 +242,9 @@ class SecureConnectorTest extends TestCase
         $encryption->expects($this->once())->method('enable')->willReturn($pending);
 
         $ref = new \ReflectionProperty($this->connector, 'streamEncryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->connector, $encryption);
 
         $deferred = new Deferred();
@@ -301,7 +311,9 @@ class SecureConnectorTest extends TestCase
         $encryption->expects($this->once())->method('enable')->willReturn($tls->promise());
 
         $ref = new \ReflectionProperty($this->connector, 'streamEncryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->connector, $encryption);
 
         $promise = $this->connector->connect('example.com:80');

--- a/tests/SecureServerTest.php
+++ b/tests/SecureServerTest.php
@@ -33,11 +33,15 @@ class SecureServerTest extends TestCase
         $server = new SecureServer($tcp);
 
         $ref = new \ReflectionProperty($server, 'encryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $encryption = $ref->getValue($server);
 
         $ref = new \ReflectionProperty($encryption, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($encryption);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
@@ -137,11 +141,15 @@ class SecureServerTest extends TestCase
         $encryption->expects($this->once())->method('enable')->willReturn($pending);
 
         $ref = new \ReflectionProperty($server, 'encryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, $encryption);
 
         $ref = new \ReflectionProperty($server, 'context');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, array());
 
         $server->on('error', $this->expectCallableNever());
@@ -168,11 +176,15 @@ class SecureServerTest extends TestCase
         $encryption->expects($this->once())->method('enable')->willReturn(\React\Promise\reject($error));
 
         $ref = new \ReflectionProperty($server, 'encryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, $encryption);
 
         $ref = new \ReflectionProperty($server, 'context');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, array());
 
         $error = null;

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -17,11 +17,15 @@ class ServerTest extends TestCase
         $server = new Server(0);
 
         $ref = new \ReflectionProperty($server, 'server');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcp = $ref->getValue($server);
 
         $ref = new \ReflectionProperty($tcp, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($tcp);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
@@ -115,7 +119,9 @@ class ServerTest extends TestCase
         $server = new Server(0);
 
         $ref = new \ReflectionProperty($server, 'server');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcp = $ref->getvalue($server);
 
         $error = new \RuntimeException();

--- a/tests/SocketServerTest.php
+++ b/tests/SocketServerTest.php
@@ -18,11 +18,15 @@ class SocketServerTest extends TestCase
         $socket->close();
 
         $ref = new \ReflectionProperty($socket, 'server');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcp = $ref->getValue($socket);
 
         $ref = new \ReflectionProperty($tcp, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($tcp);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
@@ -151,7 +155,9 @@ class SocketServerTest extends TestCase
         $socket = new SocketServer('127.0.0.1:0', array());
 
         $ref = new \ReflectionProperty($socket, 'server');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcp = $ref->getvalue($socket);
 
         $error = new \RuntimeException();

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -23,7 +23,9 @@ class TcpConnectorTest extends TestCase
         $connector = new TcpConnector();
 
         $ref = new \ReflectionProperty($connector, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connector);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -37,7 +37,9 @@ class TcpServerTest extends TestCase
         $server = new TcpServer(0);
 
         $ref = new \ReflectionProperty($server, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($server);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/TimeoutConnectorTest.php
+++ b/tests/TimeoutConnectorTest.php
@@ -24,7 +24,9 @@ class TimeoutConnectorTest extends TestCase
         $connector = new TimeoutConnector($base, 0.01);
 
         $ref = new \ReflectionProperty($connector, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connector);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/UnixConnectorTest.php
+++ b/tests/UnixConnectorTest.php
@@ -30,7 +30,9 @@ class UnixConnectorTest extends TestCase
         $connector = new UnixConnector();
 
         $ref = new \ReflectionProperty($connector, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connector);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -43,7 +43,9 @@ class UnixServerTest extends TestCase
         $server = new UnixServer($this->uds);
 
         $ref = new \ReflectionProperty($server, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($server);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations