### PR TITLE
[1.x] Update to run tests on PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - ubuntu-24.04
           - windows-2022
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -51,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
           coverage: xdebug
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
This PR adds running our CI jobs on PHP8.5 and builds up on #326, #321 and #325 to improve PHP8.5+ support.