### PR TITLE
[3.x] Improve PHP 8.5+ support by avoiding deprecated `setAccessible()` calls

### DIFF
--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -68,7 +68,9 @@ final class DnsConnector implements ConnectorInterface
                             // avoid garbage references by replacing all closures in call stack.
                             // what a lovely piece of code!
                             $r = new \ReflectionProperty(\Exception::class, 'trace');
-                            $r->setAccessible(true);
+                            if (\PHP_VERSION_ID < 80100) {
+                                $r->setAccessible(true);
+                            }
                             $trace = $r->getValue($e);
 
                             // Exception trace arguments are not available on some PHP 7.4 installs

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -74,7 +74,9 @@ final class SecureConnector implements ConnectorInterface
                 // avoid garbage references by replacing all closures in call stack.
                 // what a lovely piece of code!
                 $r = new \ReflectionProperty(\Exception::class, 'trace');
-                $r->setAccessible(true);
+                if (\PHP_VERSION_ID < 80100) {
+                    $r->setAccessible(true);
+                }
                 $trace = $r->getValue($e);
 
                 // Exception trace arguments are not available on some PHP 7.4 installs

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -15,11 +15,15 @@ class ConnectorTest extends TestCase
         $connector = new Connector();
 
         $ref = new \ReflectionProperty($connector, 'connectors');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $connectors = $ref->getValue($connector);
 
         $ref = new \ReflectionProperty($connectors['tcp'], 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connectors['tcp']);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);
@@ -32,11 +36,15 @@ class ConnectorTest extends TestCase
         $connector = new Connector([], $loop);
 
         $ref = new \ReflectionProperty($connector, 'connectors');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $connectors = $ref->getValue($connector);
 
         $ref = new \ReflectionProperty($connectors['tcp'], 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connectors['tcp']);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);
@@ -53,7 +61,9 @@ class ConnectorTest extends TestCase
         ]);
 
         $ref = new \ReflectionProperty($connector, 'connectors');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $connectors = $ref->getValue($connector);
 
         $this->assertSame($tcp, $connectors['tcp']);

--- a/tests/FunctionalTcpServerTest.php
+++ b/tests/FunctionalTcpServerTest.php
@@ -334,7 +334,9 @@ class FunctionalTcpServerTest extends TestCase
         ]);
 
         $ref = new \ReflectionProperty($server, 'master');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $socket = $ref->getValue($server);
 
         $context = stream_context_get_options($socket);
@@ -349,7 +351,9 @@ class FunctionalTcpServerTest extends TestCase
         $server = new TcpServer(0);
 
         $ref = new \ReflectionProperty($server, 'master');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $socket = $ref->getValue($server);
 
         $context = stream_context_get_options($socket);

--- a/tests/HappyEyeBallsConnectionBuilderTest.php
+++ b/tests/HappyEyeBallsConnectionBuilderTest.php
@@ -845,13 +845,17 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
 
         $ref = new \ReflectionProperty($builder, 'connectQueue');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($builder, ['::1']);
 
         $builder->check($this->expectCallableNever(), function () { });
 
         $ref = new \ReflectionProperty($builder, 'connectionPromises');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $promises = $ref->getValue($builder);
 
         $this->assertEquals([], $promises);
@@ -877,7 +881,9 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
 
         $ref = new \ReflectionProperty($builder, 'connectQueue');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($builder, ['::1', '::1']);
 
         $builder->check($this->expectCallableNever(), function () { });
@@ -905,7 +911,9 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
         $builder = new HappyEyeBallsConnectionBuilder($loop, $connector, $resolver, $uri, $host, $parts);
 
         $ref = new \ReflectionProperty($builder, 'connectQueue');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($builder, ['::1', '::1']);
 
         $builder->check($this->expectCallableNever(), function () { });
@@ -928,7 +936,9 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
             $builder->mixIpsIntoConnectQueue(['::1', '::2']);
 
             $ref = new \ReflectionProperty($builder, 'connectQueue');
-            $ref->setAccessible(true);
+            if (\PHP_VERSION_ID < 80100) {
+                $ref->setAccessible(true);
+            }
             $value = $ref->getValue($builder);
 
             if ($value === ['::1', '::2']) {
@@ -954,7 +964,9 @@ class HappyEyeBallsConnectionBuilderTest extends TestCase
             $builder->mixIpsIntoConnectQueue(['::1', '::2']);
 
             $ref = new \ReflectionProperty($builder, 'connectQueue');
-            $ref->setAccessible(true);
+            if (\PHP_VERSION_ID < 80100) {
+                $ref->setAccessible(true);
+            }
             $value = $ref->getValue($builder);
 
             if ($value === ['::2', '::1']) {

--- a/tests/HappyEyeBallsConnectorTest.php
+++ b/tests/HappyEyeBallsConnectorTest.php
@@ -40,7 +40,9 @@ class HappyEyeBallsConnectorTest extends TestCase
         $connector = new HappyEyeBallsConnector(null, $this->tcp, $this->resolver);
 
         $ref = new \ReflectionProperty($connector, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connector);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -35,11 +35,15 @@ class SecureConnectorTest extends TestCase
         $connector = new SecureConnector($this->tcp);
 
         $ref = new \ReflectionProperty($connector, 'streamEncryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $streamEncryption = $ref->getValue($connector);
 
         $ref = new \ReflectionProperty($streamEncryption, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($streamEncryption);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);
@@ -183,7 +187,9 @@ class SecureConnectorTest extends TestCase
         $encryption->expects($this->once())->method('enable')->with($connection)->willReturn(new Promise(function () { }));
 
         $ref = new \ReflectionProperty($this->connector, 'streamEncryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->connector, $encryption);
 
         $this->tcp->expects($this->once())->method('connect')->with('example.com:80')->willReturn(resolve($connection));
@@ -200,7 +206,9 @@ class SecureConnectorTest extends TestCase
         $encryption->expects($this->once())->method('enable')->willReturn(reject(new \RuntimeException('TLS error', 123)));
 
         $ref = new \ReflectionProperty($this->connector, 'streamEncryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->connector, $encryption);
 
         $this->tcp->expects($this->once())->method('connect')->with('example.com:80')->willReturn(resolve($connection));
@@ -232,7 +240,9 @@ class SecureConnectorTest extends TestCase
         $encryption->expects($this->once())->method('enable')->willReturn($pending);
 
         $ref = new \ReflectionProperty($this->connector, 'streamEncryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->connector, $encryption);
 
         $deferred = new Deferred();
@@ -299,7 +309,9 @@ class SecureConnectorTest extends TestCase
         $encryption->expects($this->once())->method('enable')->willReturn($tls->promise());
 
         $ref = new \ReflectionProperty($this->connector, 'streamEncryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->connector, $encryption);
 
         $promise = $this->connector->connect('example.com:80');

--- a/tests/SecureServerTest.php
+++ b/tests/SecureServerTest.php
@@ -21,11 +21,15 @@ class SecureServerTest extends TestCase
         $server = new SecureServer($tcp);
 
         $ref = new \ReflectionProperty($server, 'encryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $encryption = $ref->getValue($server);
 
         $ref = new \ReflectionProperty($encryption, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($encryption);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);
@@ -125,11 +129,15 @@ class SecureServerTest extends TestCase
         $encryption->expects($this->once())->method('enable')->willReturn($pending);
 
         $ref = new \ReflectionProperty($server, 'encryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, $encryption);
 
         $ref = new \ReflectionProperty($server, 'context');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, []);
 
         $server->on('error', $this->expectCallableNever());
@@ -156,11 +164,15 @@ class SecureServerTest extends TestCase
         $encryption->expects($this->once())->method('enable')->willReturn(reject($error));
 
         $ref = new \ReflectionProperty($server, 'encryption');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, $encryption);
 
         $ref = new \ReflectionProperty($server, 'context');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, []);
 
         $error = null;

--- a/tests/SocketServerTest.php
+++ b/tests/SocketServerTest.php
@@ -22,11 +22,15 @@ class SocketServerTest extends TestCase
         $socket->close();
 
         $ref = new \ReflectionProperty($socket, 'server');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcp = $ref->getValue($socket);
 
         $ref = new \ReflectionProperty($tcp, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($tcp);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);
@@ -140,7 +144,9 @@ class SocketServerTest extends TestCase
         $socket = new SocketServer('127.0.0.1:0', []);
 
         $ref = new \ReflectionProperty($socket, 'server');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $tcp = $ref->getvalue($socket);
 
         $error = new \RuntimeException();

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -22,7 +22,9 @@ class TcpConnectorTest extends TestCase
         $connector = new TcpConnector();
 
         $ref = new \ReflectionProperty($connector, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connector);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);

--- a/tests/TcpServerTest.php
+++ b/tests/TcpServerTest.php
@@ -36,7 +36,9 @@ class TcpServerTest extends TestCase
         $server = new TcpServer(0);
 
         $ref = new \ReflectionProperty($server, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($server);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);

--- a/tests/TimeoutConnectorTest.php
+++ b/tests/TimeoutConnectorTest.php
@@ -22,7 +22,9 @@ class TimeoutConnectorTest extends TestCase
         $connector = new TimeoutConnector($base, 0.01);
 
         $ref = new \ReflectionProperty($connector, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connector);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);

--- a/tests/UnixConnectorTest.php
+++ b/tests/UnixConnectorTest.php
@@ -25,7 +25,9 @@ class UnixConnectorTest extends TestCase
         $connector = new UnixConnector();
 
         $ref = new \ReflectionProperty($connector, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($connector);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);

--- a/tests/UnixServerTest.php
+++ b/tests/UnixServerTest.php
@@ -40,7 +40,9 @@ class UnixServerTest extends TestCase
         $server = new UnixServer($this->uds);
 
         $ref = new \ReflectionProperty($server, 'loop');
-        $ref->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($server);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);


### PR DESCRIPTION
This changeset improves PHP 8.5+ support by porting #325 from `1.x` to `3.x` in order to avoid deprecated `setAccessible()` calls. With these changes applied, tests against the current PHP 8.5 RC pass without errors.

Builds on top of #325 (thanks @W0rma), https://github.com/reactphp/dns/pull/242, https://github.com/clue/framework-x/pull/282 and #321