### PR TITLE
[3.x] Update to run tests on PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - ubuntu-24.04
           - windows-2022
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -44,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.5
           coverage: pcov
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
This changeset improves PHP 8.5+ support by porting #330 from `1.x` to `3.x`.

Builds on #327, #326, and many others.