### PR TITLE
[3.x] Update test environment for PHP 7.2 to compatible PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "react/stream": "^1.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^7.5",
+        "phpunit/phpunit": "^9.6 || ^8.5 || ^7.5",
         "react/async": "^4.3 || ^3",
         "react/promise-stream": "^1.4",
         "react/promise-timer": "^1.11"


### PR DESCRIPTION
This changes ensures we can continue run PHPUnit on PHP 7.2 by updating PHPUnit to 8.5. This is due to recent improvements in composer as discussed in https://github.com/reactphp/event-loop/pull/284.